### PR TITLE
fix(ci): add plugin_marketplaces so code-review plugin can be resolved

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugins: 'code-review@claude-plugins-official'
+          plugin_marketplaces: 'https://github.com/anthropics/claude-plugins-official.git'
           prompt: '/review https://github.com/${{ github.repository }}/pull/${{ github.event.issue.number || github.event.pull_request.number }}'
           additional_permissions: |
             actions: read


### PR DESCRIPTION
## Summary
- Adds `plugin_marketplaces` input pointing to the official marketplace repo
- Without it the action skips marketplace setup entirely and can't find any plugins

Follow-up to #610 — the previous fix switched to the right plugin name but the action still failed because it had no marketplace to look it up from.