### PR TITLE
fix(ci): use full /pr-review-toolkit:review-pr slash command

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -42,7 +42,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugins: 'pr-review-toolkit@claude-plugins-official'
           plugin_marketplaces: 'https://github.com/anthropics/claude-plugins-official.git'
-          prompt: '/review-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}'
+          prompt: '/pr-review-toolkit:review-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}'
           claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment"'
           settings: '{"enabledPlugins":{"pr-review-toolkit@claude-plugins-official":true}}'
           additional_permissions: |


### PR DESCRIPTION
## Root cause

`/review-pr` doesn't match any command — the lookup requires either the full name `pr-review-toolkit:review-pr` or the `userFacingName`. Verified locally:

```
$ echo "/review-pr ..." | claude --print
Unknown skill: review-pr

$ echo "/pr-review-toolkit:review-pr ..." | claude --print
# → runs the skill
```

## Fix

Use `/pr-review-toolkit:review-pr` as the prompt.

## Test plan
- [ ] Trigger `@claude review` on a PR — skill should resolve and post a comment