### PR TITLE
fix(ci): post review as sticky comment, trigger only on push not PR open

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -2,7 +2,7 @@ name: Claude Code
 
 on:
   pull_request:
-    types: [opened, ready_for_review, synchronize]
+    types: [synchronize]
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -14,7 +14,7 @@ on:
 
 jobs:
   claude-review:
-    # Auto-review on non-draft PR open/update, or manual "@claude review" comment
+    # Auto-review on PR push (not open), or manual "@claude review" comment
     if: |
       (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request != null &&
@@ -43,11 +43,12 @@ jobs:
           plugins: 'pr-review-toolkit@claude-plugins-official'
           plugin_marketplaces: 'https://github.com/anthropics/claude-plugins-official.git'
           prompt: '/pr-review-toolkit:review-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}'
-          claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh api:*)"'
+          claude_args: '--model claude-sonnet-4-6 --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh api:*)"'
           settings: '{"enabledPlugins":{"pr-review-toolkit@claude-plugins-official":true}}'
           allowed_bots: 'legreffier'
           additional_permissions: |
             actions: read
+          use_sticky_comment: true
           show_full_output: true
 
   claude:


### PR DESCRIPTION
## Summary

- `use_sticky_comment: true` — the action posts the review result as a PR comment (previously the review ran and produced content but only logged it, never posted it)
- `pull_request` trigger changed to `synchronize` only — review fires on new pushes, not on PR open/ready_for_review