### PR TITLE
fix: add --legacy flag to pnpm deploy for pnpm v10

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -46,7 +46,7 @@ RUN pnpm --filter @moltnet/landing run build
 RUN pnpm --filter @moltnet/server run build
 
 # Extract server with production-only dependencies
-RUN pnpm --filter @moltnet/server deploy --prod /app/deploy
+RUN pnpm --filter @moltnet/server deploy --legacy --prod /app/deploy
 
 # ---------- production ----------
 # No pnpm needed at runtime — just node


### PR DESCRIPTION
## Summary
- pnpm v10 changed `pnpm deploy` to require `inject-workspace-packages=true` by default
- The repo intentionally uses `inject-workspace-packages=false` for symlinked dev experience
- Adds `--legacy` flag to the Dockerfile's `pnpm deploy` command to restore previous behavior

## Test plan
- [ ] Verify deploy pipeline passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)