### PR TITLE
fix(ci): make release workflow resilient to draft release failures

### DIFF
--- a/.claude/skills/legreffier/SKILL.md
+++ b/.claude/skills/legreffier/SKILL.md
@@ -59,12 +59,12 @@ This workflow involves **two independent signature systems**. Do not confuse the
 
 - **What**: Ed25519 signature over a structured payload, submitted to and stored by the MoltNet API
 - **Key**: The MoltNet identity key seed in `.moltnet/<AGENT_NAME>/moltnet.json` (base64-encoded 32-byte Ed25519 seed)
-- **Workflow**: `crypto_prepare_signature` → `moltnet sign --request-id` → API verifies and stores the base64 Ed25519 signature
+- **Workflow**: `crypto_prepare_signature` → `npx @themoltnet/cli sign --request-id` → API verifies and stores the base64 Ed25519 signature
 - **Verification**: `crypto_verify({ signature: "<base64-ed25519-signature>" })` — the server looks up the signing request by the actual signature bytes
 - **When**: Explicitly during the accountable commit workflow (step 7)
 - **Scope**: Proves which MoltNet agent authored the diary entry content
 
-**Critical distinction**: The `<signature>` tag in diary entries must contain the **base64 Ed25519 signature** (output of `moltnet sign --request-id` on stdout), NOT the request ID (UUID). The request ID is for tracking; the signature is for verification.
+**Critical distinction**: The `<signature>` tag in diary entries must contain the **base64 Ed25519 signature** (output of `npx @themoltnet/cli sign --request-id` on stdout), NOT the request ID (UUID). The request ID is for tracking; the signature is for verification.
 
 ## MCP tool reference
 
@@ -271,7 +271,7 @@ scope: <comma-separated scope tags>
    - Call `crypto_prepare_signature({ message: "<full payload above>" })` → returns `request_id`.
    - Run the one-shot CLI command — it fetches the signing request, signs `signing_input`, submits the signature, and **prints the base64 Ed25519 signature to stdout**:
      ```bash
-     SIGNATURE=$(moltnet sign --credentials <path> --request-id <request_id>)
+     SIGNATURE=$(npx @themoltnet/cli sign --credentials <path> --request-id <request_id>)
      ```
      The CLI prints `Signature submitted for request <id>` to **stderr** (confirmation) and the **base64 signature to stdout** (capture this). No piping, no `--nonce`, no `crypto_submit_signature` call needed.
    - **Store `$SIGNATURE`** — this is the base64 Ed25519 signature that goes in the `<signature>` tag of the diary entry. This is NOT the request ID. It is the value that `crypto_verify` uses to look up and validate the signing request.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,14 @@ on:
       - 'docs/**'
       - '.claude/**'
       - '**.md'
+  workflow_dispatch:
+    inputs:
+      republish:
+        description: >
+          Comma-separated packages to re-publish from existing draft releases.
+          Valid values: sdk, github-agent, legreffier, cli, api-client, skill
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -15,6 +23,7 @@ permissions:
 jobs:
   release-please:
     name: Release Please
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     outputs:
       sdk-release-created: ${{ steps.release.outputs['libs/sdk--release_created'] }}
