### PR TITLE
fix(ci): add allowedTools to claude-review job to unblock tool permissions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,6 +40,9 @@ jobs:
           plugins: 'code-review@claude-plugins-official'
           plugin_marketplaces: 'https://github.com/anthropics/claude-plugins-official.git'
           prompt: '/review https://github.com/${{ github.repository }}/pull/${{ github.event.issue.number || github.event.pull_request.number }}'
+          claude_args: >-
+            --allowedTools
+            "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*)"
           additional_permissions: |
             actions: read
 


### PR DESCRIPTION
## Summary
- Adds `claude_args` with `--allowedTools` to the `claude-review` job
- Without it Claude runs in interactive permission mode and all tool calls get denied in CI (8 denials, no review output)
- Grants access to the inline comment MCP server (which also enables it) plus `gh pr` commands needed for the review

Follow-up to #612.