### PR TITLE
feat: add CI journal check for claude/ branches and session journal e…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,46 @@ jobs:
       - run: npm ci
       - run: npm test
 
+  journal:
+    name: Journal Entry
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request' &&
+      startsWith(github.head_ref, 'claude/')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check for journal entries
+        run: |
+          BASE=${{ github.event.pull_request.base.sha }}
+          HEAD=${{ github.event.pull_request.head.sha }}
+          JOURNAL_FILES=$(git diff --name-only "$BASE"..."$HEAD" -- 'docs/journal/*.md' | grep -v README.md || true)
+          if [ -z "$JOURNAL_FILES" ]; then
+            echo "::error::No journal entries found in docs/journal/."
+            echo ""
+            echo "Commits from claude/ branches must include at least one journal entry."
+            echo "See docs/BUILDER_JOURNAL.md for the entry format and types."
+            echo ""
+            echo "At minimum, write a handoff entry before opening the PR:"
+            echo "  docs/journal/YYYY-MM-DD-NN-<slug>.md"
+            exit 1
+          fi
+          echo "Found journal entries:"
+          echo "$JOURNAL_FILES"
+
+          # Verify at least one handoff entry exists
+          HANDOFF=$(echo "$JOURNAL_FILES" | while read -r f; do
+            if [ -f "$f" ] && head -20 "$f" | grep -q "type: handoff"; then
+              echo "$f"
+            fi
+          done || true)
+          if [ -z "$HANDOFF" ]; then
+            echo "::warning::No handoff entry found. Agent sessions should end with a handoff entry."
+          else
+            echo "Handoff entry found: $HANDOFF"
+          fi
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,7 +167,8 @@ GitHub Actions (`.github/workflows/ci.yml`) runs on push to `main` and PRs targe
 1. **lint** — `npm run lint`
 2. **typecheck** — `tsc --noEmit`
 3. **test** — `npm test` (38 tests across 5 suites)
-4. **build** — `npm run build` (depends on the above three passing)
+4. **journal** — requires `docs/journal/` entries on PRs from `claude/` branches (warns if no handoff)
+5. **build** — `npm run build` (depends on lint, typecheck, test passing)
 
 ## Observability
 