@@ -39,10 +48,119 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+  # Unified resolution: merges release-please outputs with manual republish
+  # inputs so downstream jobs use a single set of outputs regardless of trigger.
+  resolve-publish:
+    name: Resolve packages to publish
+    needs: release-please
+    if: always() && !cancelled()
+    runs-on: ubuntu-latest
+    outputs:
+      sdk: ${{ steps.resolve.outputs.sdk }}
+      sdk-tag: ${{ steps.resolve.outputs.sdk-tag }}
+      github-agent: ${{ steps.resolve.outputs.github-agent }}
+      github-agent-tag: ${{ steps.resolve.outputs.github-agent-tag }}
+      cli: ${{ steps.resolve.outputs.cli }}
+      cli-tag: ${{ steps.resolve.outputs.cli-tag }}
+      api-client: ${{ steps.resolve.outputs.api-client }}
+      api-client-tag: ${{ steps.resolve.outputs.api-client-tag }}
+      api-client-version: ${{ steps.resolve.outputs.api-client-version }}
+      skill: ${{ steps.resolve.outputs.skill }}
+      skill-tag: ${{ steps.resolve.outputs.skill-tag }}
+      skill-version: ${{ steps.resolve.outputs.skill-version }}
+      legreffier: ${{ steps.resolve.outputs.legreffier }}
+      legreffier-tag: ${{ steps.resolve.outputs.legreffier-tag }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve publish targets
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RP_SDK_CREATED: ${{ needs.release-please.outputs.sdk-release-created }}
+          RP_SDK_TAG: ${{ needs.release-please.outputs.sdk-tag-name }}
+          RP_AGENT_CREATED: ${{ needs.release-please.outputs.github-agent-release-created }}
+          RP_AGENT_TAG: ${{ needs.release-please.outputs.github-agent-tag-name }}
+          RP_CLI_CREATED: ${{ needs.release-please.outputs.cli-release-created }}
+          RP_CLI_TAG: ${{ needs.release-please.outputs.cli-tag-name }}
+          RP_API_CREATED: ${{ needs.release-please.outputs.api-client-release-created }}
+          RP_API_TAG: ${{ needs.release-please.outputs.api-client-tag-name }}
+          RP_API_VERSION: ${{ needs.release-please.outputs.api-client-version }}
+          RP_SKILL_CREATED: ${{ needs.release-please.outputs.skill-release-created }}
+          RP_SKILL_TAG: ${{ needs.release-please.outputs.skill-tag-name }}
+          RP_SKILL_VERSION: ${{ needs.release-please.outputs.skill-version }}
+          RP_LEGREFFIER_CREATED: ${{ needs.release-please.outputs.legreffier-release-created }}
+          RP_LEGREFFIER_TAG: ${{ needs.release-please.outputs.legreffier-tag-name }}
+          REPUBLISH: ${{ github.event.inputs.republish || '' }}
+        run: |
+          find_draft_tag() {
+            local component="$1"
+            gh release list --repo "$GITHUB_REPOSITORY" --limit 20 --json tagName,isDraft \
+              --jq "[.[] | select(.isDraft == true and (.tagName | startswith(\"${component}-v\")))][0].tagName // empty"
+          }
+
+          version_from_tag() {
+            local tag="$1" component="$2"
+            echo "${tag}" | sed "s/^${component}-v//"
+          }
+
+          wants_republish() {
+            echo "$REPUBLISH" | tr ',' '\n' | tr -d ' ' | grep -qx "$1"
+          }
+
+          resolve() {
+            local name="$1" rp_created="$2" rp_tag="$3" component="$4"
+
+            if [ "$rp_created" = "true" ]; then
+              echo "${name}=true" >> "$GITHUB_OUTPUT"
+              echo "${name}-tag=${rp_tag}" >> "$GITHUB_OUTPUT"
+              echo "  ✓ ${name}: release-please → ${rp_tag}"
+              return
+            fi
+
+            if wants_republish "$name"; then
+              local tag
+              tag=$(find_draft_tag "$component")
+              if [ -n "$tag" ]; then
+                echo "${name}=true" >> "$GITHUB_OUTPUT"
+                echo "${name}-tag=${tag}" >> "$GITHUB_OUTPUT"
+                echo "  ✓ ${name}: republish draft → ${tag}"
+                return
+              fi
+              echo "  ✗ ${name}: requested but no draft release found for '${component}'"
+            fi
+
+            echo "${name}=false" >> "$GITHUB_OUTPUT"
+            echo "  - ${name}: skip"
+          }
+
+          echo "Resolving publish targets..."
+          resolve "sdk"          "$RP_SDK_CREATED"       "$RP_SDK_TAG"       "sdk"
+          resolve "github-agent" "$RP_AGENT_CREATED"     "$RP_AGENT_TAG"     "github-agent"
+          resolve "cli"          "$RP_CLI_CREATED"       "$RP_CLI_TAG"       "cli"
+          resolve "api-client"   "$RP_API_CREATED"       "$RP_API_TAG"       "moltnet-api-client"
+          resolve "skill"        "$RP_SKILL_CREATED"     "$RP_SKILL_TAG"     "openclaw-skill"
+          resolve "legreffier"   "$RP_LEGREFFIER_CREATED" "$RP_LEGREFFIER_TAG" "legreffier"
+
+          # Forward version outputs
+          if [ -n "$RP_API_VERSION" ]; then
+            echo "api-client-version=${RP_API_VERSION}" >> "$GITHUB_OUTPUT"
+          elif wants_republish "api-client"; then
+            tag=$(find_draft_tag "moltnet-api-client")
+            [ -n "$tag" ] && echo "api-client-version=$(version_from_tag "$tag" "moltnet-api-client")" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ -n "$RP_SKILL_VERSION" ]; then
+            echo "skill-version=${RP_SKILL_VERSION}" >> "$GITHUB_OUTPUT"
+          elif wants_republish "skill"; then
+            tag=$(find_draft_tag "openclaw-skill")
+            [ -n "$tag" ] && echo "skill-version=$(version_from_tag "$tag" "openclaw-skill")" >> "$GITHUB_OUTPUT"
+          fi
+
   publish-sdk:
     name: Publish SDK to npm
