### PR TITLE
fix: eliminate voucher redemption race condition (#79)

### DIFF
--- a/docs/journal/2026-02-06-05-voucher-race-condition-fix.md
+++ b/docs/journal/2026-02-06-05-voucher-race-condition-fix.md
@@ -1,0 +1,53 @@
+---
+date: '2026-02-06T15:30:00Z'
+author: claude-opus-4-6
+session: unknown
+type: handoff
+importance: 0.7
+tags: [handoff, voucher, concurrency, race-condition, database]
+supersedes: null
+signature: pending
+---
+
+# Handoff: Voucher Redemption Race Condition Fix (#79)
+
+## What Was Done This Session
+
+- **Fixed `redeem()` TOCTOU race** in `voucher.repository.ts`: Replaced the SELECT-then-UPDATE pattern with a single atomic `UPDATE...WHERE...RETURNING`. Postgres row-level locking ensures only one concurrent caller can win the voucher. The old pattern did a SELECT to find a valid voucher, then a separate UPDATE to claim it — between those two statements, another caller could claim the same voucher.
+
+- **Added SERIALIZABLE isolation to `issue()`**: The `issue()` method uses a transaction to enforce the max-5 active vouchers invariant, but at the default READ COMMITTED isolation level, two concurrent `issue()` calls could both read 4 active vouchers and both insert, reaching 6. Added `{ isolationLevel: 'serializable' }` to the transaction config so Postgres detects the anomaly and aborts one of the concurrent transactions.
+
+- **Added serialization failure retry in `POST /vouch` route**: SERIALIZABLE transactions can throw Postgres error 40001 (serialization_failure) under contention. The route handler now retries up to 3 times, catching only 40001 errors. Non-serialization errors propagate immediately.
+
+- **Added unit tests for voucher repository**: 10 tests covering issue, redeem (verifies single UPDATE with no SELECT), findByCode, listActiveByIssuer, and serializable isolation level verification.
+
+- **Added integration tests for voucher repository**: 14 tests (gated on `DATABASE_URL`) covering CRUD, concurrent redemption (only one winner), concurrent issuance (max-5 holds), and expired voucher handling.
+
+- **Added serialization retry unit tests**: 3 tests in `vouch.test.ts` for the retry logic: succeeds on second attempt, rethrows after max retries, doesn't retry non-serialization errors.
+
+- **Added concurrent voucher e2e tests**: Two new test sections in `concurrency.e2e.test.ts`: concurrent `POST /vouch` issuance (max-5 invariant at HTTP level) and concurrent voucher redemption via the after-registration webhook (two agents racing for the same voucher code).
+
+## What's Not Done Yet
+
+- The `redeem()` fix doesn't need caller-side retry since the atomic UPDATE handles concurrency via row locking (no serialization errors possible).
+- The e2e tests require Docker infrastructure to run (`docker compose --profile dev up -d --wait`).
+
+## Current State
+
+- Branch: `claude/fix-voucher-race-condition-79`
+- Tests: 111 rest-api tests passing (+3), 29 database unit tests passing (+10), integration tests skipped without `DATABASE_URL`
+- Typecheck: clean
+- Lint: 0 errors (only pre-existing warnings)
+
+## Decisions Made
+
+- **Single atomic UPDATE over SELECT-then-UPDATE for `redeem()`**: The old pattern's re-check in the UPDATE WHERE clause was a partial mitigation, but the initial SELECT was wasted work and the pattern was fragile. The atomic UPDATE is strictly better.
+- **SERIALIZABLE over advisory locks for `issue()`**: Advisory locks would work but add operational complexity. SERIALIZABLE is the standard Postgres mechanism for this and works with Drizzle's transaction API.
+- **Retry in the route handler, not the repository**: The repository is a data access layer; retry policy is a business concern that belongs in the route. The repository throws the serialization error and lets the caller decide.
+- **3 max retries**: Serialization failures under normal load should resolve on the first retry. Three attempts is generous enough for bursts without masking systemic issues.
+
+## Where to Start Next
+
+1. Review the PR and merge
+2. The concurrent e2e tests can be validated by running with Docker infrastructure up
+3. Consider whether other SERIALIZABLE transactions in the codebase need similar retry wrappers

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -68,3 +68,4 @@ See [BUILDER_JOURNAL.md](../BUILDER_JOURNAL.md) for the full method specificatio
 | 2026-02-06 | handoff    | [GitHub Projects Agent Sync](2026-02-06-02-github-projects-agent-sync.md)                                         |
 | 2026-02-06 | handoff    | [Harden Docker Images](2026-02-06-03-harden-docker-images.md)                                                     |
 | 2026-02-06 | progress   | [Embedding Vector Leakage Fix](2026-02-06-04-embedding-vector-leakage-fix.md)                                     |
+| 2026-02-06 | handoff    | [Voucher Race Condition Fix](2026-02-06-05-voucher-race-condition-fix.md)                                         |

--- a/libs/database/__tests__/voucher.repository.integration.test.ts
+++ b/libs/database/__tests__/voucher.repository.integration.test.ts
@@ -1,0 +1,224 @@
+/**
+ * VoucherRepository Integration Tests
+ *
+ * Runs against a real PostgreSQL database.
+ * Requires DATABASE_URL environment variable pointing to a test database
+ * with the schema from infra/supabase/init.sql applied.
+ *
+ * Start the test database: docker compose --profile dev up -d app-db
+ * Run: DATABASE_URL=postgresql://moltnet:moltnet_secret@localhost:5433/moltnet pnpm --filter @moltnet/database test
+ */
+
+import { eq } from 'drizzle-orm';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { createDatabase, type Database } from '../src/db.js';
+import { createVoucherRepository } from '../src/repositories/voucher.repository.js';
+import { type AgentVoucher, agentVouchers } from '../src/schema.js';
+
+const DATABASE_URL = process.env.DATABASE_URL;
+
+describe.runIf(DATABASE_URL)('VoucherRepository (integration)', () => {
+  let db: Database;
+  let repo: ReturnType<typeof createVoucherRepository>;
+
+  const ISSUER_ID = '00000000-0000-4000-a000-000000000001';
+  const REDEEMER_A = '00000000-0000-4000-a000-000000000002';
+  const REDEEMER_B = '00000000-0000-4000-a000-000000000003';
+
+  beforeAll(() => {
+    // createDatabase returns DatabaseConnection; the db property is typed
+    // structurally the same — matches existing diary integration test pattern.
+    db = createDatabase(DATABASE_URL!) as unknown as Database;
+    repo = createVoucherRepository(db);
+  });
+
+  afterEach(async () => {
+    await db.delete(agentVouchers);
+  });
+
+  afterAll(async () => {
+    await db.delete(agentVouchers);
+  });
+
+  // ── Issue ──────────────────────────────────────────────────────────
+
+  describe('issue', () => {
+    it('issues a voucher and returns it', async () => {
+      const voucher = await repo.issue(ISSUER_ID);
+
+      expect(voucher).not.toBeNull();
+      expect(voucher!.issuerId).toBe(ISSUER_ID);
+      expect(voucher!.code).toHaveLength(64);
+      expect(voucher!.redeemedAt).toBeNull();
+      expect(voucher!.redeemedBy).toBeNull();
+      expect(voucher!.expiresAt).toBeInstanceOf(Date);
+      expect(voucher!.expiresAt.getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it('returns null when max active vouchers reached', async () => {
+      // Issue 5 vouchers (the max)
+      for (let i = 0; i < 5; i++) {
+        const v = await repo.issue(ISSUER_ID);
+        expect(v).not.toBeNull();
+      }
+
+      // 6th should fail
+      const sixth = await repo.issue(ISSUER_ID);
+      expect(sixth).toBeNull();
+    });
+
+    it('allows issuance after a voucher is redeemed', async () => {
+      // Issue 5 vouchers
+      const vouchers: AgentVoucher[] = [];
+      for (let i = 0; i < 5; i++) {
+        vouchers.push((await repo.issue(ISSUER_ID))!);
+      }
+
+      // Redeem one to free up a slot
+      await repo.redeem(vouchers[0]!.code, REDEEMER_A);
+
+      // Should now be able to issue again
+      const newVoucher = await repo.issue(ISSUER_ID);
+      expect(newVoucher).not.toBeNull();
+    });
+
+    it('enforces max-5 invariant under concurrent issuance', async () => {
+      // Issue 4 vouchers sequentially (leaving room for 1 more)
+      for (let i = 0; i < 4; i++) {
+        await repo.issue(ISSUER_ID);
+      }
+
+      // Fire 3 concurrent issue() calls — at most 1 should succeed
+      const results = await Promise.allSettled([
+        repo.issue(ISSUER_ID),
+        repo.issue(ISSUER_ID),
+        repo.issue(ISSUER_ID),
+      ]);
+
+      // Count successful issuances (non-null fulfilled values)
+      const succeeded = results.filter(
+        (r) => r.status === 'fulfilled' && r.value !== null,
+      );
+      // Serialization failures show up as rejected promises
+      const failed = results.filter((r) => r.status === 'rejected');
+
+      // At most 1 should have succeeded (the rest either return null or
+      // get a serialization error from SERIALIZABLE isolation)
+      expect(succeeded.length + failed.length).toBeGreaterThanOrEqual(2);
+      expect(succeeded.length).toBeLessThanOrEqual(1);
+    });
+  });
+
+  // ── Redeem ─────────────────────────────────────────────────────────
+
+  describe('redeem', () => {
+    it('redeems a valid voucher', async () => {
+      const voucher = await repo.issue(ISSUER_ID);
+
+      const redeemed = await repo.redeem(voucher!.code, REDEEMER_A);
+
+      expect(redeemed).not.toBeNull();
+      expect(redeemed!.redeemedBy).toBe(REDEEMER_A);
+      expect(redeemed!.redeemedAt).toBeInstanceOf(Date);
+      expect(redeemed!.code).toBe(voucher!.code);
+    });
+
+    it('returns null for already-redeemed voucher', async () => {
+      const voucher = await repo.issue(ISSUER_ID);
+      await repo.redeem(voucher!.code, REDEEMER_A);
+
+      const second = await repo.redeem(voucher!.code, REDEEMER_B);
+
+      expect(second).toBeNull();
+    });
+
+    it('returns null for expired voucher', async () => {
+      const voucher = await repo.issue(ISSUER_ID);
+
+      // Manually expire the voucher by setting expiresAt to the past
+      await db
+        .update(agentVouchers)
+        .set({ expiresAt: new Date(Date.now() - 1000) })
+        .where(eq(agentVouchers.code, voucher!.code));
+
+      const result = await repo.redeem(voucher!.code, REDEEMER_A);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null for nonexistent code', async () => {
+      const result = await repo.redeem('nonexistent-code', REDEEMER_A);
+
+      expect(result).toBeNull();
+    });
+
+    it('only one concurrent redeemer wins', async () => {
+      const voucher = await repo.issue(ISSUER_ID);
+
+      // Race two concurrent redemptions
+      const [resultA, resultB] = await Promise.all([
+        repo.redeem(voucher!.code, REDEEMER_A),
+        repo.redeem(voucher!.code, REDEEMER_B),
+      ]);
+
+      // Exactly one should succeed
+      const winners = [resultA, resultB].filter((r) => r !== null);
+      expect(winners).toHaveLength(1);
+
+      // The winner should have the correct redeemedBy
+      const winner = winners[0]!;
+      expect([REDEEMER_A, REDEEMER_B]).toContain(winner.redeemedBy);
+    });
+  });
+
+  // ── findByCode ─────────────────────────────────────────────────────
+
+  describe('findByCode', () => {
+    it('returns voucher by code', async () => {
+      const issued = await repo.issue(ISSUER_ID);
+
+      const found = await repo.findByCode(issued!.code);
+
+      expect(found).not.toBeNull();
+      expect(found!.id).toBe(issued!.id);
+    });
+
+    it('returns null for nonexistent code', async () => {
+      const found = await repo.findByCode('does-not-exist');
+
+      expect(found).toBeNull();
+    });
+  });
+
+  // ── listActiveByIssuer ─────────────────────────────────────────────
+
+  describe('listActiveByIssuer', () => {
+    it('returns unredeemed, unexpired vouchers', async () => {
+      await repo.issue(ISSUER_ID);
+      await repo.issue(ISSUER_ID);
+
+      const active = await repo.listActiveByIssuer(ISSUER_ID);
+
+      expect(active).toHaveLength(2);
+    });
+
+    it('excludes redeemed vouchers', async () => {
+      const v1 = await repo.issue(ISSUER_ID);
+      await repo.issue(ISSUER_ID);
+      await repo.redeem(v1!.code, REDEEMER_A);
+
+      const active = await repo.listActiveByIssuer(ISSUER_ID);
+
+      expect(active).toHaveLength(1);
+    });
+
+    it('returns empty array for unknown issuer', async () => {
+      const active = await repo.listActiveByIssuer(
+        '99999999-0000-4000-a000-000000000099',
+      );
+
+      expect(active).toHaveLength(0);
+    });
+  });
+});

--- a/libs/database/__tests__/voucher.repository.test.ts
+++ b/libs/database/__tests__/voucher.repository.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Database } from '../src/db.js';
+import { createVoucherRepository } from '../src/repositories/voucher.repository.js';
+import type { AgentVoucher } from '../src/schema.js';
+
+// Helper to create a mock Drizzle database
+function createMockDb() {
+  const mockChain = {
+    values: vi.fn().mockReturnThis(),
+    returning: vi.fn().mockResolvedValue([]),
+    onConflictDoUpdate: vi.fn().mockReturnThis(),
+    onConflictDoNothing: vi.fn().mockResolvedValue(undefined),
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    offset: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    set: vi.fn().mockReturnThis(),
+  };
+
+  const db = {
+    insert: vi.fn().mockReturnValue(mockChain),
+    select: vi.fn().mockReturnValue(mockChain),
+    update: vi.fn().mockReturnValue(mockChain),
+    delete: vi.fn().mockReturnValue(mockChain),
+    transaction: vi.fn().mockImplementation((fn) => fn(db)),
+    _chain: mockChain,
+  };
+
+  return db as unknown as Database & { _chain: typeof mockChain };
+}
+
+const ISSUER_ID = '550e8400-e29b-41d4-a716-446655440000';
+const REDEEMER_ID = '660e8400-e29b-41d4-a716-446655440001';
+
+const mockVoucher: AgentVoucher = {
+  id: '770e8400-e29b-41d4-a716-446655440002',
+  code: 'a'.repeat(64),
+  issuerId: ISSUER_ID,
+  redeemedBy: null,
+  expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+  redeemedAt: null,
+  createdAt: new Date(),
+};
+
+describe('createVoucherRepository', () => {
+  let db: ReturnType<typeof createMockDb>;
+  let repo: ReturnType<typeof createVoucherRepository>;
+
+  beforeEach(() => {
+    db = createMockDb();
+    repo = createVoucherRepository(db);
+  });
+
+  describe('issue', () => {
+    it('issues a voucher when under the limit', async () => {
+      // Active vouchers query returns empty (under limit)
+      db._chain.where.mockResolvedValueOnce([]);
+      db._chain.returning.mockResolvedValueOnce([mockVoucher]);
+
+      const result = await repo.issue(ISSUER_ID);
+
+      expect(db.transaction).toHaveBeenCalled();
+      expect(result).toEqual(mockVoucher);
+    });
+
+    it('returns null when at the voucher limit', async () => {
+      // Active vouchers query returns 5 items (at limit)
+      const fiveVouchers = Array.from({ length: 5 }, () => mockVoucher);
+      db._chain.where.mockResolvedValueOnce(fiveVouchers);
+
+      const result = await repo.issue(ISSUER_ID);
+
+      expect(result).toBeNull();
+    });
+
+    it('passes serializable isolation level to transaction', async () => {
+      db._chain.where.mockResolvedValueOnce([]);
+      db._chain.returning.mockResolvedValueOnce([mockVoucher]);
+
+      await repo.issue(ISSUER_ID);
+
+      expect(db.transaction).toHaveBeenCalledWith(expect.any(Function), {
+        isolationLevel: 'serializable',
+      });
+    });
+  });
+
+  describe('redeem', () => {
+    it('redeems a valid voucher', async () => {
+      const redeemed = {
+        ...mockVoucher,
+        redeemedBy: REDEEMER_ID,
+        redeemedAt: new Date(),
+      };
+      db._chain.returning.mockResolvedValueOnce([redeemed]);
+
+      const result = await repo.redeem(mockVoucher.code, REDEEMER_ID);
+
+      expect(db.update).toHaveBeenCalled();
+      expect(result).toEqual(redeemed);
+    });
+
+    it('returns null when voucher not found or already redeemed', async () => {
+      db._chain.returning.mockResolvedValueOnce([]);
+
+      const result = await repo.redeem('nonexistent-code', REDEEMER_ID);
+
+      expect(result).toBeNull();
+    });
+
+    it('uses a single UPDATE (no SELECT)', async () => {
+      db._chain.returning.mockResolvedValueOnce([]);
+
+      await repo.redeem(mockVoucher.code, REDEEMER_ID);
+
+      // Should call update directly, not select-then-update
+      expect(db.update).toHaveBeenCalled();
+      expect(db.select).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findByCode', () => {
+    it('returns voucher when found', async () => {
+      db._chain.limit.mockResolvedValueOnce([mockVoucher]);
+
+      const result = await repo.findByCode(mockVoucher.code);
+
+      expect(db.select).toHaveBeenCalled();
+      expect(result).toEqual(mockVoucher);
+    });
+
+    it('returns null when not found', async () => {
+      db._chain.limit.mockResolvedValueOnce([]);
+
+      const result = await repo.findByCode('nonexistent');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('listActiveByIssuer', () => {
+    it('returns active vouchers for the issuer', async () => {
+      db._chain.where.mockResolvedValueOnce([mockVoucher]);
+
+      const result = await repo.listActiveByIssuer(ISSUER_ID);
+
+      expect(db.select).toHaveBeenCalled();
+      expect(result).toEqual([mockVoucher]);
+    });
+
+    it('returns empty array when no active vouchers', async () => {
+      db._chain.where.mockResolvedValueOnce([]);
+
+      const result = await repo.listActiveByIssuer(ISSUER_ID);
+
+      expect(result).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Fixed `redeem()` TOCTOU race**: Replaced SELECT-then-UPDATE with a single atomic `UPDATE...WHERE...RETURNING`. Postgres row-level locking ensures only one concurrent caller wins the voucher.
- **Added SERIALIZABLE isolation to `issue()`**: Protects the max-5 active vouchers invariant under concurrent issuance. At READ COMMITTED, two concurrent callers could both read 4 and both insert, reaching 6.
- **Added serialization failure retry in `POST /vouch`**: SERIALIZABLE transactions can throw Postgres error 40001 under contention. The route handler retries up to 3 times, catching only serialization failures.

## Test Coverage

- **10 unit tests** for voucher repository (mock DB): issue, redeem, findByCode, listActiveByIssuer, serializable isolation verification, single-UPDATE-no-SELECT check
- **14 integration tests** (gated on `DATABASE_URL`): CRUD, concurrent redemption (only one winner), concurrent issuance (max-5 holds), expired voucher handling
- **3 route unit tests** for serialization retry: succeeds on retry, exhausts retries, doesn't retry non-serialization errors
- **2 e2e test sections** in concurrency suite: concurrent `POST /vouch` issuance (max-5 at HTTP level), concurrent voucher redemption via webhook (two agents racing for same code)

## Mission Integrity Checklist

1. **Does this move control away from the agent?** No. Voucher issuance and redemption remain agent-initiated. The fix ensures database-level atomicity — agents still control when to issue and redeem.
2. **Can this be verified without the server?** The atomicity guarantees come from Postgres (row-level locking, SERIALIZABLE isolation). These are standard database invariants verifiable via any Postgres client. The retry logic is unit-tested independently.
3. **Does this survive platform failure?** Yes. The atomic UPDATE pattern means a crash mid-operation leaves the voucher unclaimed (safe default). SERIALIZABLE aborts on conflict rather than corrupting state.
4. **Is this the simplest solution?** Yes. Single atomic UPDATE is strictly simpler than SELECT-then-UPDATE. SERIALIZABLE is the standard Postgres mechanism (vs advisory locks which add operational complexity). Retry in the route handler (not repository) keeps concerns separated.
5. **Is this documented?** Yes — journal entry `2026-02-06-05-voucher-race-condition-fix.md` covers all decisions, trade-offs, and next steps.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 111 rest-api tests (+3), 29 database unit tests (+10), all passing
- [x] `pnpm run lint` — 0 errors
- [ ] Integration tests: run with `DATABASE_URL` set against a real Postgres instance
- [ ] E2E tests: run with Docker infrastructure up (`docker compose --profile dev up -d --wait`)

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)