### PR TITLE
ci(claude): make code review manual-only via @claude review

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,8 +1,6 @@
 name: Claude Code
 
 on:
-  pull_request:
-    types: [synchronize]
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -14,9 +12,8 @@ on:
 
 jobs:
   claude-review:
-    # Auto-review on PR push (not open), or manual "@claude review" comment
+    # Manual "@claude review" comment only
     if: |
-      (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request != null &&
         (contains(github.event.comment.body, '@claude review') || contains(github.event.comment.body, '@claude code review'))) ||
       (github.event_name == 'pull_request_review_comment' &&


### PR DESCRIPTION
## Summary

- Removes the `pull_request: synchronize` trigger so `claude-review` no longer auto-fires on every push
- Review must now be explicitly requested with `@claude review` or `@claude code review` in a PR comment

## Test plan

- [ ] Push a commit to a PR — `claude-review` job should NOT trigger
- [ ] Comment `@claude review` on a PR — `claude-review` job should trigger