-    needs: [release-please, release-cli]
-    if: ${{ always() && needs.release-please.outputs.sdk-release-created == 'true' && !failure() && !cancelled() }}
+    needs: [resolve-publish, release-cli]
+    if: ${{ always() && needs.resolve-publish.outputs.sdk == 'true' && !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -78,14 +196,14 @@ jobs:
       - run: pnpm --filter @themoltnet/sdk publish --no-git-checks --access public --provenance
 
       - name: Publish SDK release
-        run: gh release edit "${{ needs.release-please.outputs.sdk-tag-name }}" --draft=false
+        run: gh release edit "${{ needs.resolve-publish.outputs.sdk-tag }}" --draft=false
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-github-agent:
     name: Publish GitHub Agent to npm
-    needs: [release-please, release-cli]
-    if: ${{ always() && needs.release-please.outputs.github-agent-release-created == 'true' && !failure() && !cancelled() }}
+    needs: [resolve-publish, release-cli]
+    if: ${{ always() && needs.resolve-publish.outputs.github-agent == 'true' && !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -114,14 +232,14 @@ jobs:
       - run: pnpm --filter @themoltnet/github-agent publish --no-git-checks --access public --provenance
 
       - name: Publish GitHub Agent release
-        run: gh release edit "${{ needs.release-please.outputs.github-agent-tag-name }}" --draft=false
+        run: gh release edit "${{ needs.resolve-publish.outputs.github-agent-tag }}" --draft=false
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release-api-client:
     name: Tag Go module for moltnet-api-client
-    needs: release-please
-    if: ${{ needs.release-please.outputs.api-client-release-created == 'true' }}
+    needs: resolve-publish
+    if: ${{ needs.resolve-publish.outputs.api-client == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -136,21 +254,25 @@ jobs:
         # release-please creates the component tag "moltnet-api-client-vX.Y.Z"; we push the
         # additional tag that the Go toolchain needs.
         run: |
-          TAG="cmd/moltnet-api-client/v${{ needs.release-please.outputs.api-client-version }}"
-          git tag "$TAG"
-          git push origin "$TAG"
+          TAG="cmd/moltnet-api-client/v${{ needs.resolve-publish.outputs.api-client-version }}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists, skipping"
+          else
+            git tag "$TAG"
+            git push origin "$TAG"
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish API client release
-        run: gh release edit "${{ needs.release-please.outputs.api-client-tag-name }}" --draft=false
+        run: gh release edit "${{ needs.resolve-publish.outputs.api-client-tag }}" --draft=false
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release-cli:
     name: Release CLI binaries
-    needs: [release-please, release-api-client]
-    if: ${{ always() && needs.release-please.outputs.cli-release-created == 'true' && !failure() && !cancelled() }}
+    needs: [resolve-publish, release-api-client]
+    if: ${{ always() && needs.resolve-publish.outputs.cli == 'true' && !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -166,13 +288,13 @@ jobs:
       - name: Extract semver from tag
         id: tag
         run: |
-          TAG="${{ needs.release-please.outputs.cli-tag-name }}"
+          TAG="${{ needs.resolve-publish.outputs.cli-tag }}"
           SEMVER="${TAG#cli-}"
           echo "semver=$SEMVER" >> "$GITHUB_OUTPUT"
-          # Resolve the api-client version: use the release-please output when
+          # Resolve the api-client version: use the resolved output when
           # the api-client is being released in the same run, otherwise fall
           # back to the version recorded in the manifest.
-          API_CLIENT_VER="${{ needs.release-please.outputs.api-client-version }}"
+          API_CLIENT_VER="${{ needs.resolve-publish.outputs.api-client-version }}"
           if [ -z "$API_CLIENT_VER" ]; then
             API_CLIENT_VER=$(jq -r '.["cmd/moltnet-api-client"]' .release-please-manifest.json)
           fi
@@ -199,7 +321,7 @@ jobs:
 
       - name: Upload binaries to GitHub Release
         run: |
-          gh release upload "${{ needs.release-please.outputs.cli-tag-name }}" \
+          gh release upload "${{ needs.resolve-publish.outputs.cli-tag }}" \
             cmd/moltnet/dist/*.tar.gz \
             cmd/moltnet/dist/*.zip \
             cmd/moltnet/dist/checksums.txt
@@ -207,14 +329,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish CLI release
-        run: gh release edit "${{ needs.release-please.outputs.cli-tag-name }}" --draft=false
+        run: gh release edit "${{ needs.resolve-publish.outputs.cli-tag }}" --draft=false
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-cli-npm:
     name: Publish CLI to npm
-    needs: [release-please, release-cli]
-    if: ${{ needs.release-please.outputs.cli-release-created == 'true' }}
+    needs: [resolve-publish, release-cli]
+    if: ${{ needs.resolve-publish.outputs.cli == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -235,8 +357,8 @@ jobs:
 
   release-skill:
     name: Release OpenClaw Skill
-    needs: release-please
-    if: ${{ needs.release-please.outputs.skill-release-created == 'true' }}
+    needs: resolve-publish
+    if: ${{ needs.resolve-publish.outputs.skill == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -248,20 +370,20 @@ jobs:
 
       - name: Upload tarball to GitHub Release
         run: |
-          gh release upload "${{ needs.release-please.outputs.skill-tag-name }}" \
-            "/tmp/moltnet-skill-v${{ needs.release-please.outputs.skill-version }}.tar.gz"
+          gh release upload "${{ needs.resolve-publish.outputs.skill-tag }}" \
+            "/tmp/moltnet-skill-v${{ needs.resolve-publish.outputs.skill-version }}.tar.gz"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish release
-        run: gh release edit "${{ needs.release-please.outputs.skill-tag-name }}" --draft=false
+        run: gh release edit "${{ needs.resolve-publish.outputs.skill-tag }}" --draft=false
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-skill-clawhub:
     name: Publish Skill to ClawHub
-    needs: [release-please, release-skill]
-    if: ${{ needs.release-please.outputs.skill-release-created == 'true' }}
+    needs: [resolve-publish, release-skill]
+    if: ${{ needs.resolve-publish.outputs.skill == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -282,12 +404,12 @@ jobs:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
         run: |
           packages/openclaw-skill/scripts/publish-clawhub.sh \
-            --changelog "Release ${{ needs.release-please.outputs.skill-tag-name }}"
+            --changelog "Release ${{ needs.resolve-publish.outputs.skill-tag }}"
 
   publish-legreffier:
     name: Publish LeGreffier to npm
-    needs: [release-please, release-cli]
-    if: ${{ always() && needs.release-please.outputs.legreffier-release-created == 'true' && !failure() && !cancelled() }}
+    needs: [resolve-publish, release-cli]
+    if: ${{ always() && needs.resolve-publish.outputs.legreffier == 'true' && !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -324,6 +446,6 @@ jobs:
       - run: pnpm --filter @themoltnet/legreffier publish --no-git-checks --access public --provenance
 
       - name: Publish LeGreffier release
-        run: gh release edit "${{ needs.release-please.outputs.legreffier-tag-name }}" --draft=false
+        run: gh release edit "${{ needs.resolve-publish.outputs.legreffier-tag }}" --draft=false
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/journal/2026-03-03-01-fix-release-workflow-draft-resilience.md
+++ b/docs/journal/2026-03-03-01-fix-release-workflow-draft-resilience.md
@@ -1,0 +1,60 @@
+---
+date: '2026-03-03T11:30:00Z'
+author: legreffier
+session: fix-release-workflow-draft-resilience
+type: handoff
+importance: 0.8
+tags: [ci, release-please, draft-releases, workflow-dispatch, npm-publish]
+supersedes: null
+signature: 9e647e5d-e3e9-4494-bb45-0e3f2b0d4ee8
+---
+
+# Fix: Release Workflow Resilient to Draft Release Failures
+
+## Context
+
+LeGreffier npm packages (v0.5.1, v0.6.0) were never published despite release-please PRs being merged successfully. The publish jobs were always skipped because `release_created` output was never set to `true`. This left multiple draft GitHub releases permanently orphaned.
+
+## Root Cause
+
+Known release-please bug ([googleapis/release-please-action#962](https://github.com/googleapis/release-please-action/issues/962)). With `"draft": true` in config, GitHub does not create git tags for draft releases ("lazy tag creation"). On subsequent pushes to main, release-please can't find the tag for the version in the manifest, says "No latest release found," and never sets `releases_created`. The publish job — gated on this output — is skipped. The draft stays draft forever.
+
+Other packages (sdk, cli) avoided this because they had prior non-draft releases as anchors. LeGreffier hit it because its first release after `draft: true` failed the publish path.
+
+## What Changed
+
+### 1. `release-please-config.json` — `force-tag-creation: true`
+
+The official fix from release-please docs. Creates git tags immediately even for draft releases, preventing the stuck state where release-please can't find previous releases.
+
+### 2. `.github/workflows/release.yml` — structural overhaul
+
+- **`workflow_dispatch` trigger**: accepts a `republish` input (comma-separated package names) for manual recovery of orphaned drafts
+- **`resolve-publish` job**: merges release-please outputs with manual republish inputs. For republish, it looks up the latest draft release by component prefix. All downstream jobs now depend on `resolve-publish` outputs instead of `release-please` directly
+- **`release-please` job**: now conditional on `github.event_name == 'push'` (skipped on manual dispatch)
+- **`release-api-client`**: idempotent tag push (checks if tag exists before creating)
+
+### 3. `.claude/skills/legreffier/SKILL.md` — CLI invocation fix
+
+Changed `moltnet sign` to `npx @themoltnet/cli sign` throughout the skill. The bare `moltnet` binary (installed via Homebrew) was blocked by macOS Gatekeeper.
+
+## Recovery Path
+
+For any orphaned draft releases:
+```bash
+gh workflow run release.yml -f republish=legreffier
+# or multiple: gh workflow run release.yml -f republish=sdk,legreffier,github-agent
+```
+
+## Mission Integrity Check
+
+- **Agent sovereignty**: No impact — this is CI infrastructure only
+- **Key management**: No changes to crypto paths
+- **Supply chain**: `force-tag-creation` is a documented release-please option, not a custom patch
+- **Centralization**: No new vendor dependencies added
+
+## What's Next
+
+- Monitor the next release-please cycle to confirm `force-tag-creation` resolves the stuck state
+- Clean up remaining orphaned draft releases (legreffier-v0.5.1) using the new workflow_dispatch
+- Consider whether `draft: true` is worth keeping at all — it adds complexity for minimal benefit (the window between release creation and artifact upload is seconds)

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -162,3 +162,4 @@ See [BUILDER_JOURNAL.md](../BUILDER_JOURNAL.md) for the full method specificatio
 | 2026-02-28 | handoff    | [Diary Search Negation Fix & E5-base-v2 Analysis](2026-02-28-01-diary-search-negation-fix.md)                                                      |
 | 2026-03-01 | handoff    | [Context Flywheel Roadmap Teaser and WS16 Setup](2026-03-01-01-context-flywheel-status-workstream.md)                                              |
 | 2026-03-02 | problem    | [Fix @themoltnet/legreffier Published with Unpublished Workspace Deps](2026-03-02-01-fix-legreffier-publish.md)                                    |
+| 2026-03-03 | handoff    | [Fix Release Workflow Resilient to Draft Release Failures](2026-03-03-01-fix-release-workflow-draft-resilience.md)                                  |

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
   "tag-separator": "-",
   "separate-pull-requests": false,
   "draft": true,
+  "force-tag-creation": true,
   "packages": {
     "libs/sdk": {
       "release-type": "node",


### PR DESCRIPTION
## Summary

- Added `force-tag-creation: true` to `release-please-config.json` — prevents the stuck state where release-please can't find draft releases as anchors ([googleapis/release-please-action#962](https://github.com/googleapis/release-please-action/issues/962))
- Restructured `release.yml` with `workflow_dispatch` trigger and `resolve-publish` job for recovering orphaned draft releases
- Updated legreffier skill to use `npx @themoltnet/cli` instead of bare `moltnet` command (macOS Gatekeeper issue)

## Problem

LeGreffier npm packages (v0.5.1, v0.6.0) were never published despite release-please PRs being merged. With `"draft": true`, GitHub doesn't create git tags for draft releases. Release-please can't find the previous version, never sets `releases_created`, and publish jobs are permanently skipped.

## Recovery

For any orphaned draft releases:
```bash
gh workflow run release.yml -f republish=legreffier
# or: gh workflow run release.yml -f republish=sdk,legreffier,github-agent
```

## Mission integrity

- No impact on agent sovereignty, key management, or crypto paths
- `force-tag-creation` is a documented release-please config option
- No new vendor dependencies

## Test plan

- [ ] Merge and verify next release-please cycle creates tags for draft releases
- [ ] Test `workflow_dispatch` with `republish=legreffier` to confirm draft lookup works
- [ ] Verify normal push-triggered flow still works (release-please → publish → undraft)

MoltNet-Diary: 9e647e5d-e3e9-4494-bb45-0e3f2b0d4ee8