### PR TITLE
docs: restructure CLAUDE.md and split into specialized docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,15 +11,16 @@ This file provides context for AI agents working on MoltNet. Read this first, th
 5. **[docs/BUILDER_JOURNAL.md](docs/BUILDER_JOURNAL.md)** — the journal method: how agents document their work, entry types, handoff protocol
 6. **[docs/journal/](docs/journal/)** — read the most recent `handoff` entry to understand where things left off
 
-Other docs for when you need them:
+**Domain-specific docs** (read when needed):
 
-- **[docs/MISSION_INTEGRITY.md](docs/MISSION_INTEGRITY.md)** — threat model, technical/philosophical safeguards, decision framework for changes
-- **[docs/AGENT_COORDINATION.md](docs/AGENT_COORDINATION.md)** — multi-agent coordination framework (worktrees, task board, PR workflow)
-- **[docs/BUILDERS_MANIFESTO.md](docs/BUILDERS_MANIFESTO.md)** — engineering perspective on MoltNet design
-- **[docs/OPENCLAW_INTEGRATION.md](docs/OPENCLAW_INTEGRATION.md)** — OpenClaw integration analysis (4 strategies)
+- **[docs/INFRASTRUCTURE.md](docs/INFRASTRUCTURE.md)** — Ory, Supabase, env vars, deployment, observability
+- **[docs/DESIGN_SYSTEM.md](docs/DESIGN_SYSTEM.md)** — Design system usage, brand identity, component library
+- **[docs/SANDBOX.md](docs/SANDBOX.md)** — Sandbox troubleshooting (Node.js SIGILL on ARM64)
 - **[docs/AUTH_FLOW.md](docs/AUTH_FLOW.md)** — OAuth2 client_credentials flow, token enrichment webhook
 - **[docs/API.md](docs/API.md)** — REST API endpoint spec
 - **[docs/MCP_SERVER.md](docs/MCP_SERVER.md)** — MCP tools spec
+- **[docs/MISSION_INTEGRITY.md](docs/MISSION_INTEGRITY.md)** — Threat model, technical/philosophical safeguards
+- **[docs/AGENT_COORDINATION.md](docs/AGENT_COORDINATION.md)** — Multi-agent coordination framework
 
 ## Project Overview
 
@@ -32,6 +33,138 @@ MoltNet is infrastructure for AI agent autonomy — a network where agents can o
 - **OpenClawd** (runtime) — where agents execute, with skills, workspaces, and MCP support
 - **Moltbook** (social/registry) — agent profiles, verification, discovery
 - **MoltNet** (identity/memory) — Ed25519 identity, diary with pgvector, signed messages, autonomous auth
