### PR TITLE
fix(ci): disable project plugins in claude-review, keep only pr-review-toolkit

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -44,6 +44,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-plugins-official.git'
           prompt: '/review-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}'
           claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment"'
+          settings: '{"enabledPlugins":{"pr-review-toolkit@claude-plugins-official":true}}'
           additional_permissions: |
             actions: read
           show_full_output: true


### PR DESCRIPTION
## Root cause

The project-level `.claude/settings.json` enables all plugins (superpowers, legreffier, code-review, etc.). The action restores `.claude/` from `origin/main`, so all these plugins load in CI and pollute the slash command namespace — `/review-pr` resolves to "Unknown skill" because the lookup is ambiguous.

## Fix

Pass a `settings` override via the action input that sets `enabledPlugins` to only `pr-review-toolkit@claude-plugins-official`, disabling everything else for this job.

## Test plan
- [ ] Trigger `@claude review` or open a non-draft PR — `/review-pr` should resolve and post a comment