### PR TITLE
fix(release): include api-client codegen commits in release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -28,6 +28,20 @@
     },
     "libs/moltnet-api-client": {
       "bump-minor-pre-major": true,
+      "changelog-sections": [
+        {
+          "section": "Features",
+          "type": "feat"
+        },
+        {
+          "section": "Bug Fixes",
+          "type": "fix"
+        },
+        {
+          "section": "Codegen",
+          "type": "chore"
+        }
+      ],
       "component": "moltnet-api-client",
       "release-type": "go"
     },


### PR DESCRIPTION
## Why
Release Please skipped `libs/moltnet-api-client` in PR #606 even though codegen changed, because those commits are `chore(codegen)` and treated as non user-facing.

## What
- For `libs/moltnet-api-client`, configure release-please changelog sections to include:
  - `feat`
  - `fix`
  - `chore` (as `Codegen`)

## Expected result
The next release-please run should include `moltnet-api-client` when only codegen commits landed in that path, avoiding missed Go module tags/releases.

Refs:
- Failed run: https://github.com/getlarge/themoltnet/actions/runs/23900186185
- Missing component in release PR: https://github.com/getlarge/themoltnet/pull/606
