### PR TITLE
debug(ci): enable show_full_output on claude-review job

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -45,6 +45,7 @@ jobs:
             "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*)"
           additional_permissions: |
             actions: read
+          show_full_output: true
 
   claude:
     # General @claude mentions (not review)


### PR DESCRIPTION
## Summary
- Adds `show_full_output: true` to the `claude-review` job to expose the full tool call stream in CI logs
- Needed to diagnose the `permission_denials_count: 1` causing the review to produce no comments on PR #623

## Test plan
- [ ] Re-trigger `@claude review` on a PR after merging — check the run log for the denied tool call