### PR TITLE
fix(tools): correct root path resolution after scripts/ move

### DIFF
--- a/tools/src/check-pack.ts
+++ b/tools/src/check-pack.ts
@@ -20,7 +20,7 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { parseArgs } from 'node:util';
 
-const root = new URL('..', import.meta.url).pathname.replace(/\/$/, '');
+const root = new URL('../..', import.meta.url).pathname.replace(/\/$/, '');
 
 const { values } = parseArgs({
   options: {

--- a/tools/src/check-sdk-types-isolation.ts
+++ b/tools/src/check-sdk-types-isolation.ts
@@ -8,7 +8,7 @@
  * imports from the built SDK dist, then runs tsc --noEmit to check for errors.
  *
  * Usage:
- *   tsx scripts/check-sdk-types-isolation.ts
+ *   tsx tools/src/check-sdk-types-isolation.ts
  */
 
 import { execSync } from 'node:child_process';
@@ -16,7 +16,7 @@ import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-const root = new URL('..', import.meta.url).pathname.replace(/\/$/, '');
+const root = new URL('../..', import.meta.url).pathname.replace(/\/$/, '');
 const sdkDist = join(root, 'libs/sdk/dist');
 const sdkTypesEntry = join(sdkDist, 'index.d.ts');
 


### PR DESCRIPTION
## Summary
- Fix `check-sdk-types-isolation` and `check-pack` scripts that resolved the repo root incorrectly after the `scripts/` → `tools/src/` migration (`new URL('..', ...)` → `new URL('../..', ...)`)
- This broke the SDK publish CI step: https://github.com/getlarge/themoltnet/actions/runs/23834951925/job/69477120781#step:11:17

## Test plan
- [ ] CI `check:types-isolation` step passes
- [ ] CI `check:pack` step passes
- [ ] Manual SDK publish after merge (release-please didn't catch this package)