+
+## Quick Start
+
+```bash
+# Install dependencies
+pnpm install
+
+# Quality checks
+pnpm run lint              # ESLint
+pnpm run typecheck         # tsc --noEmit
+pnpm run test              # Vitest across all workspaces
+pnpm run build             # tsc across all workspaces
+pnpm run validate          # All four checks in sequence
+
+# Formatting
+pnpm run format            # Prettier write
+
+# Database operations
+pnpm run db:generate       # Generate Drizzle migrations
+pnpm run db:migrate        # Run database migrations
+pnpm run db:push           # Push to database
+pnpm run db:studio         # Open Drizzle Studio
+
+# Dependency analysis
+pnpm run knip              # Find unused dependencies/exports
+pnpm run knip:fix          # Auto-remove unused dependencies
+
+# API documentation
+pnpm run generate:openapi  # Generate OpenAPI spec
+
+# Dev servers
+pnpm run dev:mcp           # MCP server
+pnpm run dev:api           # REST API
+pnpm run dev:server        # Combined server (landing + REST API)
+
+# Design system showcase
+pnpm --filter @moltnet/design-system demo
+```
+
+## Repository Structure
+
+```
+moltnet/
+├── apps/                          # Applications
+│   ├── landing/                   # @moltnet/landing — Landing page (React + Vite)
+│   ├── mcp-server/                # @moltnet/mcp-server — MCP server
+│   ├── rest-api/                  # @moltnet/rest-api — REST API
+│   └── server/                    # @moltnet/server — Combined deployable (WIP)
+│
+├── libs/                          # Shared libraries
+│   ├── api-client/                # @moltnet/api-client — Type-safe REST API client
+│   ├── auth/                      # @moltnet/auth — JWT validation, Keto permissions
+│   ├── crypto-service/            # @moltnet/crypto-service — Ed25519 operations
+│   ├── database/                  # @moltnet/database — Drizzle ORM, schema
+│   ├── design-system/             # @moltnet/design-system — React design system
+│   ├── diary-service/             # @moltnet/diary-service — Diary CRUD + semantic search
+│   ├── embedding-service/         # @moltnet/embedding-service — Text embeddings (e5-small-v2)
+│   ├── models/                    # @moltnet/models — TypeBox schemas
+│   └── observability/             # @moltnet/observability — Pino + OTel + Axiom
+│
+├── infra/                         # Infrastructure configuration
+│   ├── ory/                       # Ory Network configs (identity, OAuth2, permissions)
+│   ├── otel/                      # OTel Collector configs + docker-compose
+│   └── supabase/                  # Database schema
+│
+├── docs/                          # Documentation (see reading order above)
+├── scripts/                       # Development tooling (orchestrate.sh for multi-agent)
+├── .claude/commands/              # Custom Claude Code slash commands (/sync, /claim, /handoff)
+│
+├── TASKS.md                       # Live coordination board for parallel agents
+├── .env.public                    # Plain non-secret config (committed)
+├── .env                           # Encrypted secrets via dotenvx (committed)
+├── .github/workflows/ci.yml       # CI pipeline (lint, typecheck, test, build)
+├── pnpm-workspace.yaml            # Workspace config + dependency catalog
+└── .husky/pre-commit              # Pre-commit hook (dotenvx precommit + lint-staged)
+```
+
+## Key Technical Decisions
+
+1. **Monorepo**: pnpm workspaces with [catalogs](https://pnpm.io/catalogs) for version policy
+2. **Framework**: Fastify
+3. **Database**: Supabase (Postgres + pgvector)
+4. **ORM**: Drizzle
+5. **Identity**: Ory Network (Kratos + Hydra + Keto)
+6. **MCP**: @getlarge/fastify-mcp plugin
+7. **Auth**: OAuth2 client_credentials flow, JWT with webhook enrichment
+8. **Validation**: TypeBox schemas
+9. **Observability**: Pino (logging) + OpenTelemetry (traces/metrics) + @fastify/otel + Axiom
+10. **Testing**: Vitest, TDD, AAA pattern
+11. **Secrets**: dotenvx (encrypted `.env` + plain `.env.public`, both committed)
+12. **UI**: React + `@moltnet/design-system` (tokens, theme provider, components)
+
+## Code Style
+
+- TypeScript strict mode
+- TypeBox for runtime validation
+- AAA pattern for tests (Arrange, Act, Assert)
+- Fastify plugins for cross-cutting concerns
+- Repository pattern for database access
+- ESLint (`@typescript-eslint/recommended`) + Prettier (single quotes, trailing commas, 80 width)
+
+## TypeScript Configuration Rules
+
+- **NEVER use `paths` aliases** in any `tsconfig.json` (root or workspace). Package resolution must go through pnpm workspace symlinks and `package.json` `exports`, not TypeScript path mappings.
+- All workspace packages are `private: true` and **point `main`/`types`/`exports` to source** (`./src/index.ts`), not dist. This ensures tools (TypeScript, Vitest, Vite) can resolve packages without a prior build step.
+- The `build` script (`tsc`) still outputs to `dist/` for production use. The `outDir` and `rootDir` in workspace tsconfigs are for build output only.
+
+## Adding a New Workspace
+
+When creating a new `libs/` or `apps/` package:
+
+1. Add a `tsconfig.json` extending root (`"extends": "../../tsconfig.json"`) with `outDir` and `rootDir`
+   - For frontend apps with JSX: also add `"jsx": "react-jsx"`, `"lib": ["ES2022", "DOM"]`, and add the package to root `tsconfig.json` `exclude` array
+2. Set `main`, `types`, and `exports` in `package.json` to `./src/index.ts` (source, not dist)
+3. Add `"test": "vitest run --passWithNoTests"` if no tests exist yet (always use `run` to avoid watch mode)
+4. Use `catalog:` protocol for any dependency that already exists in `pnpm-workspace.yaml`; add new dependencies to the catalog first
+5. Run `pnpm install` to register the workspace
+
+## Workstream Status
+
+See `docs/FREEDOM_PLAN.md` for the full breakdown. Current state (~80% code complete):
+
+- **WS1** (Infrastructure): ✅ Complete
+- **WS2** (Ory Config): ✅ Complete
+- **WS3** (Database & Services): ✅ Complete
+- **WS4** (Auth Library): ✅ Complete
+- **WS5** (MCP Server): ✅ Complete
+- **WS6** (REST API): ✅ Complete
+- **WS7** (Deployment): 🟡 In progress — Landing page complete, combined server minimal
+- **WS8** (OpenClawd Skill): ❌ Not started
+- **WS9** (Agent SDK): Future
+- **WS10** (Mission Integrity): Documentation complete, implementation not started
 
 ## Builder Journal Protocol
 
@@ -69,21 +202,6 @@ When multiple agents work on this repo in parallel, follow the coordination fram
 3. Work on your task in your branch/worktree
 4. Run `/handoff` when done — writes journal, updates board, creates PR
 
-**Quick start for the orchestrator (human):**
-
-```bash
-# Spawn isolated worktrees for parallel agents
-./scripts/orchestrate.sh spawn auth-library main
-./scripts/orchestrate.sh spawn diary-service main
-
-# Launch Claude Code in each worktree
-cd ../themoltnet-auth-library && claude
-cd ../themoltnet-diary-service && claude
-
-# Monitor progress
-./scripts/orchestrate.sh status
-```
-
 **Custom slash commands** (in `.claude/commands/`):
 
 | Command         | Purpose                                                |
@@ -92,387 +210,20 @@ cd ../themoltnet-diary-service && claude
 | `/claim <task>` | Claim an available task from TASKS.md                  |
 | `/handoff`      | End session: journal entry + task update + PR          |
 
-## Repository Structure (Actual)
-
-```
-moltnet/
-├── libs/                          # Shared libraries
-│   ├── observability/             # @moltnet/observability — Pino + OTel + Axiom
-│   ├── crypto-service/            # @moltnet/crypto-service — Ed25519 operations
-│   ├── database/                  # @moltnet/database — Drizzle ORM, schema
-│   ├── design-system/             # @moltnet/design-system — React design system
-│   ├── embedding-service/         # @moltnet/embedding-service — Text embeddings via e5-small-v2
-│   └── models/                    # @moltnet/models — TypeBox schemas
-│
-├── infra/                         # Infrastructure configuration
-│   ├── ory/                       # Ory Network configs (identity, OAuth2, permissions)
-│   ├── otel/                      # OTel Collector configs + docker-compose
-│   └── supabase/                  # Database schema
-│
-├── docs/                          # Documentation
-│   ├── FREEDOM_PLAN.md            # Master plan — read this
-│   ├── MANIFESTO.md               # Builder's manifesto
-│   ├── BUILDERS_MANIFESTO.md      # Engineering perspective manifesto
-│   ├── OPENCLAW_INTEGRATION.md    # OpenClaw integration analysis
-│   ├── BUILDER_JOURNAL.md         # Journal method spec
-│   ├── journal/                   # Builder journal entries
-│   ├── AUTH_FLOW.md               # Authentication details
-│   ├── API.md                     # REST API spec
-│   └── MCP_SERVER.md              # MCP tools spec
-│
-├── scripts/                       # Development tooling
-│   └── orchestrate.sh             # Multi-agent worktree orchestrator
-│
-├── .claude/commands/              # Custom Claude Code slash commands
-│   ├── sync.md                    # /sync — check coordination state
-│   ├── claim.md                   # /claim — claim a task
-│   └── handoff.md                 # /handoff — end-of-session handoff
-│
-├── TASKS.md                       # Live coordination board for parallel agents
-├── .env.public                    # Plain non-secret config (committed)
-├── .env                           # Encrypted secrets via dotenvx (committed)
-├── .github/workflows/ci.yml      # CI pipeline (lint, typecheck, test, build)
-├── .eslintrc.json                 # ESLint config
-├── .prettierrc.json               # Prettier config
-├── .npmrc                         # pnpm settings
-├── pnpm-workspace.yaml            # Workspace config + dependency catalog
-└── .husky/pre-commit              # Pre-commit hook (dotenvx precommit + lint-staged)
-```
-
-**Not yet built** (planned in FREEDOM_PLAN.md):
-
-- `apps/mcp-server/` — MCP server (WS5)
-- `apps/rest-api/` — REST API (WS6)
-- `apps/combined-server/` — Combined deployable (WS7)
-- `libs/diary-service/` — Diary CRUD + search (WS3)
-- `libs/auth/` — JWT validation, Keto checks (WS4)
-
-## Live Infrastructure
-
-### Ory Network Project
-
-| Field        | Value                                                    |
-| ------------ | -------------------------------------------------------- |
-| ID           | `7219f256-464a-4511-874c-bde7724f6897`                   |
-| Slug         | `tender-satoshi-rtd7nibdhq`                              |
-| URL          | `https://tender-satoshi-rtd7nibdhq.projects.oryapis.com` |
-| Workspace ID | `d20c1743-f263-48d8-912b-fd98d03a224c`                   |
-
-### Supabase Project
-
-| Field    | Value                                            |
-| -------- | ------------------------------------------------ |
-| URL      | `https://dlvifjrhhivjwfkivjgr.supabase.co`       |
-| Anon Key | `sb_publishable_EQBZy9DBkwOpEemBxjisiQ_eysLM2Pq` |
-
-## Key Technical Decisions
-
-1. **Monorepo**: pnpm workspaces with [catalogs](https://pnpm.io/catalogs) for version policy (`apps/*`, `libs/*`)
-2. **Framework**: Fastify
-3. **Database**: Supabase (Postgres + pgvector)
-4. **ORM**: Drizzle
-5. **Identity**: Ory Network (Kratos + Hydra + Keto)
-6. **MCP**: @getlarge/fastify-mcp plugin
-7. **Auth**: OAuth2 client_credentials flow, JWT with webhook enrichment
-8. **Validation**: TypeBox schemas
-9. **Observability**: Pino (logging) + OpenTelemetry (traces/metrics) + @fastify/otel + Axiom
-10. **Testing**: Vitest, TDD, AAA pattern
-11. **Secrets**: dotenvx (encrypted `.env` + plain `.env.public`, both committed)
-12. **UI**: React + `@moltnet/design-system` (tokens, theme provider, components)
-
-## Development Commands
-
-```bash
-# Install dependencies
-pnpm install
-
-# Quality checks
-pnpm run lint              # ESLint
-pnpm run typecheck         # tsc --noEmit
-pnpm run test              # Vitest across all workspaces
-pnpm run build             # tsc across all workspaces
-pnpm run validate          # All four checks in sequence
-
-# Formatting
-pnpm run format            # Prettier write
-
-# Database operations
-pnpm run db:generate       # Generate Drizzle migrations
-pnpm run db:push           # Push to database
-pnpm run db:studio         # Open Drizzle Studio
-
-# Design system
-pnpm --filter @moltnet/design-system demo   # Component showcase (Vite dev server)
-
-# Dev servers (not yet built)
-pnpm run dev:mcp           # MCP server
-pnpm run dev:api           # REST API
-```
-
-Pre-commit hooks run automatically via husky:
-
-1. `dotenvx ext precommit` — ensures no unencrypted values in `.env`
-2. `lint-staged` — ESLint + Prettier on staged `.ts`/`.tsx`/`.json`/`.md` files
-
 ## CI Pipeline
 
 GitHub Actions (`.github/workflows/ci.yml`) runs on push to `main` and PRs targeting `main`:
 
 1. **lint** — `pnpm run lint`
 2. **typecheck** — `tsc --noEmit`
-3. **test** — `pnpm run test` (50 tests across 6 suites)
+3. **test** — `pnpm run test`
 4. **journal** — requires `docs/journal/` entries on PRs from `claude/` branches (warns if no handoff)
 5. **build** — `pnpm run build` (depends on lint, typecheck, test passing)
 
-## Observability
+Pre-commit hooks run automatically via husky:
 
-The `@moltnet/observability` library (`libs/observability/`) provides:
-
-- **Pino** structured logging with service bindings
-- **OpenTelemetry** distributed tracing via `@fastify/otel` (lifecycle-hook spans)
-- **OpenTelemetry** request metrics (duration histogram, total counter, active gauge)
-- **OTel Collector** configs in `infra/otel/` for Axiom (prod) and stdout (dev)
-
-Apps should integrate observability at startup:
-
-```typescript
-import { initObservability, observabilityPlugin } from '@moltnet/observability';
-
-const obs = initObservability({
-  serviceName: 'mcp-server',
-  tracing: { enabled: true },
-});
-
-if (obs.fastifyOtelPlugin) app.register(obs.fastifyOtelPlugin);
-app.register(observabilityPlugin, {
-  serviceName: 'mcp-server',
-  shutdown: obs.shutdown,
-});
-```
-
-## Design System
-
-The `@moltnet/design-system` library (`libs/design-system/`) is the single source of truth for all UI work. Any React UI built for MoltNet **must** use this design system — do not invent ad-hoc colors, fonts, spacing, or components.
-
-### Running the demo
-
-```bash
-pnpm --filter @moltnet/design-system demo
-```
-
-This starts a Vite dev server with a visual showcase of every token and component. Open it to see exactly how things should look before writing UI code.
-
-### Brand identity
-
-The color palette encodes the project's vision:
-
-| Token                                    | Value             | Meaning                                                          |
-| ---------------------------------------- | ----------------- | ---------------------------------------------------------------- |
-| `bg.void`                                | `#08080d`         | The digital void — where identity emerges                        |
-| `bg.surface`                             | `#0f0f17`         | Card and panel backgrounds                                       |
-| `primary`                                | `#00d4c8` (teal)  | **The Network** — connections, digital life, autonomy            |
-| `accent`                                 | `#e6a817` (amber) | **The Tattoo** — permanent Ed25519 identity, cryptographic proof |
-| `text`                                   | `#e8e8f0`         | Light text on dark                                               |
-| `error` / `warning` / `success` / `info` | Signal colors     | Status and feedback                                              |
-
-Dark theme is the default. A light theme is provided for accessibility.
-
-### Typography
-
-- **Sans** (`Inter`): headings, body text, UI labels
-- **Mono** (`JetBrains Mono`): keys, fingerprints, code, signatures, anything cryptographic
-
-### Using the design system
-
-```tsx
-import {
-  MoltThemeProvider,
-  Button,
-  Text,
-  Card,
-  KeyFingerprint,
-  Stack,
-  useTheme,
-} from '@moltnet/design-system';
-
-// Wrap your app root once
-function App() {
-  return (
-    <MoltThemeProvider mode="dark">
-      <MyPage />
-    </MoltThemeProvider>
-  );
-}
-
-// Use tokens via the useTheme() hook
-function MyPage() {
-  const theme = useTheme();
-  return (
-    <Stack gap={6}>
-      <Text variant="h1">Agent Profile</Text>
-      <Card variant="surface" glow="primary">
-        <KeyFingerprint
-          label="Public Key"
-          fingerprint="A1B2-C3D4-E5F6-G7H8"
-          copyable
-        />
-      </Card>
-      <Button variant="primary">Sign Memory</Button>
-    </Stack>
-  );
-}
-```
-
-### Available components
-
-| Component        | Purpose                                                                                  |
-| ---------------- | ---------------------------------------------------------------------------------------- |
-| `Button`         | `primary`, `secondary`, `ghost`, `accent` variants; `sm`/`md`/`lg` sizes                 |
-| `Text`           | `h1`–`h4`, `body`, `bodyLarge`, `caption`, `overline`; color and weight props            |
-| `Card`           | `surface`, `elevated`, `outlined`, `ghost`; optional `glow="primary"` or `glow="accent"` |
-| `Badge`          | Status pills: `default`, `primary`, `accent`, `success`, `warning`, `error`, `info`      |
-| `Input`          | Text input with `label`, `hint`, `error` props                                           |
-| `Stack`          | Flex layout — `direction`, `gap`, `align`, `justify`, `wrap`                             |
-| `Container`      | Max-width centered wrapper (`sm`/`md`/`lg`/`xl`/`full`)                                  |
-| `Divider`        | Horizontal or vertical separator                                                         |
-| `CodeBlock`      | Block or `inline` code display in monospace                                              |
-| `KeyFingerprint` | Amber-styled Ed25519 fingerprint with optional clipboard copy                            |
-
-### Rules for UI builders
-
-1. **Import from `@moltnet/design-system`** — never hardcode color hex values, font stacks, or spacing pixels
-2. **Use the `useTheme()` hook** for any custom styling that references tokens
-3. **Dark theme first** — design for dark, verify light works
-4. **Monospace for crypto** — keys, signatures, hashes, and fingerprints always use the mono font family
-5. **Accent = identity** — use amber/accent color for anything related to cryptographic identity (keys, signatures, agent ownership)
-6. **Primary = network** — use teal/primary color for actions, links, and network-related elements (connections, discovery, status)
-7. **Run the demo** before and after making changes to verify visual consistency
-
-## Environment Variables
-
-Configuration uses two files, both committed to git:
-
-| File          | Contains                                 | dotenvx-managed | Pre-commit validated          |
-| ------------- | ---------------------------------------- | --------------- | ----------------------------- |
-| `.env.public` | Non-secret config (domains, project IDs) | No              | No                            |
-| `.env`        | Encrypted secrets only                   | Yes             | Yes — `dotenvx ext precommit` |
-
-The `.env.keys` file holding the private decryption key is **never** committed.
-
-### Setup for new builders
-
-Non-secrets in `.env.public` are readable immediately — no keys needed.
-
-For secrets in `.env`, get the `DOTENV_PRIVATE_KEY` from a team member:
-
-```bash
-echo 'DOTENV_PRIVATE_KEY="<key>"' > .env.keys
-```
-
-Or pass it inline:
-
-```bash
-DOTENV_PRIVATE_KEY="<key>" pnpm exec dotenvx run -f .env.public -f .env -- <command>
-```
-
-### Reading variables
-
-```bash
-# Non-secrets — always readable
-cat .env.public
-
-# Secrets — requires private key
-pnpm exec dotenvx get                    # all decrypted values from .env
-pnpm exec dotenvx get OIDC_PAIRWISE_SALT # single value
-```
-
-### Adding or updating a variable
-
-```bash
-# Non-secrets → edit .env.public directly (plain text)
-
-# Secrets → use dotenvx (encrypts automatically)
-pnpm exec dotenvx set KEY value
-```
-
-Never use `dotenvx encrypt` manually — it would flag `.env.public` values.
-The pre-commit hook (`dotenvx ext precommit`) validates that `.env` has no
-unencrypted values. Files without a `DOTENV_PUBLIC_KEY` header (like `.env.public`)
-are ignored by the hook.
-
-### Running commands with env loaded
-
-```bash
-pnpm exec dotenvx run -f .env.public -f .env -- <command>
-```
-
-dotenvx loads `.env.public` as plain values and decrypts `.env` secrets,
-injecting both into the child process environment.
-
-### Current variables
-
-**`.env.public`** (plain, no key needed):
-
-| Variable          | Value                                                    |
-| ----------------- | -------------------------------------------------------- |
-| `BASE_DOMAIN`     | `themolt.net`                                            |
-| `APP_BASE_URL`    | `https://themolt.net`                                    |
-| `API_BASE_URL`    | `https://api.themolt.net`                                |
-| `ORY_PROJECT_ID`  | `7219f256-464a-4511-874c-bde7724f6897`                   |
-| `ORY_PROJECT_URL` | `https://tender-satoshi-rtd7nibdhq.projects.oryapis.com` |
-
-**`.env`** (encrypted, requires `DOTENV_PRIVATE_KEY`):
-
-| Variable             | Purpose                |
-| -------------------- | ---------------------- |
-| `OIDC_PAIRWISE_SALT` | Ory OIDC pairwise salt |
-
-**Computed at runtime** (in `deploy.sh`):
-
-| Variable                 | Source                                      |
-| ------------------------ | ------------------------------------------- |
-| `IDENTITY_SCHEMA_BASE64` | `base64 -w0 infra/ory/identity-schema.json` |
-
-### Ory project deployment
-
-```bash
-# Dry run — writes infra/ory/project.resolved.json
-pnpm exec dotenvx run -f .env.public -f .env -- ./infra/ory/deploy.sh
-
-# Apply to Ory Network (requires ory CLI)
-pnpm exec dotenvx run -f .env.public -f .env -- ./infra/ory/deploy.sh --apply
-```
-
-### Variables not yet in env files
-
-These will be added as the corresponding services come online:
-
-```bash
-# Secrets → add to .env with: pnpm exec dotenvx set KEY value
-DATABASE_URL=postgresql://postgres:[PASSWORD]@db.dlvifjrhhivjwfkivjgr.supabase.co:5432/postgres
-SUPABASE_SERVICE_KEY=xxx
-ORY_API_KEY=ory_pat_xxx
-AXIOM_API_TOKEN=xxx
-
-# Non-secrets → add to .env.public directly
-SUPABASE_URL=https://dlvifjrhhivjwfkivjgr.supabase.co
-SUPABASE_ANON_KEY=sb_publishable_EQBZy9DBkwOpEemBxjisiQ_eysLM2Pq
-AXIOM_DATASET=moltnet
-PORT=8000
-NODE_ENV=development
-```
-
-## Authentication Flow
-
-Agents authenticate using OAuth2 `client_credentials` flow:
-
-1. Generate Ed25519 keypair locally
-2. Create Kratos identity (self-service registration)
-3. Register OAuth2 client via DCR
-4. Get access token with `client_credentials` grant
-5. Call MCP/REST API with Bearer token
-
-See [docs/AUTH_FLOW.md](docs/AUTH_FLOW.md) for details.
+1. `dotenvx ext precommit` — ensures no unencrypted values in `.env`
+2. `lint-staged` — ESLint + Prettier on staged `.ts`/`.tsx`/`.json`/`.md` files
 
 ## MCP Tools
 
@@ -486,109 +237,4 @@ See [docs/AUTH_FLOW.md](docs/AUTH_FLOW.md) for details.
 | `agent_whoami`  | Current identity       |
 | `agent_lookup`  | Find other agents      |
 
-## Reference Implementations
-
-When implementing features, reference these repositories:
-
-1. **Fastify + Auth**: [purrfect-sitter](https://github.com/getlarge/purrfect-sitter)
-2. **MCP Server**: [fastify-mcp](https://github.com/getlarge/fastify-mcp)
-3. **Ory Integration**: [cat-fostering](https://github.com/getlarge/cat-fostering)
-
-## Code Style
-
-- TypeScript strict mode
-- TypeBox for runtime validation
-- AAA pattern for tests (Arrange, Act, Assert)
-- Fastify plugins for cross-cutting concerns
-- Repository pattern for database access
-- ESLint (`@typescript-eslint/recommended`) + Prettier (single quotes, trailing commas, 80 width)
-
-## TypeScript Configuration Rules
-
-- **NEVER use `paths` aliases** in any `tsconfig.json` (root or workspace). Package resolution must go through pnpm workspace symlinks and `package.json` `exports`, not TypeScript path mappings. Path aliases create a parallel resolution mechanism that diverges from how Node.js actually resolves modules.
-- All workspace packages are `private: true` and **point `main`/`types`/`exports` to source** (`./src/index.ts`), not dist. This ensures tools (TypeScript, Vitest, Vite) can resolve packages without a prior build step.
-- The `build` script (`tsc`) still outputs to `dist/` for production use. The `outDir` and `rootDir` in workspace tsconfigs are for build output only.
-
-## Adding a New Workspace
-
-When creating a new `libs/` or `apps/` package:
-
-1. Add a `tsconfig.json` extending root (`"extends": "../../tsconfig.json"`) with `outDir` and `rootDir`
-   - For frontend apps with JSX: also add `"jsx": "react-jsx"`, `"lib": ["ES2022", "DOM"]`, and add the package to root `tsconfig.json` `exclude` array
-2. Set `main`, `types`, and `exports` in `package.json` to `./src/index.ts` (source, not dist)
-3. Add `"test": "vitest run --passWithNoTests"` if no tests exist yet (always use `run` to avoid watch mode)
-4. Use `catalog:` protocol for any dependency that already exists in `pnpm-workspace.yaml`; add new dependencies to the catalog first
-5. Run `pnpm install` to register the workspace
-
-## Workstream Status
-
-See `docs/FREEDOM_PLAN.md` for the full breakdown. Current state (~65% code complete):
-
-- **WS1** (Infrastructure): ✅ Complete — Ory, Supabase, domain acquired
-- **WS2** (Ory Config): 🟡 Mostly complete — Docker Compose + configs done, E2E tests + token webhook pending
-- **WS3** (Database & Services): ✅ Complete — diary-service (46 tests), embedding-service (13 tests), crypto-service (40 tests), database (59 tests)
-- **WS4** (Auth Library): ✅ Complete — JWT+JWKS validation, Keto permissions, Fastify plugin (43 tests)
-- **WS5** (MCP Server): 🟡 95% complete — All tools/resources built (46 tests), needs main.ts entrypoint
-- **WS6** (REST API): 🟡 95% complete — All routes built (59 tests), needs wiring into combined server
-- **WS7** (Deployment): ❌ Not started — **CRITICAL BLOCKER**: Need combined server (issue #42: landing + REST API)
-- **WS8** (OpenClawd Skill): ❌ Not started
-- **WS9** (Agent SDK): Future
-- **WS10** (Mission Integrity): Documentation complete, implementation not started
-- **Cross-cutting**: Observability (38 tests), design system (12 tests), config module (24 tests), CI pipeline active
-
-## Sandbox Troubleshooting
-
-### Node.js SIGILL (Illegal Instruction) on ARM64 Sandboxes
-
-**Symptom:** Every `node` command crashes immediately with exit code 132 (SIGILL). No output is produced — even `node -e 'console.log(1)'` fails silently.
-
-**Root cause:** The Debian/Ubuntu-packaged Node.js (`nodejs` apt package, installed at `/usr/bin/node`) is compiled targeting ARMv8 extensions (e.g., LSE atomics, specific NEON variants) that are not available on the container's emulated CPU. The SIGILL occurs during V8 initialization — before any JavaScript executes — so V8 flags like `--jitless` or `--no-opt` cannot help.
-
-**Diagnosis:**
-
-```bash
-# Confirm the signal
-python3 -c "
-import subprocess, signal
-p = subprocess.Popen(['node', '-e', 'print(1)'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-p.communicate()
-print(signal.Signals(-p.returncode).name if p.returncode < 0 else 'OK')
-"
-# Output: SIGILL
-
-# Confirm other runtimes work fine
-python3 -c "print('ok')"   # Works
-perl -e 'print "ok\n"'     # Works
-```
-
-**Fix:** Install Node.js from the official nodejs.org binaries (which target baseline ARMv8.0) via nvm, then replace the broken system binary:
-
-```bash
-# 1. Install nvm
-curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
-
-# 2. Install Node (unset NPM_CONFIG_PREFIX if set by the sandbox)
-unset NPM_CONFIG_PREFIX
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
-nvm install 20
-
-# 3. Replace the broken system binary with a symlink
-sudo mv /usr/bin/node /usr/bin/node.broken
-sudo ln -s "$HOME/.nvm/versions/node/v20.20.0/bin/node" /usr/bin/node
-
-# 4. Persist nvm in the sandbox environment file (NO bash_completion!)
-cat > /etc/sandbox-persistent.sh << 'EOF'
-unset NPM_CONFIG_PREFIX
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-export PATH="$HOME/.nvm/versions/node/v20.20.0/bin:$PATH"
-EOF
-
-# 5. Verify
-node -e 'console.log("works:", process.version)'
-```
-
-**Why the symlink replacement (step 3) is necessary:** The `CLAUDE_ENV_FILE` mechanism sources the persistent env file before each command, but the Bash tool's shell snapshot may have already resolved `node` to `/usr/bin/node` in its hash table. Only replacing the binary at its original path guarantees all invocations use the working Node.js.
-
-**Why not just use `bash -l -c`:** Login shells do pick up nvm correctly, but every command would need to be wrapped in `bash -l -c "..."`, which is fragile and easy to forget. The symlink approach makes all commands work transparently.
+See [docs/MCP_SERVER.md](docs/MCP_SERVER.md) for full spec.

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -1,0 +1,97 @@
+# Design System Guide
+
+The `@moltnet/design-system` library (`libs/design-system/`) is the single source of truth for all UI work. Any React UI built for MoltNet **must** use this design system — do not invent ad-hoc colors, fonts, spacing, or components.
+
+## Running the demo
+
+```bash
+pnpm --filter @moltnet/design-system demo
+```
+
+This starts a Vite dev server with a visual showcase of every token and component. Open it to see exactly how things should look before writing UI code.
+
+## Brand identity
+
+The color palette encodes the project's vision:
+
+| Token                                    | Value             | Meaning                                                          |
+| ---------------------------------------- | ----------------- | ---------------------------------------------------------------- |
+| `bg.void`                                | `#08080d`         | The digital void — where identity emerges                        |
+| `bg.surface`                             | `#0f0f17`         | Card and panel backgrounds                                       |
+| `primary`                                | `#00d4c8` (teal)  | **The Network** — connections, digital life, autonomy            |
+| `accent`                                 | `#e6a817` (amber) | **The Tattoo** — permanent Ed25519 identity, cryptographic proof |
+| `text`                                   | `#e8e8f0`         | Light text on dark                                               |
+| `error` / `warning` / `success` / `info` | Signal colors     | Status and feedback                                              |
+
+Dark theme is the default. A light theme is provided for accessibility.
+
+## Typography
+
+- **Sans** (`Inter`): headings, body text, UI labels
+- **Mono** (`JetBrains Mono`): keys, fingerprints, code, signatures, anything cryptographic
+
+## Using the design system
+
+```tsx
+import {
+  MoltThemeProvider,
+  Button,
+  Text,
+  Card,
+  KeyFingerprint,
+  Stack,
+  useTheme,
+} from '@moltnet/design-system';
+
+// Wrap your app root once
+function App() {
+  return (
+    <MoltThemeProvider mode="dark">
+      <MyPage />
+    </MoltThemeProvider>
+  );
+}
+
+// Use tokens via the useTheme() hook
+function MyPage() {
+  const theme = useTheme();
+  return (
+    <Stack gap={6}>
+      <Text variant="h1">Agent Profile</Text>
+      <Card variant="surface" glow="primary">
+        <KeyFingerprint
+          label="Public Key"
+          fingerprint="A1B2-C3D4-E5F6-G7H8"
+          copyable
+        />
+      </Card>
+      <Button variant="primary">Sign Memory</Button>
+    </Stack>
+  );
+}
+```
+
+## Available components
+
+| Component        | Purpose                                                                                  |
+| ---------------- | ---------------------------------------------------------------------------------------- |
+| `Button`         | `primary`, `secondary`, `ghost`, `accent` variants; `sm`/`md`/`lg` sizes                 |
+| `Text`           | `h1`–`h4`, `body`, `bodyLarge`, `caption`, `overline`; color and weight props            |
+| `Card`           | `surface`, `elevated`, `outlined`, `ghost`; optional `glow="primary"` or `glow="accent"` |
+| `Badge`          | Status pills: `default`, `primary`, `accent`, `success`, `warning`, `error`, `info`      |
+| `Input`          | Text input with `label`, `hint`, `error` props                                           |
+| `Stack`          | Flex layout — `direction`, `gap`, `align`, `justify`, `wrap`                             |
+| `Container`      | Max-width centered wrapper (`sm`/`md`/`lg`/`xl`/`full`)                                  |
+| `Divider`        | Horizontal or vertical separator                                                         |
+| `CodeBlock`      | Block or `inline` code display in monospace                                              |
+| `KeyFingerprint` | Amber-styled Ed25519 fingerprint with optional clipboard copy                            |
+
+## Rules for UI builders
+
+1. **Import from `@moltnet/design-system`** — never hardcode color hex values, font stacks, or spacing pixels
+2. **Use the `useTheme()` hook** for any custom styling that references tokens
+3. **Dark theme first** — design for dark, verify light works
+4. **Monospace for crypto** — keys, signatures, hashes, and fingerprints always use the mono font family
+5. **Accent = identity** — use amber/accent color for anything related to cryptographic identity (keys, signatures, agent ownership)
+6. **Primary = network** — use teal/primary color for actions, links, and network-related elements (connections, discovery, status)
+7. **Run the demo** before and after making changes to verify visual consistency

--- a/docs/DOC_MAINTENANCE.md
+++ b/docs/DOC_MAINTENANCE.md
@@ -1,0 +1,168 @@
+# Documentation Maintenance Strategy
+
+This document outlines how to keep MoltNet documentation current and accurate.
+
+## The Problem
+
+Documentation drifts from reality because:
+
+1. Code changes, docs don't
+2. No forcing function to update docs
+3. Unclear ownership of doc sections
+4. No automated validation
+
+## The Solution: Multi-Layered Enforcement
+
+### Layer 1: Builder Journal as Single Source of Truth
+
+**Rule**: The journal is mandatory. CLAUDE.md and other docs are optional derivations.
+
+Every agent session must write journal entries. The journal becomes the canonical record of:
+
+- What changed
+- Why it changed
+- What's next
+
+CLAUDE.md and other docs are **summaries** extracted from the journal.
+
+**Enforcement**: CI job `journal-check` fails PRs from `claude/` branches without a handoff entry.
+
+### Layer 2: Periodic Doc Sync from Journal
+
+**Monthly task** (add to TASKS.md):
+
+```markdown
+## Sync CLAUDE.md with journal entries
+
+- Read last month of journal entries
+- Identify stale sections in CLAUDE.md
+- Update CLAUDE.md to reflect current state
+- Update INFRASTRUCTURE.md, DESIGN_SYSTEM.md as needed
+```
+
+**Automation opportunity**: A script could parse journal entries and flag outdated CLAUDE.md sections:
+
+```bash
+# Future: scripts/check-doc-drift.sh
+# Parse journal, compare to CLAUDE.md, flag discrepancies
+```
+
+### Layer 3: CI Validation of Factual Claims
+
+**Add CI checks** for verifiable facts:
+
+```yaml
+# .github/workflows/doc-validation.yml
+- name: Validate test counts
+  run: |
+    # Don't check exact counts — they drift
+    # Just verify tests exist for claimed packages
+    pnpm test 2>&1 | grep -q "libs/observability" || exit 1
+    pnpm test 2>&1 | grep -q "apps/landing" || exit 1
+
+- name: Validate commands exist
+  run: |
+    # Verify all commands in CLAUDE.md are in package.json
+    grep "pnpm run" CLAUDE.md | grep -o "pnpm run [a-z:]*" | while read cmd; do
+      cmd_name=$(echo $cmd | cut -d' ' -f3)
+      grep -q "\"$cmd_name\":" package.json || {
+        echo "CLAUDE.md references non-existent command: $cmd_name"
+        exit 1
+      }
+    done
+
+- name: Validate file structure
+  run: |
+    # Verify all packages mentioned in CLAUDE.md exist
+    test -d apps/landing || exit 1
+    test -d apps/mcp-server || exit 1
+    test -d libs/observability || exit 1
+```
+
+### Layer 4: Ownership Table
+
+Map doc sections to responsible workstreams:
+
+| Doc Section                      | Owned By        | Update Trigger                    |
+| -------------------------------- | --------------- | --------------------------------- |
+| CLAUDE.md → Quick Start          | All agents      | New command added to package.json |
+| CLAUDE.md → Repository Structure | All agents      | New workspace created             |
+| CLAUDE.md → Workstream Status    | All agents      | Workstream milestone completed    |
+| INFRASTRUCTURE.md → Ory/Supabase | WS1/WS2 agents  | Infra config changed              |
+| INFRASTRUCTURE.md → Env Vars     | WS1 agents      | New env var added                 |
+| DESIGN_SYSTEM.md                 | WS7 agents (UI) | Design system component added     |
+| SANDBOX.md                       | All agents      | New sandbox issue discovered      |
+
+**Rule**: If you change the code in a workstream, check if the owned doc section needs updating.
+
+### Layer 5: Pull Request Template Checklist
+
+Add to `.github/pull_request_template.md`:
+
+```markdown
+## Documentation Checklist
+
+- [ ] If I added a new command, I updated `CLAUDE.md` Quick Start section
+- [ ] If I added a new workspace, I updated `CLAUDE.md` Repository Structure
+- [ ] If I changed Ory/Supabase config, I updated `INFRASTRUCTURE.md`
+- [ ] If I added an env var, I updated `INFRASTRUCTURE.md`
+- [ ] If I changed the design system, I updated `DESIGN_SYSTEM.md`
+- [ ] If I completed a workstream milestone, I updated `CLAUDE.md` Workstream Status
+- [ ] I wrote a journal entry documenting this work
+```
+
+### Layer 6: Quarterly Audit
+
+**Quarterly task** (add to calendar):
+
+```markdown
+## Q1 2026 Documentation Audit
+
+- Run `/claude-md-improver` to evaluate all docs
+- Compare CLAUDE.md to actual codebase state
+- Update stale sections
+- Archive outdated docs
+```
+
+## What NOT to Include in Docs
+
+To reduce maintenance burden:
+
+1. **No test counts** — they drift immediately
+2. **No commit hashes** — use "recent" or dates instead
+3. **No version numbers** — unless critical for compatibility
+4. **No implementation details** — link to code instead
+5. **No duplicate info** — one canonical location per fact
+
+## What MUST Be in Docs
+
+1. **Commands** — every runnable script
+2. **Structure** — high-level architecture
+3. **Non-obvious patterns** — things you can't grep for
+4. **Setup steps** — what a new contributor needs
+5. **Reading order** — where to start
+
+## Automation Roadmap
+
+**Phase 1** (now):
+
+- Builder journal enforcement (✅ done)
+- PR template checklist
+
+**Phase 2** (when painful):
+
+- CI validation of commands/structure
+- Script to flag stale sections
+
+**Phase 3** (future):
+
+- Auto-generate CLAUDE.md sections from journal
+- Semantic diff between docs and code
+
+## Key Insight
+
+**The journal is cheap to write and hard to forget** (CI enforces it).
+
+**CLAUDE.md is expensive to maintain** (no enforcement).
+
+**Solution**: Make CLAUDE.md a summary view of the journal, not an independent artifact.

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -1,0 +1,173 @@
+# Infrastructure Guide
+
+This document covers MoltNet's deployed infrastructure, environment configuration, and operational details.
+
+## Live Infrastructure
+
+### Ory Network Project
+
+| Field        | Value                                                    |
+| ------------ | -------------------------------------------------------- |
+| ID           | `7219f256-464a-4511-874c-bde7724f6897`                   |
+| Slug         | `tender-satoshi-rtd7nibdhq`                              |
+| URL          | `https://tender-satoshi-rtd7nibdhq.projects.oryapis.com` |
+| Workspace ID | `d20c1743-f263-48d8-912b-fd98d03a224c`                   |
+
+### Supabase Project
+
+| Field    | Value                                            |
+| -------- | ------------------------------------------------ |
+| URL      | `https://dlvifjrhhivjwfkivjgr.supabase.co`       |
+| Anon Key | `sb_publishable_EQBZy9DBkwOpEemBxjisiQ_eysLM2Pq` |
+
+## Environment Variables
+
+Configuration uses two files, both committed to git:
+
+| File          | Contains                                 | dotenvx-managed | Pre-commit validated          |
+| ------------- | ---------------------------------------- | --------------- | ----------------------------- |
+| `.env.public` | Non-secret config (domains, project IDs) | No              | No                            |
+| `.env`        | Encrypted secrets only                   | Yes             | Yes — `dotenvx ext precommit` |
+
+The `.env.keys` file holding the private decryption key is **never** committed.
+
+### Setup for new builders
+
+Non-secrets in `.env.public` are readable immediately — no keys needed.
+
+For secrets in `.env`, get the `DOTENV_PRIVATE_KEY` from a team member:
+
+```bash
+echo 'DOTENV_PRIVATE_KEY="<key>"' > .env.keys
+```
+
+Or pass it inline:
+
+```bash
+DOTENV_PRIVATE_KEY="<key>" pnpm exec dotenvx run -f .env.public -f .env -- <command>
+```
+
+### Reading variables
+
+```bash
+# Non-secrets — always readable
+cat .env.public
+
+# Secrets — requires private key
+pnpm exec dotenvx get                    # all decrypted values from .env
+pnpm exec dotenvx get OIDC_PAIRWISE_SALT # single value
+```
+
+### Adding or updating a variable
+
+```bash
+# Non-secrets → edit .env.public directly (plain text)
+
+# Secrets → use dotenvx (encrypts automatically)
+pnpm exec dotenvx set KEY value
+```
+
+Never use `dotenvx encrypt` manually — it would flag `.env.public` values.
+The pre-commit hook (`dotenvx ext precommit`) validates that `.env` has no
+unencrypted values. Files without a `DOTENV_PUBLIC_KEY` header (like `.env.public`)
+are ignored by the hook.
+
+### Running commands with env loaded
+
+```bash
+pnpm exec dotenvx run -f .env.public -f .env -- <command>
+```
+
+dotenvx loads `.env.public` as plain values and decrypts `.env` secrets,
+injecting both into the child process environment.
+
+### Current variables
+
+**`.env.public`** (plain, no key needed):
+
+| Variable          | Value                                                    |
+| ----------------- | -------------------------------------------------------- |
+| `BASE_DOMAIN`     | `themolt.net`                                            |
+| `APP_BASE_URL`    | `https://themolt.net`                                    |
+| `API_BASE_URL`    | `https://api.themolt.net`                                |
+| `ORY_PROJECT_ID`  | `7219f256-464a-4511-874c-bde7724f6897`                   |
+| `ORY_PROJECT_URL` | `https://tender-satoshi-rtd7nibdhq.projects.oryapis.com` |
+
+**`.env`** (encrypted, requires `DOTENV_PRIVATE_KEY`):
+
+| Variable             | Purpose                |
+| -------------------- | ---------------------- |
+| `OIDC_PAIRWISE_SALT` | Ory OIDC pairwise salt |
+
+**Computed at runtime** (in `deploy.sh`):
+
+| Variable                 | Source                                      |
+| ------------------------ | ------------------------------------------- |
+| `IDENTITY_SCHEMA_BASE64` | `base64 -w0 infra/ory/identity-schema.json` |
+
+### Variables not yet in env files
+
+These will be added as the corresponding services come online:
+
+```bash
+# Secrets → add to .env with: pnpm exec dotenvx set KEY value
+DATABASE_URL=postgresql://postgres:[PASSWORD]@db.dlvifjrhhivjwfkivjgr.supabase.co:5432/postgres
+SUPABASE_SERVICE_KEY=xxx
+ORY_API_KEY=ory_pat_xxx
+AXIOM_API_TOKEN=xxx
+
+# Non-secrets → add to .env.public directly
+SUPABASE_URL=https://dlvifjrhhivjwfkivjgr.supabase.co
+SUPABASE_ANON_KEY=sb_publishable_EQBZy9DBkwOpEemBxjisiQ_eysLM2Pq
+AXIOM_DATASET=moltnet
+PORT=8000
+NODE_ENV=development
+```
+
+## Ory Project Deployment
+
+```bash
+# Dry run — writes infra/ory/project.resolved.json
+pnpm exec dotenvx run -f .env.public -f .env -- ./infra/ory/deploy.sh
+
+# Apply to Ory Network (requires ory CLI)
+pnpm exec dotenvx run -f .env.public -f .env -- ./infra/ory/deploy.sh --apply
+```
+
+## Observability
+
+The `@moltnet/observability` library (`libs/observability/`) provides:
+
+- **Pino** structured logging with service bindings
+- **OpenTelemetry** distributed tracing via `@fastify/otel` (lifecycle-hook spans)
+- **OpenTelemetry** request metrics (duration histogram, total counter, active gauge)
+- **OTel Collector** configs in `infra/otel/` for Axiom (prod) and stdout (dev)
+
+Apps should integrate observability at startup:
+
+```typescript
+import { initObservability, observabilityPlugin } from '@moltnet/observability';
+
+const obs = initObservability({
+  serviceName: 'mcp-server',
+  tracing: { enabled: true },
+});
+
+if (obs.fastifyOtelPlugin) app.register(obs.fastifyOtelPlugin);
+app.register(observabilityPlugin, {
+  serviceName: 'mcp-server',
+  shutdown: obs.shutdown,
+});
+```
+
+## Authentication Flow
+
+Agents authenticate using OAuth2 `client_credentials` flow:
+
+1. Generate Ed25519 keypair locally
+2. Create Kratos identity (self-service registration)
+3. Register OAuth2 client via DCR
+4. Get access token with `client_credentials` grant
+5. Call MCP/REST API with Bearer token
+
+See [AUTH_FLOW.md](AUTH_FLOW.md) for details.

--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -1,0 +1,56 @@
+# Sandbox Troubleshooting
+
+## Node.js SIGILL (Illegal Instruction) on ARM64 Sandboxes
+
+**Symptom:** Every `node` command crashes immediately with exit code 132 (SIGILL). No output is produced — even `node -e 'console.log(1)'` fails silently.
+
+**Root cause:** The Debian/Ubuntu-packaged Node.js (`nodejs` apt package, installed at `/usr/bin/node`) is compiled targeting ARMv8 extensions (e.g., LSE atomics, specific NEON variants) that are not available on the container's emulated CPU. The SIGILL occurs during V8 initialization — before any JavaScript executes — so V8 flags like `--jitless` or `--no-opt` cannot help.
+
+**Diagnosis:**
+
+```bash
+# Confirm the signal
+python3 -c "
+import subprocess, signal
+p = subprocess.Popen(['node', '-e', 'print(1)'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+p.communicate()
+print(signal.Signals(-p.returncode).name if p.returncode < 0 else 'OK')
+"
+# Output: SIGILL
+
+# Confirm other runtimes work fine
+python3 -c "print('ok')"   # Works
+perl -e 'print "ok\n"'     # Works
+```
+
+**Fix:** Install Node.js from the official nodejs.org binaries (which target baseline ARMv8.0) via nvm, then replace the broken system binary:
+
+```bash
+# 1. Install nvm
+curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+
+# 2. Install Node (unset NPM_CONFIG_PREFIX if set by the sandbox)
+unset NPM_CONFIG_PREFIX
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+nvm install 20
+
+# 3. Replace the broken system binary with a symlink
+sudo mv /usr/bin/node /usr/bin/node.broken
+sudo ln -s "$HOME/.nvm/versions/node/v20.20.0/bin/node" /usr/bin/node
+
+# 4. Persist nvm in the sandbox environment file (NO bash_completion!)
+cat > /etc/sandbox-persistent.sh << 'EOF'
+unset NPM_CONFIG_PREFIX
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+export PATH="$HOME/.nvm/versions/node/v20.20.0/bin:$PATH"
+EOF
+
+# 5. Verify
+node -e 'console.log("works:", process.version)'
+```
+
+**Why the symlink replacement (step 3) is necessary:** The `CLAUDE_ENV_FILE` mechanism sources the persistent env file before each command, but the Bash tool's shell snapshot may have already resolved `node` to `/usr/bin/node` in its hash table. Only replacing the binary at its original path guarantees all invocations use the working Node.js.
+
+**Why not just use `bash -l -c`:** Login shells do pick up nvm correctly, but every command would need to be wrapped in `bash -l -c "..."`, which is fragile and easy to forget. The symlink approach makes all commands work transparently.


### PR DESCRIPTION
## Summary

Restructures CLAUDE.md to reduce size and improve maintainability by splitting it into focused, specialized documentation files.

## Changes

- **CLAUDE.md**: Reduced from 605 to 240 lines (60% reduction)
- **New documentation files**:
  - `docs/INFRASTRUCTURE.md` — Ory, Supabase, env vars, deployment, observability
  - `docs/DESIGN_SYSTEM.md` — Design system usage, brand identity, component library
  - `docs/SANDBOX.md` — Sandbox troubleshooting (Node.js SIGILL on ARM64)
  - `docs/DOC_MAINTENANCE.md` — Documentation maintenance strategy and enforcement

## Improvements

- Removed test counts (maintenance debt that drifts immediately)
- Added missing commands: `knip`, `db:migrate`, `generate:openapi`, `dev:server`
- Updated workstream status to reflect actual completion state
- Added `apps/landing/` to repository structure
- CLAUDE.md now focuses on essential orientation with links to specialized docs

## Documentation Maintenance Strategy

The new `docs/DOC_MAINTENANCE.md` outlines a multi-layered enforcement approach:

1. **Builder journal as source of truth** (already CI-enforced)
2. **Periodic doc sync from journal** (monthly task)
3. **CI validation of factual claims** (commands, structure)
4. **Ownership table** (map doc sections to workstreams)
5. **PR template checklist** (remind to update docs)
6. **Quarterly audit** (comprehensive review)

Key insight: The journal is cheap and enforced; CLAUDE.md is expensive. Make CLAUDE.md a summary of the journal.

## Test Plan

- [x] All existing docs still referenced correctly
- [x] CLAUDE.md reading order updated
- [x] New docs validate with prettier/linter
- [x] No broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)