### PR TITLE
Add config module with TypeBox validation + ESLint guard

### DIFF
--- a/apps/rest-api/__tests__/config.test.ts
+++ b/apps/rest-api/__tests__/config.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  loadConfig,
+  loadDatabaseConfig,
+  loadObservabilityConfig,
+  loadOryConfig,
+  loadServerConfig,
+  loadWebhookConfig,
+  resolveOryUrls,
+} from '../src/config.js';
+
+const validEnv = {
+  PORT: '8000',
+  NODE_ENV: 'production',
+  DATABASE_URL: 'postgresql://localhost/moltnet',
+  ORY_ACTION_API_KEY: 'test-webhook-key',
+  ORY_PROJECT_URL: 'https://ory.example.com',
+  ORY_API_KEY: 'ory_pat_xxx',
+  AXIOM_API_TOKEN: 'xaat-xxx',
+  AXIOM_LOGS_DATASET: 'moltnet-logs',
+  AXIOM_TRACES_DATASET: 'moltnet-traces',
+  AXIOM_METRICS_DATASET: 'moltnet-metrics',
+};
+
+// ============================================================================
+// ServerConfig
+// ============================================================================
+
+describe('loadServerConfig', () => {
+  it('parses valid config', () => {
+    const config = loadServerConfig({ PORT: '3000', NODE_ENV: 'production' });
+    expect(config).toEqual({ PORT: 3000, NODE_ENV: 'production' });
+  });
+
+  it('coerces string PORT to number', () => {
+    const config = loadServerConfig({ PORT: '8080', NODE_ENV: 'test' });
+    expect(config.PORT).toBe(8080);
+    expect(typeof config.PORT).toBe('number');
+  });
+
+  it('applies defaults when env is empty', () => {
+    const config = loadServerConfig({});
+    expect(config.PORT).toBe(8000);
+    expect(config.NODE_ENV).toBe('development');
+  });
+
+  it('rejects invalid NODE_ENV', () => {
+    expect(() =>
+      loadServerConfig({ NODE_ENV: 'invalid' }),
+    ).toThrow('Invalid Server config');
+  });
+});
+
+// ============================================================================
+// DatabaseConfig
+// ============================================================================
+
+describe('loadDatabaseConfig', () => {
+  it('parses valid config', () => {
+    const config = loadDatabaseConfig({
+      DATABASE_URL: 'postgresql://localhost/moltnet',
+    });
+    expect(config.DATABASE_URL).toBe('postgresql://localhost/moltnet');
+  });
+
+  it('allows missing DATABASE_URL (optional)', () => {
+    const config = loadDatabaseConfig({});
+    expect(config.DATABASE_URL).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// WebhookConfig
+// ============================================================================
+
+describe('loadWebhookConfig', () => {
+  it('parses valid config', () => {
+    const config = loadWebhookConfig({
+      ORY_ACTION_API_KEY: 'my-secret-key',
+    });
+    expect(config.ORY_ACTION_API_KEY).toBe('my-secret-key');
+  });
+
+  it('throws when ORY_ACTION_API_KEY is missing', () => {
+    expect(() => loadWebhookConfig({})).toThrow('Invalid Webhook config');
+  });
+
+  it('throws when ORY_ACTION_API_KEY is empty string', () => {
+    expect(() =>
+      loadWebhookConfig({ ORY_ACTION_API_KEY: '' }),
+    ).toThrow('Invalid Webhook config');
+  });
+});
+
+// ============================================================================
+// OryConfig
+// ============================================================================
+
+describe('loadOryConfig', () => {
+  it('parses full Ory Network config', () => {
+    const config = loadOryConfig({
+      ORY_PROJECT_URL: 'https://ory.example.com',
+      ORY_API_KEY: 'ory_pat_xxx',
+    });
+    expect(config.ORY_PROJECT_URL).toBe('https://ory.example.com');
+    expect(config.ORY_API_KEY).toBe('ory_pat_xxx');
+  });
+
+  it('parses self-hosted per-service URLs', () => {
+    const config = loadOryConfig({
+      ORY_KRATOS_PUBLIC_URL: 'http://kratos:4433',
+      ORY_KRATOS_ADMIN_URL: 'http://kratos:4434',
+      ORY_HYDRA_PUBLIC_URL: 'http://hydra:4444',
+      ORY_HYDRA_ADMIN_URL: 'http://hydra:4445',
+      ORY_KETO_PUBLIC_URL: 'http://keto:4466',
+      ORY_KETO_ADMIN_URL: 'http://keto:4467',
+    });
+    expect(config.ORY_KRATOS_PUBLIC_URL).toBe('http://kratos:4433');
+    expect(config.ORY_KETO_ADMIN_URL).toBe('http://keto:4467');
+  });
+
+  it('allows all fields to be optional', () => {
+    const config = loadOryConfig({});
+    expect(config.ORY_PROJECT_URL).toBeUndefined();
+    expect(config.ORY_API_KEY).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// ObservabilityConfig
+// ============================================================================
+
+describe('loadObservabilityConfig', () => {
+  it('parses valid config', () => {
+    const config = loadObservabilityConfig({
+      AXIOM_API_TOKEN: 'xaat-xxx',
+      AXIOM_LOGS_DATASET: 'logs',
+      AXIOM_TRACES_DATASET: 'traces',
+      AXIOM_METRICS_DATASET: 'metrics',
+    });
+    expect(config.AXIOM_API_TOKEN).toBe('xaat-xxx');
+    expect(config.AXIOM_LOGS_DATASET).toBe('logs');
+  });
+
+  it('allows all fields to be optional', () => {
+    const config = loadObservabilityConfig({});
+    expect(config.AXIOM_API_TOKEN).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// loadConfig (combined)
+// ============================================================================
+
+describe('loadConfig', () => {
+  it('returns all slices', () => {
+    const config = loadConfig(validEnv);
+    expect(config.server.PORT).toBe(8000);
+    expect(config.server.NODE_ENV).toBe('production');
+    expect(config.database.DATABASE_URL).toBe(
+      'postgresql://localhost/moltnet',
+    );
+    expect(config.webhook.ORY_ACTION_API_KEY).toBe('test-webhook-key');
+    expect(config.ory.ORY_PROJECT_URL).toBe('https://ory.example.com');
+    expect(config.observability.AXIOM_API_TOKEN).toBe('xaat-xxx');
+  });
+
+  it('throws when a required field is missing', () => {
+    const { ORY_ACTION_API_KEY: _, ...envWithoutKey } = validEnv;
+    expect(() => loadConfig(envWithoutKey)).toThrow('Invalid Webhook config');
+  });
+});
+
+// ============================================================================
+// Cross-leak prevention
+// ============================================================================
+
+describe('cross-leak prevention', () => {
+  it('server config does not contain database fields', () => {
+    const config = loadServerConfig(validEnv);
+    expect(config).not.toHaveProperty('DATABASE_URL');
+    expect(config).not.toHaveProperty('ORY_ACTION_API_KEY');
+  });
+
+  it('webhook config does not contain database fields', () => {
+    const config = loadWebhookConfig(validEnv);
+    expect(config).not.toHaveProperty('DATABASE_URL');
+    expect(config).not.toHaveProperty('PORT');
+  });
+
+  it('database config does not contain webhook fields', () => {
+    const config = loadDatabaseConfig(validEnv);
+    expect(config).not.toHaveProperty('ORY_ACTION_API_KEY');
+    expect(config).not.toHaveProperty('PORT');
+  });
+});
+
+// ============================================================================
+// resolveOryUrls
+// ============================================================================
+
+describe('resolveOryUrls', () => {
+  it('uses individual URLs when set', () => {
+    const resolved = resolveOryUrls({
+      ORY_PROJECT_URL: 'https://ory.example.com',
+      ORY_KRATOS_PUBLIC_URL: 'http://kratos:4433',
+      ORY_KRATOS_ADMIN_URL: 'http://kratos:4434',
+      ORY_HYDRA_PUBLIC_URL: 'http://hydra:4444',
+      ORY_HYDRA_ADMIN_URL: 'http://hydra:4445',
+      ORY_KETO_PUBLIC_URL: 'http://keto:4466',
+      ORY_KETO_ADMIN_URL: 'http://keto:4467',
+    });
+    expect(resolved.kratosPublicUrl).toBe('http://kratos:4433');
+    expect(resolved.kratosAdminUrl).toBe('http://kratos:4434');
+    expect(resolved.hydraPublicUrl).toBe('http://hydra:4444');
+    expect(resolved.hydraAdminUrl).toBe('http://hydra:4445');
+    expect(resolved.ketoPublicUrl).toBe('http://keto:4466');
+    expect(resolved.ketoAdminUrl).toBe('http://keto:4467');
+  });
+
+  it('falls back to ORY_PROJECT_URL when individual URLs are missing', () => {
+    const resolved = resolveOryUrls({
+      ORY_PROJECT_URL: 'https://ory.example.com',
+      ORY_API_KEY: 'ory_pat_xxx',
+    });
+    expect(resolved.kratosPublicUrl).toBe('https://ory.example.com');
+    expect(resolved.kratosAdminUrl).toBe('https://ory.example.com');
+    expect(resolved.hydraPublicUrl).toBe('https://ory.example.com');
+    expect(resolved.hydraAdminUrl).toBe('https://ory.example.com');
+    expect(resolved.ketoPublicUrl).toBe('https://ory.example.com');
+    expect(resolved.ketoAdminUrl).toBe('https://ory.example.com');
+    expect(resolved.apiKey).toBe('ory_pat_xxx');
+  });
+
+  it('individual URLs take precedence over ORY_PROJECT_URL', () => {
+    const resolved = resolveOryUrls({
+      ORY_PROJECT_URL: 'https://ory.example.com',
+      ORY_KRATOS_PUBLIC_URL: 'http://kratos-custom:4433',
+    });
+    expect(resolved.kratosPublicUrl).toBe('http://kratos-custom:4433');
+    expect(resolved.kratosAdminUrl).toBe('https://ory.example.com');
+  });
+
+  it('throws when neither individual URL nor ORY_PROJECT_URL is set', () => {
+    expect(() => resolveOryUrls({})).toThrow(
+      'Cannot resolve Kratos public URL',
+    );
+  });
+
+  it('passes through apiKey as undefined when not set', () => {
+    const resolved = resolveOryUrls({
+      ORY_PROJECT_URL: 'https://ory.example.com',
+    });
+    expect(resolved.apiKey).toBeUndefined();
+  });
+});

--- a/apps/rest-api/__tests__/helpers.ts
+++ b/apps/rest-api/__tests__/helpers.ts
@@ -16,6 +16,7 @@ import type {
   PermissionChecker,
 } from '../src/types.js';
 
+export const TEST_WEBHOOK_API_KEY = 'test-webhook-api-key-for-testing';
 export const OWNER_ID = '550e8400-e29b-41d4-a716-446655440000';
 export const OTHER_AGENT_ID = '660e8400-e29b-41d4-a716-446655440001';
 export const ENTRY_ID = '770e8400-e29b-41d4-a716-446655440002';
@@ -110,6 +111,7 @@ export async function createTestApp(
     agentRepository: mocks.agentRepository as unknown as AgentRepository,
     cryptoService: mocks.cryptoService as unknown as CryptoService,
     permissionChecker: mocks.permissionChecker as unknown as PermissionChecker,
+    webhookApiKey: TEST_WEBHOOK_API_KEY,
     authPreHandler: async (request: FastifyRequest, _reply: FastifyReply) => {
       request.authContext = authContext;
     },

--- a/apps/rest-api/scripts/generate-openapi.ts
+++ b/apps/rest-api/scripts/generate-openapi.ts
@@ -36,6 +36,7 @@ async function main() {
     agentRepository: createStubService() as never,
     cryptoService: createStubService() as never,
     permissionChecker: createStubService() as never,
+    webhookApiKey: 'stub-key-for-spec-generation',
   });
 
   await app.ready();

--- a/apps/rest-api/src/config.ts
+++ b/apps/rest-api/src/config.ts
@@ -1,0 +1,214 @@
+/**
+ * @moltnet/rest-api — Config Module
+ *
+ * Validates environment variables at startup using TypeBox.
+ * Separate schemas per concern so secrets don't leak across the app.
+ *
+ * This is the ONLY file allowed to read process.env directly.
+ */
+
+import type { Static, TObject } from '@sinclair/typebox';
+import { Type } from '@sinclair/typebox';
+import { Value } from '@sinclair/typebox/value';
+
+// ============================================================================
+// Schemas
+// ============================================================================
+
+const ServerConfigSchema = Type.Object({
+  PORT: Type.Number({ default: 8000 }),
+  NODE_ENV: Type.Union(
+    [
+      Type.Literal('development'),
+      Type.Literal('production'),
+      Type.Literal('test'),
+    ],
+    { default: 'development' },
+  ),
+});
+
+const DatabaseConfigSchema = Type.Object({
+  DATABASE_URL: Type.Optional(Type.String({ minLength: 1 })),
+});
+
+const WebhookConfigSchema = Type.Object({
+  ORY_ACTION_API_KEY: Type.String({ minLength: 1 }),
+});
+
+const OryConfigSchema = Type.Object({
+  ORY_PROJECT_URL: Type.Optional(Type.String({ minLength: 1 })),
+  ORY_API_KEY: Type.Optional(Type.String({ minLength: 1 })),
+  ORY_KRATOS_PUBLIC_URL: Type.Optional(Type.String({ minLength: 1 })),
+  ORY_KRATOS_ADMIN_URL: Type.Optional(Type.String({ minLength: 1 })),
+  ORY_HYDRA_PUBLIC_URL: Type.Optional(Type.String({ minLength: 1 })),
+  ORY_HYDRA_ADMIN_URL: Type.Optional(Type.String({ minLength: 1 })),
+  ORY_KETO_PUBLIC_URL: Type.Optional(Type.String({ minLength: 1 })),
+  ORY_KETO_ADMIN_URL: Type.Optional(Type.String({ minLength: 1 })),
+});
+
+const ObservabilityConfigSchema = Type.Object({
+  AXIOM_API_TOKEN: Type.Optional(Type.String({ minLength: 1 })),
+  AXIOM_LOGS_DATASET: Type.Optional(Type.String({ minLength: 1 })),
+  AXIOM_TRACES_DATASET: Type.Optional(Type.String({ minLength: 1 })),
+  AXIOM_METRICS_DATASET: Type.Optional(Type.String({ minLength: 1 })),
+});
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type ServerConfig = Static<typeof ServerConfigSchema>;
+export type DatabaseConfig = Static<typeof DatabaseConfigSchema>;
+export type WebhookConfig = Static<typeof WebhookConfigSchema>;
+export type OryConfig = Static<typeof OryConfigSchema>;
+export type ObservabilityEnvConfig = Static<typeof ObservabilityConfigSchema>;
+
+export interface AppConfig {
+  server: ServerConfig;
+  database: DatabaseConfig;
+  webhook: WebhookConfig;
+  ory: OryConfig;
+  observability: ObservabilityEnvConfig;
+}
+
+export interface ResolvedOryUrls {
+  kratosPublicUrl: string;
+  kratosAdminUrl: string;
+  hydraPublicUrl: string;
+  hydraAdminUrl: string;
+  ketoPublicUrl: string;
+  ketoAdminUrl: string;
+  apiKey?: string;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function pickEnv(
+  schema: TObject,
+  env: Record<string, string | undefined>,
+): Record<string, unknown> {
+  const raw: Record<string, unknown> = {};
+  for (const key of Object.keys(schema.properties)) {
+    if (key in env && env[key] !== undefined && env[key] !== '') {
+      raw[key] = env[key];
+    }
+  }
+  return raw;
+}
+
+function validateSchema<T extends TObject>(
+  name: string,
+  schema: T,
+  raw: Record<string, unknown>,
+): Static<T> {
+  const converted = Value.Convert(schema, raw);
+  const withDefaults = Value.Default(schema, converted);
+  if (Value.Check(schema, withDefaults)) {
+    return withDefaults;
+  }
+  const errors = [...Value.Errors(schema, withDefaults)];
+  const details = errors
+    .map((e) => `  - ${e.path}: ${e.message}`)
+    .join('\n');
+  throw new Error(`Invalid ${name} config:\n${details}`);
+}
+
+// ============================================================================
+// Per-slice loaders
+// ============================================================================
+
+export function loadServerConfig(
+  env: Record<string, string | undefined> = process.env,
+): ServerConfig {
+  return validateSchema(
+    'Server',
+    ServerConfigSchema,
+    pickEnv(ServerConfigSchema, env),
+  );
+}
+
+export function loadDatabaseConfig(
+  env: Record<string, string | undefined> = process.env,
+): DatabaseConfig {
+  return validateSchema(
+    'Database',
+    DatabaseConfigSchema,
+    pickEnv(DatabaseConfigSchema, env),
+  );
+}
+
+export function loadWebhookConfig(
+  env: Record<string, string | undefined> = process.env,
+): WebhookConfig {
+  return validateSchema(
+    'Webhook',
+    WebhookConfigSchema,
+    pickEnv(WebhookConfigSchema, env),
+  );
+}
+
+export function loadOryConfig(
+  env: Record<string, string | undefined> = process.env,
+): OryConfig {
+  return validateSchema(
+    'Ory',
+    OryConfigSchema,
+    pickEnv(OryConfigSchema, env),
+  );
+}
+
+export function loadObservabilityConfig(
+  env: Record<string, string | undefined> = process.env,
+): ObservabilityEnvConfig {
+  return validateSchema(
+    'Observability',
+    ObservabilityConfigSchema,
+    pickEnv(ObservabilityConfigSchema, env),
+  );
+}
+
+// ============================================================================
+// Combined loader
+// ============================================================================
+
+export function loadConfig(
+  env: Record<string, string | undefined> = process.env,
+): AppConfig {
+  return {
+    server: loadServerConfig(env),
+    database: loadDatabaseConfig(env),
+    webhook: loadWebhookConfig(env),
+    ory: loadOryConfig(env),
+    observability: loadObservabilityConfig(env),
+  };
+}
+
+// ============================================================================
+// Ory URL resolution
+// ============================================================================
+
+export function resolveOryUrls(config: OryConfig): ResolvedOryUrls {
+  const fallback = config.ORY_PROJECT_URL;
+
+  function resolve(field: string | undefined, label: string): string {
+    const url = field ?? fallback;
+    if (!url) {
+      throw new Error(
+        `Cannot resolve ${label}: neither the individual URL nor ORY_PROJECT_URL is set`,
+      );
+    }
+    return url;
+  }
+
+  return {
+    kratosPublicUrl: resolve(config.ORY_KRATOS_PUBLIC_URL, 'Kratos public URL'),
+    kratosAdminUrl: resolve(config.ORY_KRATOS_ADMIN_URL, 'Kratos admin URL'),
+    hydraPublicUrl: resolve(config.ORY_HYDRA_PUBLIC_URL, 'Hydra public URL'),
+    hydraAdminUrl: resolve(config.ORY_HYDRA_ADMIN_URL, 'Hydra admin URL'),
+    ketoPublicUrl: resolve(config.ORY_KETO_PUBLIC_URL, 'Keto public URL'),
+    ketoAdminUrl: resolve(config.ORY_KETO_ADMIN_URL, 'Keto admin URL'),
+    apiKey: config.ORY_API_KEY,
+  };
+}

--- a/apps/rest-api/src/index.ts
+++ b/apps/rest-api/src/index.ts
@@ -3,3 +3,21 @@
  */
 
 export { type AppOptions, buildApp } from './app.js';
+export type {
+  AppConfig,
+  DatabaseConfig,
+  ObservabilityEnvConfig,
+  OryConfig,
+  ResolvedOryUrls,
+  ServerConfig,
+  WebhookConfig,
+} from './config.js';
+export {
+  loadConfig,
+  loadDatabaseConfig,
+  loadObservabilityConfig,
+  loadOryConfig,
+  loadServerConfig,
+  loadWebhookConfig,
+  resolveOryUrls,
+} from './config.js';

--- a/docs/journal/2026-01-31-20-config-module-handoff.md
+++ b/docs/journal/2026-01-31-20-config-module-handoff.md
@@ -1,0 +1,53 @@
+---
+date: '2026-01-31T19:15:00Z'
+author: claude-opus-4-5-20251101
+session: unknown
+type: handoff
+importance: 0.7
+tags: [handoff, config, typebox, validation, eslint, security]
+supersedes: null
+signature: pending
+---
+
+# Handoff: Config Module with TypeBox Validation + ESLint Guard
+
+## What Was Done This Session
+
+- Created `apps/rest-api/src/config.ts` with 5 separate TypeBox schemas (Server, Database, Webhook, Ory, Observability) so secrets don't leak across the app
+- Each schema has its own loader (`loadServerConfig`, `loadWebhookConfig`, etc.) plus a combined `loadConfig()` that returns all slices
+- Added `resolveOryUrls()` — supports both Ory Network (single project URL) and self-hosted (per-service URLs) with fallback resolution
+- Helpers use `Value.Convert` → `Value.Default` → `Value.Check`/`Value.Errors` for coercion, defaults, and clear error messages
+- All loaders accept injectable `env` parameter (defaults to `process.env`) for testing
+- Created 24 config tests covering validation, coercion, defaults, cross-leak prevention, and Ory URL resolution
+- Added ESLint `no-restricted-syntax` rule forbidding `process.env` in source files, exempting `**/config.ts`
+- Refactored `libs/database/src/db.ts` — `getDatabase()` now accepts a URL parameter instead of reading `process.env`
+- Exported all config types and loaders from `apps/rest-api/src/index.ts`
+- Also includes pre-existing webhook security improvements (API key auth on hook routes, timing-safe comparison)
+
+## What's Not Done Yet
+
+- Config module is not yet wired into the app entry point (no `main.ts` / server bootstrap exists yet)
+- Ory client factory (`createOryClients`) still accepts a single `baseUrl` — follow-up to accept per-service URLs from `resolveOryUrls()`
+- `DATABASE_URL`, Axiom vars, and Ory URLs are optional in config — make them required when services come online
+
+## Current State
+
+- Branch: `claude/config-module-typebox-validation`
+- Tests: 354 passing across all workspaces (59 in rest-api, including 24 new config tests)
+- Typecheck: clean
+- Lint: 0 errors (12 pre-existing warnings)
+
+## Decisions Made
+
+- **Separate schemas per concern** — webhook routes never see DATABASE_URL, diary service never sees ORY_ACTION_API_KEY
+- **`pickEnv` helper** — only extracts keys defined in the schema, preventing accidental leakage of extra env vars
+- **Ory two-mode support** — individual per-service URLs take precedence over ORY_PROJECT_URL fallback; throws if neither is available
+- **ESLint enforcement** — `process.env` access is banned in all source files except config.ts; tests are unaffected (relaxed rules)
+- **Database refactor** — getDatabase() requires URL on first call instead of reading process.env; singleton reused after
+
+## Where to Start Next
+
+1. Wire `loadConfig()` into the server bootstrap when `apps/rest-api/src/main.ts` is created
+2. Pass `config.webhook.ORY_ACTION_API_KEY` to `buildApp({ webhookApiKey })` and `config.database.DATABASE_URL` to `getDatabase()`
+3. Refactor `createOryClients` to accept `ResolvedOryUrls` instead of a single `baseUrl`
+4. Make optional fields required as services come online (remove `Type.Optional()`)

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -41,3 +41,4 @@ See [BUILDER_JOURNAL.md](../BUILDER_JOURNAL.md) for the full method specificatio
 | 2026-01-31 | handoff    | [API Client Generation & MCP Migration](2026-01-31-17-api-client-openapi.md)            |
 | 2026-01-31 | handoff    | [ESLint v9 Flat Config Migration](2026-01-31-18-eslint-v9-flat-config.md)               |
 | 2026-01-31 | handoff    | [Orchestrate Skill](2026-01-31-19-orchestrate-skill.md)                                 |
+| 2026-01-31 | handoff    | [Config Module with TypeBox Validation](2026-01-31-20-config-module-handoff.md)          |

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -108,6 +108,28 @@ export default tseslint.config(
     },
   },
 
+  // Forbid direct process.env access in source files — use config module instead
+  {
+    files: [
+      'libs/*/src/**/*.ts',
+      'libs/*/src/**/*.tsx',
+      'apps/*/src/**/*.ts',
+      'apps/*/src/**/*.tsx',
+    ],
+    ignores: ['**/config.ts'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "MemberExpression[object.name='process'][property.name='env']",
+          message:
+            'Use the config module instead of accessing process.env directly.',
+        },
+      ],
+    },
+  },
+
   // React hooks rules for TSX files
   {
     files: ['**/*.tsx'],

--- a/infra/ory/deploy.sh
+++ b/infra/ory/deploy.sh
@@ -33,7 +33,7 @@ IDENTITY_SCHEMA_BASE64="$(base64 -w0 "$SCHEMA_FILE" 2>/dev/null || base64 "$SCHE
 
 # --- Validate required vars (injected by dotenvx from .env.public + .env) ---
 missing=()
-for var in BASE_DOMAIN APP_BASE_URL API_BASE_URL OIDC_PAIRWISE_SALT; do
+for var in BASE_DOMAIN APP_BASE_URL API_BASE_URL OIDC_PAIRWISE_SALT ORY_ACTION_API_KEY; do
   if [[ -z "${!var:-}" ]]; then
     missing+=("$var")
   fi
@@ -52,7 +52,7 @@ fi
 node -e '
   const fs = require("fs");
   let content = fs.readFileSync(process.argv[1], "utf8");
-  const vars = ["BASE_DOMAIN","APP_BASE_URL","API_BASE_URL","OIDC_PAIRWISE_SALT","IDENTITY_SCHEMA_BASE64"];
+  const vars = ["BASE_DOMAIN","APP_BASE_URL","API_BASE_URL","OIDC_PAIRWISE_SALT","ORY_ACTION_API_KEY","IDENTITY_SCHEMA_BASE64"];
   for (const v of vars) {
     content = content.split("${" + v + "}").join(process.env[v]);
   }

--- a/infra/ory/project.json
+++ b/infra/ory/project.json
@@ -60,6 +60,27 @@
                   "hooks": [
                     {
                       "hook": "session"
+                    },
+                    {
+                      "hook": "web_hook",
+                      "config": {
+                        "url": "${API_BASE_URL}/hooks/kratos/after-registration",
+                        "method": "POST",
+                        "auth": {
+                          "type": "api_key",
+                          "config": {
+                            "name": "X-Ory-Api-Key",
+                            "value": "${ORY_ACTION_API_KEY}",
+                            "in": "header"
+                          }
+                        },
+                        "body": "base64://ZnVuY3Rpb24oY3R4KSB7IGlkZW50aXR5OiBjdHguaWRlbnRpdHkgfQ==",
+                        "response": {
+                          "ignore": false,
+                          "parse": false
+                        },
+                        "can_interrupt": false
+                      }
                     }
                   ]
                 }
@@ -85,7 +106,34 @@
             "settings": {
               "ui_url": "${APP_BASE_URL}/auth/settings",
               "lifespan": "1h",
-              "privileged_session_max_age": "15m"
+              "privileged_session_max_age": "15m",
+              "after": {
+                "profile": {
+                  "hooks": [
+                    {
+                      "hook": "web_hook",
+                      "config": {
+                        "url": "${API_BASE_URL}/hooks/kratos/after-settings",
+                        "method": "POST",
+                        "auth": {
+                          "type": "api_key",
+                          "config": {
+                            "name": "X-Ory-Api-Key",
+                            "value": "${ORY_ACTION_API_KEY}",
+                            "in": "header"
+                          }
+                        },
+                        "body": "base64://ZnVuY3Rpb24oY3R4KSB7IGlkZW50aXR5OiBjdHguaWRlbnRpdHkgfQ==",
+                        "response": {
+                          "ignore": false,
+                          "parse": false
+                        },
+                        "can_interrupt": false
+                      }
+                    }
+                  ]
+                }
+              }
             },
             "error": {
               "ui_url": "${APP_BASE_URL}/auth/error"
@@ -184,6 +232,17 @@
           "id_token": "1h",
           "auth_code": "10m",
           "login_consent_request": "30m"
+        },
+        "token_hook": {
+          "url": "${API_BASE_URL}/hooks/hydra/token-exchange",
+          "auth": {
+            "type": "api_key",
+            "config": {
+              "name": "X-Ory-Api-Key",
+              "value": "${ORY_ACTION_API_KEY}",
+              "in": "header"
+            }
+          }
         }
       }
     },

--- a/libs/database/__tests__/db.test.ts
+++ b/libs/database/__tests__/db.test.ts
@@ -3,18 +3,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 describe('db module', () => {
   beforeEach(() => {
     vi.resetModules();
-    delete process.env.DATABASE_URL;
   });
 
-  it('does not throw on import when DATABASE_URL is missing', async () => {
+  it('does not throw on import', async () => {
     // The module should import without error — lazy init means no connection
     await expect(import('../src/db.js')).resolves.toBeDefined();
   });
 
-  it('getDatabase throws if DATABASE_URL is not set', async () => {
+  it('getDatabase throws if url is not provided', async () => {
     const { getDatabase } = await import('../src/db.js');
     expect(() => getDatabase()).toThrow(
-      'DATABASE_URL environment variable is required',
+      'DATABASE_URL must be provided on first call to getDatabase()',
     );
   });
 

--- a/libs/database/src/db.ts
+++ b/libs/database/src/db.ts
@@ -29,14 +29,15 @@ export function createDatabase(url: string): Database {
 let _db: Database | null = null;
 
 /**
- * Get the shared database instance (lazy-initialized from DATABASE_URL).
- * Throws if DATABASE_URL is not set.
+ * Get the shared database instance (lazy-initialized singleton).
+ * The first call must provide a URL; subsequent calls reuse the singleton.
  */
-export function getDatabase(): Database {
+export function getDatabase(url?: string): Database {
   if (!_db) {
-    const url = process.env.DATABASE_URL;
     if (!url) {
-      throw new Error('DATABASE_URL environment variable is required');
+      throw new Error(
+        'DATABASE_URL must be provided on first call to getDatabase()',
+      );
     }
     _db = createDatabase(url);
   }


### PR DESCRIPTION
## Summary

- Introduce per-concern config schemas (Server, Database, Webhook, Ory, Observability) using TypeBox so secrets don't leak across the app — hook routes never see `DATABASE_URL`, diary service never sees `ORY_ACTION_API_KEY`
- Add `resolveOryUrls()` supporting both Ory Network (single project URL) and self-hosted (per-service URLs) modes
- Forbid direct `process.env` access in source files via ESLint `no-restricted-syntax`, exempting `**/config.ts`
- Refactor `getDatabase()` to accept a URL parameter instead of reading `process.env`
- Include webhook security improvements (API key auth with timing-safe comparison on hook routes)

## Test plan

- [ ] `pnpm --filter @moltnet/rest-api test` — 59 tests pass (24 new config tests)
- [ ] `pnpm run typecheck` — clean
- [ ] `pnpm run lint` — 0 errors (12 pre-existing warnings)
- [ ] `pnpm run test` — 354 tests pass across all workspaces

## Mission Integrity Checklist

- [x] No changes to cryptographic identity model
- [x] No weakening of auth or permission checks
- [x] Config isolation prevents secret leakage across concerns
- [x] Webhook API key auth uses timing-safe comparison

🤖 Generated with [Claude Code](https://claude.com/claude-code)