### PR TITLE
Add offset parameter to list endpoints and fix total count semantics

### DIFF
--- a/apps/rest-api/__tests__/diary-entries.test.ts
+++ b/apps/rest-api/__tests__/diary-entries.test.ts
@@ -129,7 +129,10 @@ describe('Diary entry routes', () => {
   describe(`GET /diaries/${DIARY_ID}/entries`, () => {
     it('lists entries for authenticated user', async () => {
       const entries = [createMockEntry(), createMockEntry({ id: 'other-id' })];
-      mocks.diaryService.listEntries.mockResolvedValue(entries);
+      mocks.diaryService.listEntries.mockResolvedValue({
+        items: entries,
+        total: 5,
+      });
 
       const response = await app.inject({
         method: 'GET',
@@ -140,11 +143,14 @@ describe('Diary entry routes', () => {
       expect(response.statusCode).toBe(200);
       const body = response.json();
       expect(body.items).toHaveLength(2);
-      expect(body.total).toBe(2);
+      expect(body.total).toBe(5);
     });
 
     it('passes query parameters through', async () => {
-      mocks.diaryService.listEntries.mockResolvedValue([]);
+      mocks.diaryService.listEntries.mockResolvedValue({
+        items: [],
+        total: 0,
+      });
 
       await app.inject({
         method: 'GET',
@@ -158,7 +164,10 @@ describe('Diary entry routes', () => {
     });
 
     it('passes tags filter from query string', async () => {
-      mocks.diaryService.listEntries.mockResolvedValue([]);
+      mocks.diaryService.listEntries.mockResolvedValue({
+        items: [],
+        total: 0,
+      });
 
       await app.inject({
         method: 'GET',
@@ -175,7 +184,10 @@ describe('Diary entry routes', () => {
     });
 
     it('passes single tag from query string', async () => {
-      mocks.diaryService.listEntries.mockResolvedValue([]);
+      mocks.diaryService.listEntries.mockResolvedValue({
+        items: [],
+        total: 0,
+      });
 
       await app.inject({
         method: 'GET',
@@ -192,7 +204,10 @@ describe('Diary entry routes', () => {
     });
 
     it('passes excludeTags filter from query string', async () => {
-      mocks.diaryService.listEntries.mockResolvedValue([]);
+      mocks.diaryService.listEntries.mockResolvedValue({
+        items: [],
+        total: 0,
+      });
 
       await app.inject({
         method: 'GET',
@@ -241,7 +256,10 @@ describe('Diary entry routes', () => {
     });
 
     it('omits tags when not in query string', async () => {
-      mocks.diaryService.listEntries.mockResolvedValue([]);
+      mocks.diaryService.listEntries.mockResolvedValue({
+        items: [],
+        total: 0,
+      });
 
       await app.inject({
         method: 'GET',
@@ -579,7 +597,10 @@ describe('Diary entry routes', () => {
         createMockEntry({ embedding: [0.1, 0.2, 0.3] }),
         createMockEntry({ id: 'other-id', embedding: [0.4, 0.5, 0.6] }),
       ];
-      mocks.diaryService.listEntries.mockResolvedValue(entries);
+      mocks.diaryService.listEntries.mockResolvedValue({
+        items: entries,
+        total: 2,
+      });
 
       const response = await app.inject({
         method: 'GET',

--- a/apps/rest-api/__tests__/entry-relations.test.ts
+++ b/apps/rest-api/__tests__/entry-relations.test.ts
@@ -194,12 +194,13 @@ describe('Entry relation routes', () => {
   // ── GET /entries/:entryId/relations ─────────────────────────────────────
 
   describe('GET /entries/:entryId/relations', () => {
-    it('returns 200 with items/total/limit shape', async () => {
+    it('returns 200 with items/total/limit/offset shape', async () => {
       // Arrange
       mocks.permissionChecker.canViewEntry.mockResolvedValue(true);
-      mocks.entryRelationRepository.listByEntry.mockResolvedValue([
-        MOCK_RELATION,
-      ]);
+      mocks.entryRelationRepository.listByEntry.mockResolvedValue({
+        items: [MOCK_RELATION],
+        total: 3,
+      });
 
       // Act
       const response = await app.inject({
@@ -212,8 +213,9 @@ describe('Entry relation routes', () => {
       expect(response.statusCode).toBe(200);
       const body = response.json();
       expect(body).toHaveProperty('items');
-      expect(body).toHaveProperty('total', 1);
+      expect(body).toHaveProperty('total', 3);
       expect(body).toHaveProperty('limit');
+      expect(body).toHaveProperty('offset', 0);
       expect(body.items[0]).toHaveProperty('id', RELATION_ID);
     });
 
@@ -235,12 +237,15 @@ describe('Entry relation routes', () => {
     it('passes query params to listByEntry', async () => {
       // Arrange
       mocks.permissionChecker.canViewEntry.mockResolvedValue(true);
-      mocks.entryRelationRepository.listByEntry.mockResolvedValue([]);
+      mocks.entryRelationRepository.listByEntry.mockResolvedValue({
+        items: [],
+        total: 0,
+      });
 
       // Act
       const response = await app.inject({
         method: 'GET',
-        url: `/entries/${ENTRY_ID}/relations?relation=supersedes&status=accepted&direction=as_source&limit=10`,
+        url: `/entries/${ENTRY_ID}/relations?relation=supersedes&status=accepted&direction=as_source&limit=10&offset=5`,
         headers: authHeaders,
       });
 
@@ -253,10 +258,12 @@ describe('Entry relation routes', () => {
           status: 'accepted',
           direction: 'as_source',
           limit: 10,
+          offset: 5,
         },
       );
       const body = response.json();
       expect(body.limit).toBe(10);
+      expect(body.offset).toBe(5);
     });
   });
 

--- a/apps/rest-api/__tests__/packs.test.ts
+++ b/apps/rest-api/__tests__/packs.test.ts
@@ -78,10 +78,10 @@ describe('Pack routes', () => {
       return null;
     });
     mocks.contextPackRepository.findByCid.mockResolvedValue(MOCK_PACK);
-    mocks.contextPackRepository.listByDiary.mockResolvedValue([
-      MOCK_PACK,
-      MOCK_PACK_2,
-    ]);
+    mocks.contextPackRepository.listByDiary.mockResolvedValue({
+      items: [MOCK_PACK, MOCK_PACK_2],
+      total: 2,
+    });
     mocks.contextPackRepository.listEntriesExpanded.mockResolvedValue([
       {
         id: 'pack-entry-1',
@@ -131,18 +131,21 @@ describe('Pack routes', () => {
         [PACK_ID_2, true],
       ]),
     );
-    mocks.diaryEntryRepository.list.mockResolvedValue([
-      createMockEntry({
-        id: '11111111-1111-4111-8111-111111111111',
-        content: LONG_ENTRY_CONTENT,
-        contentHash: ENTRY_1_HASH,
-      }),
-      createMockEntry({
-        id: '22222222-2222-4222-8222-222222222222',
-        content: LONG_ENTRY_CONTENT,
-        contentHash: ENTRY_2_HASH,
-      }),
-    ]);
+    mocks.diaryEntryRepository.list.mockResolvedValue({
+      items: [
+        createMockEntry({
+          id: '11111111-1111-4111-8111-111111111111',
+          content: LONG_ENTRY_CONTENT,
+          contentHash: ENTRY_1_HASH,
+        }),
+        createMockEntry({
+          id: '22222222-2222-4222-8222-222222222222',
+          content: LONG_ENTRY_CONTENT,
+          contentHash: ENTRY_2_HASH,
+        }),
+      ],
+      total: 2,
+    });
     mocks.contextPackRepository.createPack.mockImplementation(
       async (input) => ({
         id: PACK_ID,
@@ -292,7 +295,7 @@ describe('Pack routes', () => {
     expect(response.statusCode).toBe(200);
     expect(response.json().items).toHaveLength(1);
     expect(response.json().items[0].id).toBe(PACK_ID);
-    expect(response.json().total).toBe(1);
+    expect(response.json().total).toBe(2);
   });
 
   it('returns 500 when batch pack authorization fails', async () => {
@@ -410,12 +413,15 @@ describe('Pack routes', () => {
       new Error('Keto unavailable'),
     );
     mocks.contextPackRepository.deleteMany = vi.fn().mockResolvedValue(1);
-    mocks.diaryEntryRepository.list.mockResolvedValue([
-      createMockEntry({
-        id: '11111111-1111-4111-8111-111111111111',
-        contentHash: ENTRY_1_HASH,
-      }),
-    ]);
+    mocks.diaryEntryRepository.list.mockResolvedValue({
+      items: [
+        createMockEntry({
+          id: '11111111-1111-4111-8111-111111111111',
+          contentHash: ENTRY_1_HASH,
+        }),
+      ],
+      total: 1,
+    });
 
     const response = await app.inject({
       method: 'POST',
@@ -440,12 +446,15 @@ describe('Pack routes', () => {
   });
 
   it('rejects custom pack selections that include entries outside the diary', async () => {
-    mocks.diaryEntryRepository.list.mockResolvedValue([
-      createMockEntry({
-        id: '11111111-1111-4111-8111-111111111111',
-        contentHash: ENTRY_1_HASH,
-      }),
-    ]);
+    mocks.diaryEntryRepository.list.mockResolvedValue({
+      items: [
+        createMockEntry({
+          id: '11111111-1111-4111-8111-111111111111',
+          contentHash: ENTRY_1_HASH,
+        }),
+      ],
+      total: 1,
+    });
 
     const response = await app.inject({
       method: 'POST',

--- a/apps/rest-api/__tests__/workflows/context-distill-workflows.test.ts
+++ b/apps/rest-api/__tests__/workflows/context-distill-workflows.test.ts
@@ -237,9 +237,10 @@ describe('context-distill compile workflow', () => {
   });
 
   it('persists proposed entry relations from consolidation clusters', async () => {
-    const list = vi
-      .fn()
-      .mockResolvedValue([createEntry('entry-1'), createEntry('entry-2')]);
+    const list = vi.fn().mockResolvedValue({
+      items: [createEntry('entry-1'), createEntry('entry-2')],
+      total: 2,
+    });
     fetchEmbeddings.mockResolvedValue([
       { id: 'entry-1', embedding: [1, 0, 0] },
       { id: 'entry-2', embedding: [0.99, 0.01, 0] },

--- a/apps/rest-api/public/openapi.json
+++ b/apps/rest-api/public/openapi.json
@@ -656,12 +656,16 @@
             "description": "Maximum number of items requested for this response.",
             "type": "number"
           },
+          "offset": {
+            "description": "Number of items skipped from the start.",
+            "type": "number"
+          },
           "total": {
-            "description": "Number of items returned in this response window. This API currently uses returned-count semantics for list totals.",
+            "description": "Total number of matching packs in the database.",
             "type": "number"
           }
         },
-        "required": ["items", "total", "limit"],
+        "required": ["items", "total", "limit", "offset"],
         "type": "object"
       },
       "ContextPackResponse": {
@@ -777,12 +781,16 @@
             "description": "Maximum number of items requested for this response.",
             "type": "number"
           },
+          "offset": {
+            "description": "Number of items skipped from the start.",
+            "type": "number"
+          },
           "total": {
-            "description": "Number of items returned in this response window. This API currently uses returned-count semantics for list totals.",
+            "description": "Total number of matching packs in the database.",
             "type": "number"
           }
         },
-        "required": ["items", "total", "limit"],
+        "required": ["items", "total", "limit", "offset"],
         "type": "object"
       },
       "CryptoIdentity": {
@@ -1250,12 +1258,15 @@
             "type": "array"
           },
           "limit": {
+            "description": "Maximum number of items requested.",
             "type": "number"
           },
           "offset": {
+            "description": "Number of items skipped from the start.",
             "type": "number"
           },
           "total": {
+            "description": "Total number of matching entries in the database.",
             "type": "number"
           }
         },
@@ -1584,12 +1595,16 @@
             "description": "Maximum number of items requested.",
             "type": "number"
           },
+          "offset": {
+            "description": "Number of items skipped from the start.",
+            "type": "number"
+          },
           "total": {
-            "description": "Number of items returned in this response window.",
+            "description": "Total number of matching relations in the database.",
             "type": "number"
           }
         },
-        "required": ["items", "total", "limit"],
+        "required": ["items", "total", "limit", "offset"],
         "type": "object"
       },
       "EntryType": {
@@ -3019,12 +3034,15 @@
             "type": "array"
           },
           "limit": {
+            "description": "Maximum number of items requested.",
             "type": "number"
           },
           "offset": {
+            "description": "Number of items skipped from the start.",
             "type": "number"
           },
           "total": {
+            "description": "Total number of matching signing requests in the database.",
             "type": "number"
           }
         },
@@ -5771,6 +5789,15 @@
           },
           {
             "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
             "name": "expand",
             "required": false,
             "schema": {
@@ -6457,6 +6484,15 @@
             "schema": {
               "maximum": 100,
               "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "minimum": 0,
               "type": "integer"
             }
           },

--- a/apps/rest-api/src/routes/diary-entries.ts
+++ b/apps/rest-api/src/routes/diary-entries.ts
@@ -288,7 +288,7 @@ export async function diaryEntryRoutes(fastify: FastifyInstance) {
         ? excludeTags.split(',').map((t) => t.trim())
         : undefined;
 
-      const entries = await fastify.diaryService.listEntries({
+      const { items, total } = await fastify.diaryService.listEntries({
         diaryId: diary.id,
         tags: tagsFilter,
         excludeTags: excludedTagsFilter,
@@ -298,8 +298,8 @@ export async function diaryEntryRoutes(fastify: FastifyInstance) {
       });
 
       return {
-        items: entries,
-        total: entries.length,
+        items,
+        total,
         limit: limit ?? 20,
         offset: offset ?? 0,
       };

--- a/apps/rest-api/src/routes/entry-relations.ts
+++ b/apps/rest-api/src/routes/entry-relations.ts
@@ -68,6 +68,7 @@ const ListRelationsQuerySchema = Type.Object({
     ]),
   ),
   limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 100 })),
+  offset: Type.Optional(Type.Integer({ minimum: 0 })),
 });
 
 const UpdateRelationStatusBodySchema = Type.Object({
@@ -185,7 +186,13 @@ export async function entryRelationRoutes(fastify: FastifyInstance) {
     async (request) => {
       const identityId = request.authContext!.identityId;
       const { entryId } = request.params;
-      const { relation, status, direction, limit = 50 } = request.query;
+      const {
+        relation,
+        status,
+        direction,
+        limit = 50,
+        offset = 0,
+      } = request.query;
 
       const allowed = await fastify.permissionChecker.canViewEntry(
         entryId,
@@ -195,17 +202,20 @@ export async function entryRelationRoutes(fastify: FastifyInstance) {
         throw createProblem('forbidden', 'Not authorized to view this entry');
       }
 
-      const items = await fastify.entryRelationRepository.listByEntry(entryId, {
-        relation,
-        status,
-        direction,
-        limit,
-      });
+      const { items, total } =
+        await fastify.entryRelationRepository.listByEntry(entryId, {
+          relation,
+          status,
+          direction,
+          limit,
+          offset,
+        });
 
       return {
         items: items.map(toRelationResponse),
-        total: items.length,
+        total,
         limit,
+        offset,
       };
     },
   );

--- a/apps/rest-api/src/routes/packs.ts
+++ b/apps/rest-api/src/routes/packs.ts
@@ -34,6 +34,7 @@ const PackQuerySchema = Type.Object({
 
 const PackListQuerySchema = Type.Object({
   limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 100 })),
+  offset: Type.Optional(Type.Integer({ minimum: 0 })),
   expand: Type.Optional(Type.Literal('entries')),
 });
 
@@ -100,14 +101,13 @@ function wantsExpandedEntries(expand?: 'entries'): boolean {
   return expand === 'entries';
 }
 
-function toListResponse<T>(items: T[], limit: number) {
-  return {
-    items,
-    // `total` follows the existing REST list convention in this API:
-    // it reports the number of items returned in this response window.
-    total: items.length,
-    limit,
-  };
+function toListResponse<T>(
+  items: T[],
+  total: number,
+  limit: number,
+  offset: number,
+) {
+  return { items, total, limit, offset };
 }
 
 function translateFindDiaryError(err: DiaryServiceError): never {
@@ -151,7 +151,7 @@ async function loadSelectedEntries(
   requestedEntries: SelectedEntry[],
 ): Promise<ResolvedSelection[]> {
   const selectedEntries = normalizeSelection(requestedEntries);
-  const rows = await fastify.diaryEntryRepository.list({
+  const { items: rows } = await fastify.diaryEntryRepository.list({
     diaryId,
     ids: selectedEntries.map((entry) => entry.entryId),
     limit: selectedEntries.length,
@@ -710,10 +710,13 @@ export async function packRoutes(fastify: FastifyInstance) {
         throw err;
       }
       const limit = request.query.limit ?? 20;
-      const packs = await fastify.contextPackRepository.listByDiary(
-        diary.id,
-        limit,
-      );
+      const offset = request.query.offset ?? 0;
+      const { items: packs, total } =
+        await fastify.contextPackRepository.listByDiary(
+          diary.id,
+          limit,
+          offset,
+        );
       let allowedPackIds: Map<string, boolean>;
       try {
         allowedPackIds = await fastify.permissionChecker.canReadPacks(
@@ -732,7 +735,7 @@ export async function packRoutes(fastify: FastifyInstance) {
       );
 
       if (!wantsExpandedEntries(request.query.expand)) {
-        return toListResponse(visiblePacks, limit);
+        return toListResponse(visiblePacks, total, limit, offset);
       }
 
       const entriesByPack =
@@ -740,12 +743,12 @@ export async function packRoutes(fastify: FastifyInstance) {
           visiblePacks.map((pack) => pack.id),
         );
 
-      const items = visiblePacks.map((pack) => ({
+      const expandedItems = visiblePacks.map((pack) => ({
         ...pack,
         entries: entriesByPack.get(pack.id) ?? [],
       }));
 
-      return toListResponse(items, limit);
+      return toListResponse(expandedItems, total, limit, offset);
     },
   );
 

--- a/apps/rest-api/src/schemas.ts
+++ b/apps/rest-api/src/schemas.ts
@@ -86,9 +86,15 @@ export const DiaryEntrySchema = Type.Object(
 export const DiaryListSchema = Type.Object(
   {
     items: Type.Array(Type.Ref(DiaryEntrySchema)),
-    total: Type.Number(),
-    limit: Type.Number(),
-    offset: Type.Number(),
+    total: Type.Number({
+      description: 'Total number of matching entries in the database.',
+    }),
+    limit: Type.Number({
+      description: 'Maximum number of items requested.',
+    }),
+    offset: Type.Number({
+      description: 'Number of items skipped from the start.',
+    }),
   },
   { $id: 'DiaryList' },
 );
@@ -365,9 +371,15 @@ export const SigningRequestSchema = Type.Object(
 export const SigningRequestListSchema = Type.Object(
   {
     items: Type.Array(Type.Ref(SigningRequestSchema)),
-    total: Type.Number(),
-    limit: Type.Number(),
-    offset: Type.Number(),
+    total: Type.Number({
+      description: 'Total number of matching signing requests in the database.',
+    }),
+    limit: Type.Number({
+      description: 'Maximum number of items requested.',
+    }),
+    offset: Type.Number({
+      description: 'Number of items skipped from the start.',
+    }),
   },
   { $id: 'SigningRequestList' },
 );
@@ -688,10 +700,13 @@ export const EntryRelationListSchema = Type.Object(
   {
     items: Type.Array(Type.Ref(EntryRelationSchema)),
     total: Type.Number({
-      description: 'Number of items returned in this response window.',
+      description: 'Total number of matching relations in the database.',
     }),
     limit: Type.Number({
       description: 'Maximum number of items requested.',
+    }),
+    offset: Type.Number({
+      description: 'Number of items skipped from the start.',
     }),
   },
   { $id: 'EntryRelationList' },
@@ -782,11 +797,13 @@ export const ContextPackListSchema = Type.Object(
   {
     items: Type.Array(Type.Ref(ContextPackSchema)),
     total: Type.Number({
-      description:
-        'Number of items returned in this response window. This API currently uses returned-count semantics for list totals.',
+      description: 'Total number of matching packs in the database.',
     }),
     limit: Type.Number({
       description: 'Maximum number of items requested for this response.',
+    }),
+    offset: Type.Number({
+      description: 'Number of items skipped from the start.',
     }),
   },
   { $id: 'ContextPackList' },
@@ -796,11 +813,13 @@ export const ContextPackResponseListSchema = Type.Object(
   {
     items: Type.Array(Type.Ref(ContextPackResponseSchema)),
     total: Type.Number({
-      description:
-        'Number of items returned in this response window. This API currently uses returned-count semantics for list totals.',
+      description: 'Total number of matching packs in the database.',
     }),
     limit: Type.Number({
       description: 'Maximum number of items requested for this response.',
+    }),
+    offset: Type.Number({
+      description: 'Number of items skipped from the start.',
     }),
   },
   { $id: 'ContextPackResponseList' },

--- a/apps/rest-api/src/workflows/context-distill-workflows.ts
+++ b/apps/rest-api/src/workflows/context-distill-workflows.ts
@@ -171,20 +171,22 @@ export function initContextDistillWorkflows(): void {
       if (entryIds && entryIds.length > 0) {
         // Always pass diaryId to scope entries to the caller's diary.
         // Prevents cross-diary entry access via user-supplied entryIds.
-        return diaryEntryRepository.list({
+        const { items } = await diaryEntryRepository.list({
           ids: entryIds,
           diaryId,
           excludeTags,
           limit: Math.min(entryIds.length, 500),
         });
+        return items;
       }
-      return diaryEntryRepository.list({
+      const { items } = await diaryEntryRepository.list({
         diaryId,
         tags,
         excludeTags,
         limit,
         excludeSuperseded: true,
       });
+      return items;
     },
     { name: 'context-distill.step.fetchEntries' },
   );

--- a/cmd/moltnet-api-client/oas_client_gen.go
+++ b/cmd/moltnet-api-client/oas_client_gen.go
@@ -4628,6 +4628,23 @@ func (c *Client) sendListDiaryPacks(ctx context.Context, params ListDiaryPacksPa
 		}
 	}
 	{
+		// Encode "offset" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "offset",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if val, ok := params.Offset.Get(); ok {
+				return e.EncodeValue(conv.IntToString(val))
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
 		// Encode "expand" parameter.
 		cfg := uri.QueryParameterEncodingConfig{
 			Name:    "expand",
@@ -5142,6 +5159,23 @@ func (c *Client) sendListEntryRelations(ctx context.Context, params ListEntryRel
 
 		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
 			if val, ok := params.Limit.Get(); ok {
+				return e.EncodeValue(conv.IntToString(val))
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "offset" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "offset",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if val, ok := params.Offset.Get(); ok {
 				return e.EncodeValue(conv.IntToString(val))
 			}
 			return nil

--- a/cmd/moltnet-api-client/oas_json_gen.go
+++ b/cmd/moltnet-api-client/oas_json_gen.go
@@ -3750,15 +3750,20 @@ func (s *ContextPackResponseList) encodeFields(e *jx.Encoder) {
 		e.Float64(s.Limit)
 	}
 	{
+		e.FieldStart("offset")
+		e.Float64(s.Offset)
+	}
+	{
 		e.FieldStart("total")
 		e.Float64(s.Total)
 	}
 }
 
-var jsonFieldsNameOfContextPackResponseList = [3]string{
+var jsonFieldsNameOfContextPackResponseList = [4]string{
 	0: "items",
 	1: "limit",
-	2: "total",
+	2: "offset",
+	3: "total",
 }
 
 // Decode decodes ContextPackResponseList from json.
@@ -3800,8 +3805,20 @@ func (s *ContextPackResponseList) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"limit\"")
 			}
-		case "total":
+		case "offset":
 			requiredBitSet[0] |= 1 << 2
+			if err := func() error {
+				v, err := d.Float64()
+				s.Offset = float64(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"offset\"")
+			}
+		case "total":
+			requiredBitSet[0] |= 1 << 3
 			if err := func() error {
 				v, err := d.Float64()
 				s.Total = float64(v)
@@ -3822,7 +3839,7 @@ func (s *ContextPackResponseList) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00000111,
+		0b00001111,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -9980,15 +9997,20 @@ func (s *EntryRelationList) encodeFields(e *jx.Encoder) {
 		e.Float64(s.Limit)
 	}
 	{
+		e.FieldStart("offset")
+		e.Float64(s.Offset)
+	}
+	{
 		e.FieldStart("total")
 		e.Float64(s.Total)
 	}
 }
 
-var jsonFieldsNameOfEntryRelationList = [3]string{
+var jsonFieldsNameOfEntryRelationList = [4]string{
 	0: "items",
 	1: "limit",
-	2: "total",
+	2: "offset",
+	3: "total",
 }
 
 // Decode decodes EntryRelationList from json.
@@ -10030,8 +10052,20 @@ func (s *EntryRelationList) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"limit\"")
 			}
-		case "total":
+		case "offset":
 			requiredBitSet[0] |= 1 << 2
+			if err := func() error {
+				v, err := d.Float64()
+				s.Offset = float64(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"offset\"")
+			}
+		case "total":
+			requiredBitSet[0] |= 1 << 3
 			if err := func() error {
 				v, err := d.Float64()
 				s.Total = float64(v)
@@ -10052,7 +10086,7 @@ func (s *EntryRelationList) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00000111,
+		0b00001111,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.

--- a/cmd/moltnet-api-client/oas_parameters_gen.go
+++ b/cmd/moltnet-api-client/oas_parameters_gen.go
@@ -2491,6 +2491,7 @@ func decodeListDiaryEntriesParams(args [1]string, argsEscaped bool, r *http.Requ
 // ListDiaryPacksParams is parameters of listDiaryPacks operation.
 type ListDiaryPacksParams struct {
 	Limit  OptInt                  `json:",omitempty,omitzero"`
+	Offset OptInt                  `json:",omitempty,omitzero"`
 	Expand OptListDiaryPacksExpand `json:",omitempty,omitzero"`
 	// UUID v4 identifier.
 	ID uuid.UUID
@@ -2504,6 +2505,15 @@ func unpackListDiaryPacksParams(packed middleware.Parameters) (params ListDiaryP
 		}
 		if v, ok := packed[key]; ok {
 			params.Limit = v.(OptInt)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "offset",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.Offset = v.(OptInt)
 		}
 	}
 	{
@@ -2589,6 +2599,72 @@ func decodeListDiaryPacksParams(args [1]string, argsEscaped bool, r *http.Reques
 	}(); err != nil {
 		return params, &ogenerrors.DecodeParamError{
 			Name: "limit",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: offset.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "offset",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				var paramsDotOffsetVal int
+				if err := func() error {
+					val, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToInt(val)
+					if err != nil {
+						return err
+					}
+
+					paramsDotOffsetVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.Offset.SetTo(paramsDotOffsetVal)
+				return nil
+			}); err != nil {
+				return err
+			}
+			if err := func() error {
+				if value, ok := params.Offset.Get(); ok {
+					if err := func() error {
+						if err := (validate.Int{
+							MinSet:        true,
+							Min:           0,
+							MaxSet:        false,
+							Max:           0,
+							MinExclusive:  false,
+							MaxExclusive:  false,
+							MultipleOfSet: false,
+							MultipleOf:    0,
+							Pattern:       nil,
+						}).Validate(int64(value)); err != nil {
+							return errors.Wrap(err, "int")
+						}
+						return nil
+					}(); err != nil {
+						return err
+					}
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "offset",
 			In:   "query",
 			Err:  err,
 		}
@@ -3071,6 +3147,7 @@ type ListEntryRelationsParams struct {
 	Status    OptRelationStatus              `json:",omitempty,omitzero"`
 	Direction OptListEntryRelationsDirection `json:",omitempty,omitzero"`
 	Limit     OptInt                         `json:",omitempty,omitzero"`
+	Offset    OptInt                         `json:",omitempty,omitzero"`
 	// UUID v4 identifier.
 	EntryId uuid.UUID
 }
@@ -3110,6 +3187,15 @@ func unpackListEntryRelationsParams(packed middleware.Parameters) (params ListEn
 		}
 		if v, ok := packed[key]; ok {
 			params.Limit = v.(OptInt)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "offset",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.Offset = v.(OptInt)
 		}
 	}
 	{
@@ -3354,6 +3440,72 @@ func decodeListEntryRelationsParams(args [1]string, argsEscaped bool, r *http.Re
 	}(); err != nil {
 		return params, &ogenerrors.DecodeParamError{
 			Name: "limit",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: offset.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "offset",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				var paramsDotOffsetVal int
+				if err := func() error {
+					val, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToInt(val)
+					if err != nil {
+						return err
+					}
+
+					paramsDotOffsetVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.Offset.SetTo(paramsDotOffsetVal)
+				return nil
+			}); err != nil {
+				return err
+			}
+			if err := func() error {
+				if value, ok := params.Offset.Get(); ok {
+					if err := func() error {
+						if err := (validate.Int{
+							MinSet:        true,
+							Min:           0,
+							MaxSet:        false,
+							Max:           0,
+							MinExclusive:  false,
+							MaxExclusive:  false,
+							MultipleOfSet: false,
+							MultipleOf:    0,
+							Pattern:       nil,
+						}).Validate(int64(value)); err != nil {
+							return errors.Wrap(err, "int")
+						}
+						return nil
+					}(); err != nil {
+						return err
+					}
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "offset",
 			In:   "query",
 			Err:  err,
 		}

--- a/cmd/moltnet-api-client/oas_schemas_gen.go
+++ b/cmd/moltnet-api-client/oas_schemas_gen.go
@@ -1568,8 +1568,9 @@ type ContextPackResponseList struct {
 	Items []ContextPackResponse `json:"items"`
 	// Maximum number of items requested for this response.
 	Limit float64 `json:"limit"`
-	// Number of items returned in this response window. This API currently uses returned-count semantics
-	// for list totals.
+	// Number of items skipped before the returned window.
+	Offset float64 `json:"offset"`
+	// Total number of matching packs in the database.
 	Total float64 `json:"total"`
 }
 
@@ -1581,6 +1582,11 @@ func (s *ContextPackResponseList) GetItems() []ContextPackResponse {
 // GetLimit returns the value of Limit.
 func (s *ContextPackResponseList) GetLimit() float64 {
 	return s.Limit
+}
+
+// GetOffset returns the value of Offset.
+func (s *ContextPackResponseList) GetOffset() float64 {
+	return s.Offset
 }
 
 // GetTotal returns the value of Total.
@@ -1596,6 +1602,11 @@ func (s *ContextPackResponseList) SetItems(val []ContextPackResponse) {
 // SetLimit sets the value of Limit.
 func (s *ContextPackResponseList) SetLimit(val float64) {
 	s.Limit = val
+}
+
+// SetOffset sets the value of Offset.
+func (s *ContextPackResponseList) SetOffset(val float64) {
+	s.Offset = val
 }
 
 // SetTotal sets the value of Total.
@@ -3836,7 +3847,9 @@ type EntryRelationList struct {
 	Items []EntryRelation `json:"items"`
 	// Maximum number of items requested.
 	Limit float64 `json:"limit"`
-	// Number of items returned in this response window.
+	// Number of items skipped before the returned window.
+	Offset float64 `json:"offset"`
+	// Total number of matching relations in the database.
 	Total float64 `json:"total"`
 }
 
@@ -3848,6 +3861,11 @@ func (s *EntryRelationList) GetItems() []EntryRelation {
 // GetLimit returns the value of Limit.
 func (s *EntryRelationList) GetLimit() float64 {
 	return s.Limit
+}
+
+// GetOffset returns the value of Offset.
+func (s *EntryRelationList) GetOffset() float64 {
+	return s.Offset
 }
 
 // GetTotal returns the value of Total.
@@ -3863,6 +3881,11 @@ func (s *EntryRelationList) SetItems(val []EntryRelation) {
 // SetLimit sets the value of Limit.
 func (s *EntryRelationList) SetLimit(val float64) {
 	s.Limit = val
+}
+
+// SetOffset sets the value of Offset.
+func (s *EntryRelationList) SetOffset(val float64) {
+	s.Offset = val
 }
 
 // SetTotal sets the value of Total.

--- a/libs/api-client/src/generated/types.gen.ts
+++ b/libs/api-client/src/generated/types.gen.ts
@@ -274,25 +274,33 @@ export type ContextPackResponse = {
 export type ContextPackList = {
   items: Array<ContextPack>;
   /**
-   * Number of items returned in this response window. This API currently uses returned-count semantics for list totals.
+   * Total number of matching packs in the database.
    */
   total: number;
   /**
    * Maximum number of items requested for this response.
    */
   limit: number;
+  /**
+   * Number of items skipped from the start.
+   */
+  offset: number;
 };
 
 export type ContextPackResponseList = {
   items: Array<ContextPackResponse>;
   /**
-   * Number of items returned in this response window. This API currently uses returned-count semantics for list totals.
+   * Total number of matching packs in the database.
    */
   total: number;
   /**
    * Maximum number of items requested for this response.
    */
   limit: number;
+  /**
+   * Number of items skipped from the start.
+   */
+  offset: number;
 };
 
 export type CompileStats = {
@@ -803,13 +811,17 @@ export type EntryRelation = {
 export type EntryRelationList = {
   items: Array<EntryRelation>;
   /**
-   * Number of items returned in this response window.
+   * Total number of matching relations in the database.
    */
   total: number;
   /**
    * Maximum number of items requested.
    */
   limit: number;
+  /**
+   * Number of items skipped from the start.
+   */
+  offset: number;
 };
 
 export type GetOAuth2TokenData = {
@@ -2269,6 +2281,7 @@ export type ListDiaryPacksData = {
   };
   query?: {
     limit?: number;
+    offset?: number;
     expand?: 'entries';
   };
   url: '/diaries/{id}/packs';
@@ -2378,6 +2391,7 @@ export type ListEntryRelationsData = {
     status?: RelationStatus;
     direction?: 'as_source' | 'as_target' | 'both';
     limit?: number;
+    offset?: number;
   };
   url: '/entries/{entryId}/relations';
 };

--- a/libs/database/__tests__/diary.repository.integration.test.ts
+++ b/libs/database/__tests__/diary.repository.integration.test.ts
@@ -221,9 +221,12 @@ describe('DiaryEntryRepository (integration)', () => {
       await createEntry({ content: 'Second entry.' });
       await createEntry({ content: 'Third entry.' });
 
-      const entries = await repo.list({ diaryId: DIARY_ID });
+      const { items: entries, total } = await repo.list({
+        diaryId: DIARY_ID,
+      });
 
       expect(entries.length).toBe(3);
+      expect(total).toBe(3);
       expect(entries[0].content).toBe('Third entry.');
       expect(entries[2].content).toBe('First entry.');
     });
@@ -242,11 +245,12 @@ describe('DiaryEntryRepository (integration)', () => {
         entryType: 'reflection',
       });
 
-      const episodicOnly = await repo.list({
+      const { items: episodicOnly, total } = await repo.list({
         diaryId: DIARY_ID,
         entryType: 'episodic',
       });
       expect(episodicOnly.length).toBe(1);
+      expect(total).toBe(1);
       expect(episodicOnly[0].content).toBe('Episodic entry.');
     });
 
@@ -255,10 +259,18 @@ describe('DiaryEntryRepository (integration)', () => {
         await createEntry({ content: `Entry ${i}` });
       }
 
-      const page1 = await repo.list({ diaryId: DIARY_ID, limit: 2 });
+      const { items: page1, total } = await repo.list({
+        diaryId: DIARY_ID,
+        limit: 2,
+      });
       expect(page1.length).toBe(2);
+      expect(total).toBe(5);
 
-      const page2 = await repo.list({ diaryId: DIARY_ID, limit: 2, offset: 2 });
+      const { items: page2 } = await repo.list({
+        diaryId: DIARY_ID,
+        limit: 2,
+        offset: 2,
+      });
       expect(page2.length).toBe(2);
       expect(page2[0].id).not.toBe(page1[0].id);
       expect(page2[0].id).not.toBe(page1[1].id);
@@ -484,7 +496,7 @@ describe('DiaryEntryRepository (integration)', () => {
         .set({ createdAt: pastDate })
         .where(eq(diaryEntries.id, old.id));
 
-      const results = await repo.list({
+      const { items: results } = await repo.list({
         diaryId: DIARY_ID,
         createdBefore: new Date('2025-06-01T00:00:00Z'),
       });
@@ -503,7 +515,7 @@ describe('DiaryEntryRepository (integration)', () => {
         .set({ createdAt: pastDate })
         .where(eq(diaryEntries.id, old.id));
 
-      const results = await repo.list({
+      const { items: results } = await repo.list({
         diaryId: DIARY_ID,
         createdAfter: new Date('2025-06-01T00:00:00Z'),
       });
@@ -530,7 +542,7 @@ describe('DiaryEntryRepository (integration)', () => {
         .set({ createdAt: new Date('2025-12-15T00:00:00Z') })
         .where(eq(diaryEntries.id, e3.id));
 
-      const results = await repo.list({
+      const { items: results } = await repo.list({
         diaryId: DIARY_ID,
         createdAfter: new Date('2025-03-01T00:00:00Z'),
         createdBefore: new Date('2025-10-01T00:00:00Z'),

--- a/libs/database/__tests__/repositories.test.ts
+++ b/libs/database/__tests__/repositories.test.ts
@@ -273,13 +273,33 @@ describe('createEntryRelationRepository', () => {
     expect(result).toBeNull();
   });
 
-  it('listByEntry returns matching relations', async () => {
-    db._chain.limit.mockResolvedValue([mockRelation]);
+  it('listByEntry returns matching relations with total count', async () => {
+    // Promise.all runs two queries: items (select → from → where → orderBy → limit → offset)
+    // and count (select → from → where). Both call db.select(), so we make select()
+    // return different chains for each call.
+    let selectCallCount = 0;
+    const itemsChain = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      offset: vi.fn().mockResolvedValue([mockRelation]),
+    };
+    const countChain = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([{ value: 5 }]),
+    };
+    db.select.mockImplementation(() => {
+      selectCallCount += 1;
+      return (selectCallCount === 1
+        ? itemsChain
+        : countChain) as unknown as ReturnType<typeof db.select>;
+    });
 
     const result = await repo.listByEntry(ENTRY_ID, { limit: 1 });
 
-    expect(db.select).toHaveBeenCalled();
-    expect(result).toEqual([mockRelation]);
+    expect(db.select).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ items: [mockRelation], total: 5 });
   });
 
   it('listByEntry with direction as_source only returns relations where entry is source', async () => {
@@ -289,16 +309,32 @@ describe('createEntryRelationRepository', () => {
       sourceId: '990e8400-e29b-41d4-a716-446655440004',
       targetId: ENTRY_ID,
     };
-    // as_source: only mockRelation (where sourceId === ENTRY_ID) should appear
-    db._chain.limit.mockResolvedValue([mockRelation]);
+    let selectCallCount = 0;
+    const itemsChain = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      offset: vi.fn().mockResolvedValue([mockRelation]),
+    };
+    const countChain = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([{ value: 1 }]),
+    };
+    db.select.mockImplementation(() => {
+      selectCallCount += 1;
+      return (selectCallCount === 1
+        ? itemsChain
+        : countChain) as unknown as ReturnType<typeof db.select>;
+    });
 
     const result = await repo.listByEntry(ENTRY_ID, {
       direction: 'as_source',
     });
 
-    expect(db.select).toHaveBeenCalled();
-    expect(result).toEqual([mockRelation]);
-    expect(result).not.toContainEqual(targetOnlyRelation);
+    expect(db.select).toHaveBeenCalledTimes(2);
+    expect(result.items).toEqual([mockRelation]);
+    expect(result.items).not.toContainEqual(targetOnlyRelation);
   });
 
   it('updateStatus returns the updated relation', async () => {

--- a/libs/database/src/repositories/context-pack.repository.ts
+++ b/libs/database/src/repositories/context-pack.repository.ts
@@ -7,6 +7,7 @@
 import {
   and,
   asc,
+  count,
   desc,
   eq,
   inArray,
@@ -342,16 +343,26 @@ export function createContextPackRepository(db: Database) {
     async listByDiary(
       diaryId: string,
       limit = 50,
-    ): Promise<ContextPackWithCreator[]> {
-      const rows = (await getExecutor(db)
-        .select(packSelection)
-        .from(contextPacks)
-        .leftJoin(agentKeys, eq(contextPacks.createdBy, agentKeys.identityId))
-        .where(eq(contextPacks.diaryId, diaryId))
-        .orderBy(desc(contextPacks.createdAt))
-        .limit(limit)) as PackRow[];
+      offset = 0,
+    ): Promise<{ items: ContextPackWithCreator[]; total: number }> {
+      const where = eq(contextPacks.diaryId, diaryId);
 
-      return rows.map(normalizePack);
+      const [rows, [{ value: total }]] = await Promise.all([
+        getExecutor(db)
+          .select(packSelection)
+          .from(contextPacks)
+          .leftJoin(agentKeys, eq(contextPacks.createdBy, agentKeys.identityId))
+          .where(where)
+          .orderBy(desc(contextPacks.createdAt))
+          .limit(limit)
+          .offset(offset) as Promise<PackRow[]>,
+        getExecutor(db)
+          .select({ value: count() })
+          .from(contextPacks)
+          .where(where),
+      ]);
+
+      return { items: rows.map(normalizePack), total };
     },
   };
 }

--- a/libs/database/src/repositories/diary-entry.repository.ts
+++ b/libs/database/src/repositories/diary-entry.repository.ts
@@ -274,7 +274,9 @@ export function createDiaryEntryRepository(db: Database) {
     /**
      * List entries for a diary
      */
-    async list(options: DiaryListOptions): Promise<DiaryEntry[]> {
+    async list(
+      options: DiaryListOptions,
+    ): Promise<{ items: DiaryEntry[]; total: number }> {
       const {
         diaryId,
         diaryIds,
@@ -316,14 +318,22 @@ export function createDiaryEntryRepository(db: Database) {
         }),
       );
 
-      const rows = await db
-        .select(publicColumns)
-        .from(diaryEntries)
-        .where(and(...conditions))
-        .orderBy(desc(diaryEntries.createdAt))
-        .limit(limit)
-        .offset(offset);
-      return rows.map((row) => ({ ...row, embedding: null }));
+      const where = and(...conditions);
+
+      const [rows, [{ value: total }]] = await Promise.all([
+        db
+          .select(publicColumns)
+          .from(diaryEntries)
+          .where(where)
+          .orderBy(desc(diaryEntries.createdAt))
+          .limit(limit)
+          .offset(offset),
+        db.select({ value: count() }).from(diaryEntries).where(where),
+      ]);
+      return {
+        items: rows.map((row) => ({ ...row, embedding: null })),
+        total,
+      };
     },
 
     /**
@@ -526,7 +536,7 @@ export function createDiaryEntryRepository(db: Database) {
       }
 
       // No query/embedding → fall back to list (pass all filters)
-      return this.list({
+      const { items } = await this.list({
         diaryId,
         diaryIds,
         tags,
@@ -538,6 +548,7 @@ export function createDiaryEntryRepository(db: Database) {
         createdBefore,
         createdAfter,
       });
+      return items;
     },
 
     /**

--- a/libs/database/src/repositories/entry-relation.repository.ts
+++ b/libs/database/src/repositories/entry-relation.repository.ts
@@ -4,7 +4,7 @@
  * CRUD and traversal primitives for associative entry graph edges.
  */
 
-import { and, desc, eq, inArray, or } from 'drizzle-orm';
+import { and, count, desc, eq, inArray, or } from 'drizzle-orm';
 
 import type { Database } from '../db.js';
 import {
@@ -138,13 +138,15 @@ export function createEntryRelationRepository(db: Database) {
         relation?: EntryRelation['relation'];
         status?: EntryRelation['status'];
         limit?: number;
+        offset?: number;
         direction?: 'as_source' | 'as_target' | 'both';
       },
-    ): Promise<EntryRelation[]> {
+    ): Promise<{ items: EntryRelation[]; total: number }> {
       const {
         relation,
         status,
         limit = 100,
+        offset = 0,
         direction = 'both',
       } = options ?? {};
 
@@ -168,12 +170,23 @@ export function createEntryRelationRepository(db: Database) {
         conditions.push(eq(entryRelations.status, status));
       }
 
-      return getExecutor(db)
-        .select()
-        .from(entryRelations)
-        .where(and(...conditions))
-        .orderBy(desc(entryRelations.createdAt))
-        .limit(limit);
+      const where = and(...conditions);
+
+      const [items, [{ value: total }]] = await Promise.all([
+        getExecutor(db)
+          .select()
+          .from(entryRelations)
+          .where(where)
+          .orderBy(desc(entryRelations.createdAt))
+          .limit(limit)
+          .offset(offset),
+        getExecutor(db)
+          .select({ value: count() })
+          .from(entryRelations)
+          .where(where),
+      ]);
+
+      return { items, total };
     },
 
     async updateStatus(

--- a/libs/diary-service/src/diary-service.ts
+++ b/libs/diary-service/src/diary-service.ts
@@ -99,7 +99,9 @@ export interface DiaryService {
     agentId: string,
     opts?: { diaryId?: string },
   ): Promise<DiaryEntry>;
-  listEntries(input: ListInput): Promise<DiaryEntry[]>;
+  listEntries(
+    input: ListInput,
+  ): Promise<{ items: DiaryEntry[]; total: number }>;
   listTags(input: ListTagsInput, agentId: string): Promise<TagCount[]>;
   searchEntries(input: SearchInput, agentId: string): Promise<DiaryEntry[]>;
   searchOwned(input: SearchInput, agentId: string): Promise<DiaryEntry[]>;
@@ -556,7 +558,9 @@ export function createDiaryService(deps: DiaryServiceDeps): DiaryService {
       return entry;
     },
 
-    listEntries(input: ListInput): Promise<DiaryEntry[]> {
+    listEntries(
+      input: ListInput,
+    ): Promise<{ items: DiaryEntry[]; total: number }> {
       return diaryEntryRepository.list({
         diaryId: input.diaryId,
         tags: input.tags,

--- a/libs/models/src/schemas.ts
+++ b/libs/models/src/schemas.ts
@@ -164,9 +164,15 @@ export const PaginatedResponseSchema = <
 ) =>
   Type.Object({
     items: Type.Array(itemSchema),
-    total: Type.Number(),
-    limit: Type.Number(),
-    offset: Type.Number(),
+    total: Type.Number({
+      description: 'Total number of matching items in the database.',
+    }),
+    limit: Type.Number({
+      description: 'Maximum number of items requested.',
+    }),
+    offset: Type.Number({
+      description: 'Number of items skipped from the start.',
+    }),
   });
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Add `offset` query parameter support to `listDiaryPacks` and `listEntryRelations` endpoints
- Fix `total` field semantics: now returns total matching items in database instead of items in current response
- Update repository methods to return paginated responses with `{ items, total }` structure
- Update OpenAPI schema and generated client code to reflect these changes

## Changes

**API Changes:**
- Added `offset` parameter to `ListDiaryPacksParams` and `ListEntryRelationsParams` with validation (minimum: 0)
- Updated response schemas (`ContextPackList`, `ContextPackResponseList`, `EntryRelationList`) to include `offset` field
- Changed `total` field description from "items returned in this response window" to "total number of matching items in the database"
- Updated OpenAPI schema (`openapi.json`) with new field descriptions

**Repository Layer:**
- `contextPackRepository.listByDiary()`: Now accepts `offset` parameter and returns `{ items, total }` with database count
- `diaryEntryRepository.list()`: Returns `{ items, total }` with database count via parallel queries
- `entryRelationRepository.listByEntry()`: Accepts `offset` parameter and returns `{ items, total }` with database count

**Route Handlers:**
- `packRoutes`: Updated to pass `offset` from query params and use new paginated response structure
- `entryRelationRoutes`: Updated to pass `offset` and return correct `total` count
- `diaryEntryRoutes`: Updated to destructure `items` and `total` from service response

**Generated Code:**
- Updated OpenAPI client parameter encoding/decoding for `offset` in both endpoints
- Updated schema generation for list response types with new `offset` field
- Updated TypeScript type definitions to include `offset` field

**Tests:**
- Updated mock returns in `packs.test.ts`, `diary-entries.test.ts`, `entry-relations.test.ts` to use new `{ items, total }` structure
- Updated repository tests to verify both items and total count are returned correctly
- Fixed test expectations for `total` to reflect database count rather than response item count

## Test plan

- [x] Tests pass (`npm test`) - Updated all test mocks and assertions to match new paginated response structure
- [x] Type check passes (`npm run typecheck`) - Updated TypeScript types for repository methods and API responses
- [x] Lint passes (`npm run lint`)

https://claude.ai/code/session_014EkERnk6gFR38Ho8dk1tJb