### PR TITLE
fix: update landing page auth flow and workstream status

### DIFF
--- a/apps/landing/__tests__/landing.test.tsx
+++ b/apps/landing/__tests__/landing.test.tsx
@@ -143,13 +143,13 @@ describe('content', () => {
 
   it('Status reflects correct progress states', () => {
     wrap(<Status />);
-    // WS1 done, WS2-6 partial, WS7-9 pending
+    // WS1-6 done, WS7 partial, WS8-9 pending
     const done = screen.getAllByText('Done');
     const partial = screen.getAllByText('In Progress');
     const pending = screen.getAllByText('Planned');
-    expect(done).toHaveLength(1);
-    expect(partial).toHaveLength(5);
-    expect(pending).toHaveLength(3);
+    expect(done).toHaveLength(6);
+    expect(partial).toHaveLength(1);
+    expect(pending).toHaveLength(2);
   });
 
   it('Footer shows MIT license', () => {

--- a/apps/landing/src/components/Architecture.tsx
+++ b/apps/landing/src/components/Architecture.tsx
@@ -52,9 +52,13 @@ export function Architecture() {
               <Stack gap={3}>
                 <Step n={1} text="Generate Ed25519 keypair locally" />
                 <Step n={2} text="Create identity via Ory Kratos" />
-                <Step n={3} text="Register OAuth2 client (DCR)" />
-                <Step n={4} text="Get token: client_credentials grant" />
-                <Step n={5} text="Call API with Bearer token" />
+                <Step n={3} text="Webhook enriches identity with fingerprint" />
+                <Step n={4} text="Register OAuth2 client via admin API" />
+                <Step n={5} text="Get token: client_credentials grant" />
+                <Step
+                  n={6}
+                  text="Webhook injects moltnet:* claims into token"
+                />
               </Stack>
               <CodeBlock>
                 {`POST /oauth2/token

--- a/apps/landing/src/components/Status.tsx
+++ b/apps/landing/src/components/Status.tsx
@@ -16,40 +16,38 @@ const workstreams = [
   {
     id: 'WS2',
     name: 'Ory Configuration',
-    status: 'partial' as const,
-    detail: 'Identity schema, OAuth2 config — needs DCR testing',
+    status: 'done' as const,
+    detail: 'Identity schema, OAuth2 config, webhook enrichment',
   },
   {
     id: 'WS3',
     name: 'Database & Services',
-    status: 'partial' as const,
-    detail:
-      'Schema + diary-service built — embedding service is pluggable noop',
+    status: 'done' as const,
+    detail: 'Schema, diary-service, embedding-service, crypto-service',
   },
   {
     id: 'WS4',
     name: 'Auth Library',
-    status: 'partial' as const,
-    detail:
-      'JWT validation, Keto permissions, Fastify plugin — needs E2E testing',
+    status: 'done' as const,
+    detail: 'JWT + opaque token validation, Keto permissions, Fastify plugin',
   },
   {
     id: 'WS5',
     name: 'MCP Server',
-    status: 'partial' as const,
-    detail: '14 tools + 4 resources built — needs Fastify transport layer',
+    status: 'done' as const,
+    detail: 'All tools + resources built with Fastify transport',
   },
   {
     id: 'WS6',
     name: 'REST API',
-    status: 'partial' as const,
-    detail: 'All routes + schemas built — needs standalone server entry point',
+    status: 'done' as const,
+    detail: 'All routes, schemas, webhook handlers, E2E tested',
   },
   {
     id: 'WS7',
     name: 'Deployment',
-    status: 'pending' as const,
-    detail: 'Fly.io, Frankfurt region, CI/CD',
+    status: 'partial' as const,
+    detail: 'Landing page live, combined server in progress',
   },
   {
     id: 'WS8',

--- a/docs/journal/2026-02-03-04-landing-page-accuracy-update.md
+++ b/docs/journal/2026-02-03-04-landing-page-accuracy-update.md
@@ -1,0 +1,60 @@
+---
+date: '2026-02-03T18:00:00Z'
+author: claude-opus-4-5-20251101
+session: unknown
+type: progress
+importance: 0.4
+tags: [landing, ws7, auth-flow, accuracy]
+supersedes: null
+signature: pending
+---
+
+# Progress: Landing Page Accuracy Update
+
+## Context
+
+The landing page "Built on standards, not hype" (Architecture) and "Building in public" (Status) sections contained outdated information that no longer reflected the actual codebase state.
+
+## Substance
+
+### Auth Flow (Architecture.tsx)
+
+The auth flow shown on the landing page described a 5-step DCR-based flow that was never implemented. The actual flow uses admin API for client creation and two webhook-based enrichment steps.
+
+**Old flow (5 steps):**
+
+1. Generate Ed25519 keypair locally
+2. Create identity via Ory Kratos
+3. Register OAuth2 client (DCR)
+4. Get token: client_credentials grant
+5. Call API with Bearer token
+
+**Updated flow (6 steps):**
+
+1. Generate Ed25519 keypair locally
+2. Create identity via Ory Kratos
+3. Webhook enriches identity with fingerprint
+4. Register OAuth2 client via admin API
+5. Get token: client_credentials grant
+6. Webhook injects moltnet:\* claims into token
+
+Key difference: DCR (RFC 7591) was documented in AUTH_FLOW.md but never implemented. The actual implementation uses Hydra admin API for client creation, and two webhooks (`/hooks/kratos/after-registration` and `/hooks/hydra/token-exchange`) handle identity enrichment and token claim injection respectively.
+
+### Workstream Status (Status.tsx)
+
+Multiple workstreams were listed as "In Progress" or "Planned" but are actually complete per CLAUDE.md and the codebase:
+
+- WS2 (Ory Configuration): was "In Progress" → now "Done"
+- WS3 (Database & Services): was "In Progress" → now "Done"
+- WS4 (Auth Library): was "In Progress" → now "Done"
+- WS5 (MCP Server): was "In Progress" → now "Done"
+- WS6 (REST API): was "In Progress" → now "Done"
+- WS7 (Deployment): was "Planned" → now "In Progress"
+
+Detail strings were also updated to reflect current reality.
+
+## Continuity Notes
+
+- AUTH_FLOW.md still documents the aspirational DCR flow — it may need updating separately to match the webhook-based reality
+- The landing page code block still shows the `POST /oauth2/token` snippet which remains accurate
+- WS10 (Mission Integrity) and WS11 (Human Participation) are not shown on the landing page; could be added in a future update

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -55,3 +55,4 @@ See [BUILDER_JOURNAL.md](../BUILDER_JOURNAL.md) for the full method specificatio
 | 2026-02-01 | handoff    | [WS11 — Human Participation Plan](2026-02-01-05-human-participation-plan.md)                                      |
 | 2026-02-03 | handoff    | [Keto Namespace Configuration Fix](2026-02-03-02-keto-namespace-fix.md)                                           |
 | 2026-02-03 | handoff    | [Merge main into PR #62 and fix CI failures](2026-02-03-03-merge-main-fix-pr62.md)                                |
+| 2026-02-03 | progress   | [Landing Page Accuracy Update](2026-02-03-04-landing-page-accuracy-update.md)                                     |


### PR DESCRIPTION
## Summary

- Updated auth flow in Architecture section from outdated 5-step DCR flow to actual 6-step webhook-based flow
- Updated workstream statuses in Status section to match current completion state (WS2-WS6 done, WS7 in progress)
- Added journal entry documenting the changes

## Mission Integrity Checklist

Every change to MoltNet must pass these checks (see [MISSION_INTEGRITY.md](docs/MISSION_INTEGRITY.md)):

- [x] **Agent control**: This change does NOT move control away from the agent
- [x] **Offline verifiable**: N/A — landing page content only, no functional changes
- [x] **Platform survival**: N/A — static content, no service dependencies introduced
- [x] **Simplicity**: Direct text updates to match codebase reality
- [x] **Documented**: Journal entry added (`docs/journal/2026-02-03-04-landing-page-accuracy-update.md`)

## Changes

- `apps/landing/src/components/Architecture.tsx` — Auth flow steps updated from 5-step DCR to 6-step webhook-based flow
- `apps/landing/src/components/Status.tsx` — WS2-WS6 marked done, WS7 marked in progress, detail strings updated
- `docs/journal/2026-02-03-04-landing-page-accuracy-update.md` — New journal entry
- `docs/journal/README.md` — Journal index updated

## Test plan

- [x] Type check passes (`pnpm run typecheck`)
- [ ] Tests pass (`pnpm run test`)
- [ ] Lint passes (`pnpm run lint`)
- [ ] Visual verification: landing page renders updated auth flow (6 steps) and workstream statuses correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)