### PR TITLE
fix(ci): pin npm@10.9.8 for CLI npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -478,6 +478,8 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
+      - run: npm install -g npm@10.9.8
+
       - name: Publish @themoltnet/cli
         working-directory: packages/cli
         run: npm publish --access public --provenance


### PR DESCRIPTION
npm 11 dropped `promise-retry` as a bundled dep causing `--provenance` publishes to fail with a 404. Pins to npm@10.9.8 (last stable npm 10) for this job only, same pattern used in other publish jobs before the npm upgrade was removed.