### PR TITLE
fix(ci): add id-token: write to top-level workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release-please:


### PR DESCRIPTION
## Problem

`publish-cli-npm` was failing to publish with provenance. Root cause: the top-level workflow `permissions` block was missing `id-token: write`.

GitHub Actions only grants job-level permissions that are a **subset** of the top-level permissions. Without `id-token` at the top level, the runtime token for `publish-cli-npm` showed only `Contents: read, Metadata: read` — `id-token` was never issued.

`npm publish --provenance` calls `getIDToken()` internally, which requires `id-token: write`. This was silently failing, causing the 404/auth error.

## Fix

Add `id-token: write` to the top-level `permissions` block (one line change).

## Note

`@themoltnet/cli@1.15.0` needs to be manually published to npm once more (`pnpm --filter @themoltnet/cli publish --access public --no-git-checks`) since the automated job failed for this version.