### PR TITLE
fix(ci): allow legreffier bot to trigger claude-review

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -45,6 +45,7 @@ jobs:
           prompt: '/pr-review-toolkit:review-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}'
           claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment"'
           settings: '{"enabledPlugins":{"pr-review-toolkit@claude-plugins-official":true}}'
+          allowed_bots: 'legreffier'
           additional_permissions: |
             actions: read
           show_full_output: true


### PR DESCRIPTION
## Summary

PR #665 was opened by `legreffier[bot]` which is blocked by the action's default bot filter. Add it to `allowed_bots`.