### PR TITLE
fix: moltnet start target arg forwarding

### DIFF
--- a/cmd/moltnet/cobra_start.go
+++ b/cmd/moltnet/cobra_start.go
@@ -11,7 +11,7 @@ import "github.com/spf13/cobra"
 // the Use line and examples below.
 func newStartCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "start <target>",
+		Use:   "start <target> [-- <target-args>...]",
 		Short: "Start an agent session with resolved credentials",
 		Long: `Start an agent session with the resolved agent's environment.
 Sources the agent's .moltnet/<agent>/env file and exec's into the target binary.
@@ -19,13 +19,14 @@ Common targets: claude, codex.`,
 		Example: `  moltnet start claude
   moltnet start codex
   moltnet start claude --agent legreffier
+  moltnet start codex -- --model gpt-5.4 --profile dev
   moltnet start claude --dry-run`,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			dir, _ := cmd.Flags().GetString("dir")
 			agent, _ := cmd.Flags().GetString("agent")
 			dryRun, _ := cmd.Flags().GetBool("dry-run")
-			return runStartCmd(cmd, dir, agent, args[0], dryRun)
+			return runStartCmd(cmd, dir, agent, args[0], args[1:], dryRun)
 		},
 	}
 	cmd.Flags().String("agent", "", "Agent name (overrides default)")

--- a/cmd/moltnet/env_test.go
+++ b/cmd/moltnet/env_test.go
@@ -300,6 +300,44 @@ func TestStartDryRun(t *testing.T) {
 	}
 }
 
+func TestStartDryRunForwardsTargetArgs(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	moltnetDir := filepath.Join(dir, ".moltnet")
+	agentDir := filepath.Join(moltnetDir, "test-agent")
+	os.MkdirAll(agentDir, 0o755)
+	os.WriteFile(filepath.Join(agentDir, "moltnet.json"), []byte("{}"), 0o644)
+	os.WriteFile(filepath.Join(agentDir, "env"), []byte("MY_VAR='hello'\n"), 0o644)
+
+	root := NewRootCmd("test", "")
+	stdout, _, err := executeCommand(
+		root,
+		"start",
+		"echo",
+		"--agent",
+		"test-agent",
+		"--dir",
+		dir,
+		"--dry-run",
+		"--",
+		"--model",
+		"gpt-5.4",
+		"--profile",
+		"dev",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stdout, "Forwarded target arguments:") {
+		t.Fatalf("expected forwarded argument section, got: %s", stdout)
+	}
+	for _, want := range []string{`"--model"`, `"gpt-5.4"`, `"--profile"`, `"dev"`} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("expected dry-run output to include %s, got: %s", want, stdout)
+		}
+	}
+}
+
 func TestStartMissingAgent(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/cmd/moltnet/start.go
+++ b/cmd/moltnet/start.go
@@ -6,13 +6,14 @@ import (
 	osExec "os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"syscall"
 
 	"github.com/spf13/cobra"
 )
 
-func runStartCmd(cmd *cobra.Command, dir, agentFlag, target string, dryRun bool) error {
+func runStartCmd(cmd *cobra.Command, dir, agentFlag, target string, targetArgs []string, dryRun bool) error {
 	moltnetDir, err := resolveMoltnetDir(dir)
 	if err != nil {
 		return err
@@ -65,6 +66,13 @@ func runStartCmd(cmd *cobra.Command, dir, agentFlag, target string, dryRun bool)
 	if dryRun {
 		fmt.Fprintf(cmd.OutOrStdout(), "Agent: %s\n", agentName)
 		fmt.Fprintf(cmd.OutOrStdout(), "Target: %s (%s)\n\n", target, targetPath)
+		if len(targetArgs) > 0 {
+			fmt.Fprintln(cmd.OutOrStdout(), "Forwarded target arguments:")
+			for _, arg := range targetArgs {
+				fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", strconv.Quote(arg))
+			}
+			fmt.Fprintln(cmd.OutOrStdout())
+		}
 		fmt.Fprintln(cmd.OutOrStdout(), "Environment variables from env file:")
 		keys := make([]string, 0, len(vars))
 		for k := range vars {
@@ -82,7 +90,8 @@ func runStartCmd(cmd *cobra.Command, dir, agentFlag, target string, dryRun bool)
 	}
 
 	// exec replaces the current process
-	return syscall.Exec(targetPath, []string{target}, env)
+	argv := append([]string{target}, targetArgs...)
+	return syscall.Exec(targetPath, argv, env)
 }
 
 // isSecretKey returns true for env var names that likely contain secrets.


### PR DESCRIPTION
## Summary

Fix `moltnet start` so it forwards trailing target arguments to Claude or Codex instead of dropping them.

## Root Cause

The launcher lost target arguments in two places:

1. the Cobra command required exactly one positional argument, so extra target flags were rejected instead of being treated as child-process args
2. the final `syscall.Exec` call only passed `[]string{target}`, so even parsed arguments would have been discarded

## Changes

- allow `moltnet start <target> [-- <target-args>...]`
- pass trailing args through to `runStartCmd`
- forward the full argv to `syscall.Exec`
- show forwarded args in `--dry-run` output for easier debugging
- add a regression test covering forwarded target args

## Validation

- `GOCACHE=/tmp/moltnet-go-cache go test ./... -run 'TestStart'`

## Notes

The full `go test ./...` suite was not runnable in the Codex sandbox because unrelated tests use `httptest` listeners and local port binding is blocked there.