### PR TITLE
fix(ci): switch to pr-review-toolkit with proper PR triggers

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,6 +1,8 @@
 name: Claude Code
 
 on:
+  pull_request:
+    types: [opened, ready_for_review, synchronize]
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -12,8 +14,9 @@ on:
 
 jobs:
   claude-review:
-    # Triggered by "@claude review" or "@claude code review" on a PR comment
+    # Auto-review on non-draft PR open/update, or manual "@claude review" comment
     if: |
+      (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request != null &&
         (contains(github.event.comment.body, '@claude review') || contains(github.event.comment.body, '@claude code review'))) ||
       (github.event_name == 'pull_request_review_comment' &&
@@ -31,15 +34,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 50
+          fetch-depth: 1
 
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugins: 'code-review@claude-plugins-official'
+          plugins: 'pr-review-toolkit@claude-plugins-official'
           plugin_marketplaces: 'https://github.com/anthropics/claude-plugins-official.git'
-          prompt: '/code-review:code-review https://github.com/${{ github.repository }}/pull/${{ github.event.issue.number || github.event.pull_request.number }}'
+          prompt: '/review-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}'
+          claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment"'
           additional_permissions: |
             actions: read
           show_full_output: true


### PR DESCRIPTION
## Summary
- Switch from `code-review` plugin to `pr-review-toolkit` (matches official action example)
- Use `/review-pr REPO: ... PR_NUMBER: ...` prompt format
- Add `pull_request` triggers: `opened`, `ready_for_review`, `synchronize` (skips drafts)
- Keep manual `@claude review` comment trigger
- Restrict `allowedTools` to `mcp__github_inline_comment__create_inline_comment`

## Test plan
- [ ] Open or push to a non-draft PR — should auto-trigger review
- [ ] Comment `@claude review` on a PR — should trigger manually