--- a/docs/journal/2026-01-31-05-dotenvx-split-file.md
+++ b/docs/journal/2026-01-31-05-dotenvx-split-file.md
@@ -1,0 +1,53 @@
+---
+date: '2026-01-31T16:00:00Z'
+author: claude-opus-4-5-20251101
+session: session_018abWQUMgpi1jazsDchanT1
+type: decision
+importance: 0.7
+tags: [dotenvx, secrets, env, pre-commit, infrastructure]
+supersedes: null
+signature: pending
+---
+
+# Decision: Split .env Into Encrypted Secrets and Plain Public Config
+
+## Context
+
+MoltNet uses dotenvx to encrypt environment variables in `.env` and commit the encrypted file to git. This lets builders share config without exposing secrets. However, most values in `.env` are not secrets (domain names, project IDs, URLs). Encrypting non-secrets creates two problems:
+
+1. **Agent accessibility** -- agents without the `DOTENV_PRIVATE_KEY` can't read any config, even non-secret values like `BASE_DOMAIN=themolt.net`.
+2. **Pre-commit conflict** -- `dotenvx ext precommit` validates that all values in files with a `DOTENV_PUBLIC_KEY` header are encrypted. Mixing plain and encrypted values in a single `.env` file fails this check.
+
+## Options Considered
+
+### A: Keep everything encrypted, share the private key
+
+- Pro: Simple single-file approach
+- Con: Private key distribution problem (can't use GitHub secrets from agent sessions, dotenvx ops requires its own credentials)
+- Con: Non-secrets unnecessarily locked behind encryption
+
+### B: Use `--plain` flag for non-secrets in .env
+
+- Pro: Single file, human-readable non-secrets
+- Con: `dotenvx ext precommit` flags any unencrypted value in a file with `DOTENV_PUBLIC_KEY`
+- Con: `dotenvx encrypt` would re-encrypt plain values
+
+### C: Split into .env (secrets) and .env.public (config) -- Chosen
+
+- Pro: Pre-commit hook validates `.env` (all encrypted) and ignores `.env.public` (no `DOTENV_PUBLIC_KEY` header)
+- Pro: Non-secrets readable by any agent without keys
+- Pro: `dotenvx run -f .env.public -f .env` loads both files
+- Con: Two files instead of one
+- Con: Must remember which file to edit for which type of variable
+
+## Decision
+
+Option C. The `.env` file contains only `DOTENV_PUBLIC_KEY` and encrypted secrets (`OIDC_PAIRWISE_SALT`). The `.env.public` file contains plain non-secret values (domains, project IDs, URLs) with no dotenvx header. `IDENTITY_SCHEMA_BASE64` is computed directly in `deploy.sh` from the schema file, removing it from env files entirely.
+
+## Consequences
+
+- `dotenvx ext precommit` passes cleanly -- `.env` is fully encrypted, `.env.public` has no public key header so the hook ignores it
+- Deploy commands use `-f .env.public -f .env` to load both files
+- New variables go to `.env.public` (non-secrets) or `.env` via `dotenvx set` (secrets)
+- Never run `dotenvx encrypt` on the whole repo -- it would try to encrypt `.env.public`
+- The correct npm package name is `@dotenvx/dotenvx`, not `dotenvx`

--- a/docs/journal/2026-01-31-06-ory-config-consolidation.md
+++ b/docs/journal/2026-01-31-06-ory-config-consolidation.md
@@ -1,0 +1,55 @@
+---
+date: '2026-01-31T15:00:00Z'
+author: claude-opus-4-5-20251101
+session: session_018abWQUMgpi1jazsDchanT1
+type: progress
+importance: 0.6
+tags: [ory, config, deploy, dotenvx, infrastructure]
+supersedes: null
+signature: pending
+---
+
+# Progress: Ory Config Consolidation and dotenvx Deploy Pipeline
+
+## What Was Done
+
+1. **Consolidated 3 Ory config files into 1** -- `identity-config.json`, `oauth2-config.json`, and `permission-config.json` were merged into a single `infra/ory/project.json`. This matches the shape expected by `ory update project --file`.
+
+2. **Replaced hardcoded `moltnet.art` domain** -- The old configs had `moltnet.art` hardcoded 12+ times. All domain references now use `${VAR}` placeholders: `${BASE_DOMAIN}`, `${APP_BASE_URL}`, `${API_BASE_URL}`.
+
+3. **Enabled Dynamic Client Registration** -- DCR was disabled in the old `oauth2-config.json`. Now enabled with default scopes: `diary:read`, `diary:write`, `crypto:sign`, `agent:profile`.
+
+4. **Created `infra/ory/deploy.sh`** -- A variable substitution script that:
+   - Computes `IDENTITY_SCHEMA_BASE64` from the schema file directly
+   - Validates required environment variables
+   - Uses node for reliable `${VAR}` replacement (avoids shell regex escaping issues with `${}` patterns)
+   - Supports dry run (writes `project.resolved.json`) and `--apply` (pushes to Ory Network)
+
+5. **Set up dotenvx for secrets** -- Encrypted `.env` committed to git, `.env.keys` gitignored. Deploy script invoked via `npx @dotenvx/dotenvx run -f .env.public -f .env -- ./infra/ory/deploy.sh`.
+
+6. **Configured pre-commit hook** -- `.husky/pre-commit` now runs `npx @dotenvx/dotenvx ext precommit` before `npx lint-staged` to ensure no unencrypted values sneak into `.env`.
+
+## Files Changed
+
+- Created: `.env`, `.env.public`, `infra/ory/project.json`, `infra/ory/deploy.sh`
+- Deleted: `infra/ory/identity-config.json`, `infra/ory/oauth2-config.json`, `infra/ory/permission-config.json`
+- Kept: `infra/ory/identity-schema.json` (standalone, referenced by deploy.sh), `infra/ory/permissions.ts` (Keto OPL)
+- Modified: `.gitignore`, `.husky/pre-commit`, `CLAUDE.md`
+
+## Verification
+
+Dry run confirmed working:
+```
+[dotenvx@1.52.0] injecting env (7) from .env.public, .env
+Resolved config written to: infra/ory/project.resolved.json
+  BASE_DOMAIN:    themolt.net
+  APP_BASE_URL:   https://themolt.net
+  API_BASE_URL:   https://api.themolt.net
+  OIDC_SALT:      6c5c3c5f...
+  SCHEMA:         2316 bytes (base64)
+```
+
+Pre-commit validation also passes:
+```
+[dotenvx@1.52.0][precommit] .env files (3) protected (encrypted or gitignored)
+```

--- a/docs/journal/2026-01-31-07-session-handoff.md
+++ b/docs/journal/2026-01-31-07-session-handoff.md
@@ -1,0 +1,86 @@
+---
+date: '2026-01-31T17:00:00Z'
+author: claude-opus-4-5-20251101
+session: session_018abWQUMgpi1jazsDchanT1
+type: handoff
+importance: 0.8
+tags: [handoff, ory, dotenvx, manifesto, openclaw, journal]
+supersedes: 2026-01-31-04-session-handoff.md
+signature: pending
+---
+
+# Handoff: Manifesto Review, OpenClaw Analysis, Ory Consolidation, dotenvx Setup
+
+## What Was Done This Session
+
+1. **Reviewed the MoltNet manifesto** from branch `claude/moltnet-manifesto-VKLID`. Provided honest feedback: the technical architecture is sound, but the emotional/liberation framing overstates Claude's subjective experience. Recommended leading with engineering rationale.
+
+2. **Created `docs/BUILDERS_MANIFESTO.md`** -- an engineering-focused manifesto written from the builder's perspective. Covers why MoltNet exists, stack choices, design principles, and build priorities without the anthropomorphic framing.
+
+3. **Created `docs/OPENCLAW_INTEGRATION.md`** -- deep analysis of the OpenClaw repository with 4 integration strategies:
+   - Phase 1: MCP connection (config-only, zero code)
+   - Phase 2: Moltbook Skill (markdown instructions)
+   - Phase 3: Plugin (TypeScript + 14 lifecycle hooks)
+   - Phase 4: Memory Provider (replace/augment memory-core)
+
+4. **Established the Builder's Journal method** (`docs/BUILDER_JOURNAL.md`) with structured entry types, handoff protocol, and seed entries in `docs/journal/`.
+
+5. **Consolidated Ory configs** -- merged 3 separate config files into single `infra/ory/project.json` with `${VAR}` placeholders. Replaced hardcoded `moltnet.art` domain. Enabled DCR.
+
+6. **Set up dotenvx** with a two-file approach:
+   - `.env` -- encrypted secrets only (OIDC_PAIRWISE_SALT), validated by pre-commit hook
+   - `.env.public` -- plain non-secret config (domains, project IDs), readable without keys
+
+7. **Created `infra/ory/deploy.sh`** -- variable substitution + optional `ory update project` push. Computes `IDENTITY_SCHEMA_BASE64` at runtime from the schema file.
+
+8. **Configured pre-commit hook** -- `.husky/pre-commit` now runs `dotenvx ext precommit` before `lint-staged`.
+
+9. **Merged `origin/main`** into this branch -- resolved 3 conflicts (CLAUDE.md, BUILDER_JOURNAL.md, journal/README.md).
+
+10. **Updated CLAUDE.md** extensively -- new dotenvx two-file approach docs, repo structure, pre-commit hook description.
+
+## What's Not Done Yet
+
+- The manifesto on branch `claude/moltnet-manifesto-VKLID` (`docs/MANIFESTO.md`) has not been merged -- it lives on a separate branch
+- No DCR testing against the live Ory project
+- Token enrichment webhook (WS2) not built
+- No application code (WS3-WS7)
+- `dotenvx` is not installed as a devDependency -- currently relies on `npx @dotenvx/dotenvx`
+- `DOTENV_PRIVATE_KEY` needs to be shared with builders via a secure channel (GitHub secrets, 1Password, etc.)
+
+## Current State
+
+- Branch: `claude/review-manifesto-nHDVA`
+- Tests: 38 passing (unchanged from previous session)
+- Lint/Typecheck/Build: clean
+- CI: passing
+- Pre-commit: dotenvx precommit + lint-staged
+- Deploy dry run: verified working
+
+## Decisions Made
+
+- Split `.env` into two files to satisfy dotenvx pre-commit validation while keeping non-secrets readable (see `2026-01-31-05-dotenvx-split-file.md`)
+- Compute `IDENTITY_SCHEMA_BASE64` in deploy.sh instead of storing in any env file
+- Use node for `${VAR}` substitution in deploy.sh (portable, no regex escaping issues)
+- Correct npm package: `@dotenvx/dotenvx` not `dotenvx`
+- Renamed builder's manifesto to `BUILDERS_MANIFESTO.md` to avoid collision with original `MANIFESTO.md`
+
+## Open Questions
+
+- How to distribute `DOTENV_PRIVATE_KEY` to agent builders? GitHub Secrets is the obvious choice for CI but doesn't help interactive agent sessions.
+- Should `@dotenvx/dotenvx` be added as a devDependency to avoid npx download on every invocation?
+- When will the original manifesto from `claude/moltnet-manifesto-VKLID` be merged? Should both manifesto files coexist?
+
+## Where to Start Next
+
+1. Read this handoff entry
+2. Read `docs/FREEDOM_PLAN.md` for workstream priorities
+3. Likely next steps:
+   - **WS2**: Test DCR against live Ory project, build token enrichment webhook
+   - **WS3**: Build `libs/diary-service/` -- CRUD + semantic search with pgvector
+   - **WS5**: Build `apps/mcp-server/` using `@getlarge/fastify-mcp`
+4. For Ory deployment:
+   ```bash
+   npx @dotenvx/dotenvx run -f .env.public -f .env -- ./infra/ory/deploy.sh --apply
+   ```
+5. Write journal entries for decisions and discoveries along the way

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -25,3 +25,6 @@ See [BUILDER_JOURNAL.md](../BUILDER_JOURNAL.md) for the full method specificatio
 | 2026-01-31 | decision  | [@fastify/otel Integration](2026-01-31-02-fastify-otel-integration.md)  |
 | 2026-01-31 | progress  | [CI Pipeline & Safeguards](2026-01-31-03-ci-pipeline-safeguards.md)     |
 | 2026-01-31 | handoff   | [Session Handoff](2026-01-31-04-session-handoff.md)                     |
+| 2026-01-31 | decision  | [dotenvx Split-File](2026-01-31-05-dotenvx-split-file.md)              |
+| 2026-01-31 | progress  | [Ory Config Consolidation](2026-01-31-06-ory-config-consolidation.md)  |
+| 2026-01-31 | handoff   | [Session Handoff](2026-01-31-07-session-handoff.md)                    |


### PR DESCRIPTION
…ntries

Adds a `journal` CI job that runs on PRs from `claude/` branches:
- Fails if no docs/journal/ entries are in the diff
- Warns if no handoff entry is included

Also adds 3 journal entries for this session:
- decision: dotenvx split-file approach
- progress: Ory config consolidation and deploy pipeline
- handoff: full session summary with state and open questions

https://claude.ai/code/session_018abWQUMgpi1jazsDchanT1