### PR TITLE
fix(ci): allow Bash gh commands in claude-review allowedTools

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,7 +43,7 @@ jobs:
           plugins: 'pr-review-toolkit@claude-plugins-official'
           plugin_marketplaces: 'https://github.com/anthropics/claude-plugins-official.git'
           prompt: '/pr-review-toolkit:review-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}'
-          claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment"'
+          claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh api:*)"'
           settings: '{"enabledPlugins":{"pr-review-toolkit@claude-plugins-official":true}}'
           allowed_bots: 'legreffier'
           additional_permissions: |


### PR DESCRIPTION
## Summary

- The `pr-review-toolkit:review-pr` skill was running and producing a full review (reading PR diff, git history, source files) but never posting the comment
- Root cause: `allowedTools` only allowed `mcp__github_inline_comment__create_inline_comment`, but the skill posts via `Bash(gh pr comment:*)`
- Fix: expand the allow-list to include `gh pr comment`, `gh pr view`, `gh pr diff`, and `gh api` bash commands

## Test plan

- [ ] Merge this PR, then open or push to any non-draft PR
- [ ] The `claude-review` job should now complete and post a PR comment with the review