### PR TITLE
fix(ci): workaround action#1061 by posting review via gh pr comment

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,17 +38,18 @@ jobs:
 
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@v1
+        # Workaround for anthropics/claude-code-action#1061: action silently drops
+        # output on pull_request triggers. Claude must explicitly post via gh pr comment.
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugins: 'pr-review-toolkit@claude-plugins-official'
           plugin_marketplaces: 'https://github.com/anthropics/claude-plugins-official.git'
-          prompt: '/pr-review-toolkit:review-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}'
+          prompt: 'Run /pr-review-toolkit:review-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }} — then post the complete review as a PR comment with: gh pr comment ${{ github.event.pull_request.number || github.event.issue.number }} --repo ${{ github.repository }} --body <review>'
           claude_args: '--model claude-sonnet-4-6 --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh api:*)"'
           settings: '{"enabledPlugins":{"pr-review-toolkit@claude-plugins-official":true}}'
           allowed_bots: 'legreffier'
           additional_permissions: |
             actions: read
-          use_sticky_comment: true
           show_full_output: true
 
   claude:


### PR DESCRIPTION
## Summary

- Workaround for [anthropics/claude-code-action#1061](https://github.com/anthropics/claude-code-action/issues/1061): the action silently drops Claude's output on `pull_request` triggers — no comment is ever posted
- Fix: instruct Claude explicitly in the prompt to post the review via `gh pr comment` after running the skill
- Remove `use_sticky_comment: true` (ineffective for this trigger type per the bug)
- Add inline comment referencing the upstream issue for future cleanup

## Test plan

- [ ] Merge and push a commit to an open non-draft PR
- [ ] Verify the `claude-review` job posts a review comment on the PR