### PR TITLE
fix(release): auto-sync CLI go.mod to released api-client/dspy versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -361,6 +361,24 @@ jobs:
           owner: getlarge
           repositories: homebrew-moltnet
 
+      - name: Sync CLI Go dependencies to released module versions
+        working-directory: apps/moltnet-cli
+        env:
+          API_CLIENT_VERSION: ${{ needs.resolve-publish.outputs.api-client-version }}
+          DSPY_ADAPTERS_VERSION: ${{ needs.resolve-publish.outputs.dspy-adapters-version }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "${API_CLIENT_VERSION}" ]; then
+            go mod edit -require=github.com/getlarge/themoltnet/libs/moltnet-api-client@v${API_CLIENT_VERSION}
+          fi
+
+          if [ -n "${DSPY_ADAPTERS_VERSION}" ]; then
+            go mod edit -require=github.com/getlarge/themoltnet/libs/dspy-adapters@v${DSPY_ADAPTERS_VERSION}
+          fi
+
+          go mod tidy
+
       - uses: goreleaser/goreleaser-action@v6
         with:
           version: '~> v2'


### PR DESCRIPTION
## Why
`Release CLI binaries` failed in run 23900875230 because GoReleaser built CLI with `GOWORK=off` and resolved module deps from pinned `apps/moltnet-cli/go.mod` versions.

`go.mod` still pinned:
- `github.com/getlarge/themoltnet/libs/moltnet-api-client v1.7.0`

But CLI code required symbols from `v1.7.1` (`ListDiaryRenderedPacks*`), so release build failed.

## What
In `release-cli` job, before GoReleaser:
- Read resolved versions from `resolve-publish` outputs.
- Run `go mod edit -require=...@v<version>` for:
  - `libs/moltnet-api-client` (when version output exists)
  - `libs/dspy-adapters` (when version output exists)
- Run `go mod tidy`.

## Result
When api-client/dspy are tagged earlier in the same release workflow, CLI build automatically aligns to those fresh versions. No manual `go.mod` bump needed for release integrity.

## Ref
- Failed job: https://github.com/getlarge/themoltnet/actions/runs/23900875230/job/69697384084
