### PR TITLE
fix(ci): use GitHub App token to push go.mod to protected main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,10 +66,18 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.MOLTNET_RELEASE_APP_ID }}
+          private-key: ${{ secrets.MOLTNET_RELEASE_APP_KEY }}
+
       - uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 1
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/setup-go@v5
         with:
@@ -117,6 +125,8 @@ jobs:
 
       - name: Commit go.mod and go.sum to main
         if: ${{ steps.sync.outputs.changed == 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
Branch protection blocks `GITHUB_TOKEN` from pushing directly to main (requires PR + 12 status checks). The `sync-go-mod` commit step was failing with `GH013: Changes must be made through a pull request`.

Fix: use the same `MOLTNET_RELEASE_APP_ID`/`MOLTNET_RELEASE_APP_KEY` GitHub App token that release-please and the other tagging jobs use — it has bypass permissions for branch protection.