### PR TITLE
fix(rest-api): externalize @huggingface/transformers and onnxruntime-node from Vite SSR bundle

### DIFF
--- a/apps/rest-api/vite.config.ts
+++ b/apps/rest-api/vite.config.ts
@@ -20,6 +20,11 @@ export default defineConfig({
       'thread-stream',
       '@fastify/otel',
       /^@opentelemetry\//,
+      // onnxruntime-node uses native .node addons loaded via dynamic require().
+      // Rollup cannot resolve these at bundle time; must stay external so Node
+      // resolves them from node_modules at runtime.
+      '@huggingface/transformers',
+      'onnxruntime-node',
     ],
   },
   test: {

--- a/docs/journal/2026-02-21-02-onnxruntime-vite-bundle-fix.md
+++ b/docs/journal/2026-02-21-02-onnxruntime-vite-bundle-fix.md
@@ -1,0 +1,64 @@
+---
+date: '2026-02-21T15:00:00Z'
+author: claude-sonnet-4-6
+session: unknown
+type: problem
+importance: 0.7
+tags: [vite, ssr, bundling, onnxruntime, embeddings, production]
+supersedes: null
+signature: <pending>
+---
+
+# onnxruntime-node Native Addon Bundled by Vite SSR — Silent Embedding Failure
+
+## Context
+
+Production Fly.io logs showed the embedding service failing on every first call with a
+`commonjsRequire` error, then silently falling back to FTS. Semantic search was broken
+in production without any alert.
+
+## Substance
+
+**Root cause:** `@huggingface/transformers` was not listed in `ssr.external` in
+`apps/rest-api/vite.config.ts`. Vite/Rollup bundled the package into `dist/main.js`.
+The package loads `onnxruntime-node` internally, which uses a native `.node` addon via
+a dynamic `require()`. Rollup replaces dynamic `require()` calls with a
+`commonjsRequire()` stub that throws at runtime — it cannot resolve native addon paths
+at bundle time.
+
+The error message was clear and pointed directly at the fix:
+
+```
+Could not dynamically require "../bin/napi-v3/linux/x64/onnxruntime_binding.node".
+Please configure the dynamicRequireTargets or/and ignoreDynamicRequires option of
+@rollup/plugin-commonjs appropriately for this require call to work.
+```
+
+**Fix:** Added `@huggingface/transformers` and `onnxruntime-node` to `ssr.external` in
+`apps/rest-api/vite.config.ts`. The existing Dockerfile already handles native binary
+availability — `pnpm deploy --prod` copies the full production `node_modules` (including
+the pre-bundled CPU `.node` binary that ships inside the `onnxruntime-node` tarball)
+into the production image. No Dockerfile changes required.
+
+**Key invariant established:** Any package that loads native `.node` addons (ML runtimes,
+crypto libraries, image processors, compression libraries) **must** be in `ssr.external`.
+Rollup fundamentally cannot bundle native addons. A comment was added to `vite.config.ts`
+to document this for future maintainers.
+
+**Investigation note:** `--ignore-scripts` in the Dockerfile `pnpm install` step does
+_not_ cause the issue. The `onnxruntime-node` postinstall script only downloads CUDA
+binaries for Linux/x64 — the CPU binary ships pre-bundled in the package tarball and
+is available regardless of whether postinstall runs.
+
+**Prevention gap identified:** There is no post-build smoke test that imports `dist/main.js`
+and exercises the embedding path. Such a test would have caught this before deploy. A
+`node --input-type=module -e "import('./dist/main.js')"` check in CI after the build step
+would be a low-cost guard.
+
+## Continuity Notes
+
+- Issue: [#273](https://github.com/getlarge/themoltnet/issues/273)
+- Files changed: `apps/rest-api/vite.config.ts`
+- A post-build smoke test for native addon loading is a useful follow-up but not blocking
+- Any future package additions in the ML/crypto/native space need the same treatment —
+  check with `find node_modules/<pkg> -name "*.node"` before adding to the bundle

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -137,3 +137,4 @@ See [BUILDER_JOURNAL.md](../BUILDER_JOURNAL.md) for the full method specificatio
 | 2026-02-20 | handoff    | [Go CLI: Authenticated API Operations](2026-02-20-01-go-cli-api-operations.md)                                     |
 | 2026-02-20 | decision   | [Content-Signed Immutable Diary Entries](2026-02-20-01-content-signed-immutable-entries.md) |
 | 2026-02-20 | decision   | [MoltNet Memory Consolidation Skill](2026-02-20-02-moltnet-memory-consolidation-skill.md) |
+| 2026-02-21 | problem    | [onnxruntime-node Native Addon Bundled by Vite SSR — Silent Embedding Failure](2026-02-21-02-onnxruntime-vite-bundle-fix.md) |


### PR DESCRIPTION
## Summary

- `@huggingface/transformers` and `onnxruntime-node` were being bundled by Vite/Rollup into `dist/main.js`
- `onnxruntime-node` loads a native `.node` addon via dynamic `require()`, which Rollup replaces with a `commonjsRequire()` stub that throws at runtime
- Result: embedding service failed silently on every startup, falling back to FTS — semantic search was broken in production
- Fix: add both packages to `ssr.external` so Node resolves them from `node_modules` at runtime; no Dockerfile changes needed since `pnpm deploy --prod` already copies production `node_modules` including the pre-bundled CPU binary

## Test plan

- [x] Verify CI build succeeds (Vite SSR build with updated externals)
- [ ] Deploy to production and confirm log no longer shows `commonjsRequire` error on startup
- [ ] Confirm embedding log shows `"Embedding model loaded"` instead of `"Embedding generation failed, falling back to FTS"`

Closes #273

## Mission Integrity

- [x] Agent control: does NOT move control away from the agent
- [x] Offline verifiable: can be verified without the server
- [x] Platform survival: works if a managed service is replaced
- [x] Simplicity: simplest solution that solves the problem (one-line config change)
- [x] Documented: architectural decisions are recorded (vite.config.ts comment + journal entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)