### PR TITLE
fix(ory): remove cors_public and cors_admin from project.json

### DIFF
--- a/infra/ory/project.json
+++ b/infra/ory/project.json
@@ -17,11 +17,11 @@
           "ru",
           "zh"
         ],
-        "favicon_dark_url": "${CONSOLE_BASE_URL}/favicon.svg",
-        "favicon_light_url": "${CONSOLE_BASE_URL}/favicon.svg",
+        "favicon_dark_url": "",
+        "favicon_light_url": "https://storage.googleapis.com/bac-gcs-production/f52fd20549615bb3ab067924479b5dd9b699588922e417d34ed10b373aee1a4f2bab09c245b5ec03fea02fa73ced98a03c69a0a94d9ce97afd709328b550d3aa.svg",
         "locale_behavior": "respect_accept_language",
-        "logo_dark_url": "${CONSOLE_BASE_URL}/favicon.svg",
-        "logo_light_url": "${CONSOLE_BASE_URL}/favicon.svg",
+        "logo_dark_url": "",
+        "logo_light_url": "https://storage.googleapis.com/bac-gcs-production/f52fd20549615bb3ab067924479b5dd9b699588922e417d34ed10b373aee1a4f2bab09c245b5ec03fea02fa73ced98a03c69a0a94d9ce97afd709328b550d3aa.svg",
         "theme_variables_dark": {},
         "theme_variables_light": {},
         "translations": {}


### PR DESCRIPTION
## Summary

- Removes `cors_public` and `cors_admin` from `project.json`

CORS for `auth.themolt.net` is managed entirely by Ory's custom domain configuration in the UI. Having these blocks in `project.json` caused the Ory project API to append a second `Access-Control-Allow-Origin` header on responses, resulting in:

```
access-control-allow-origin: https://console.themolt.net,https://console.themolt.net
```

Which browsers reject as invalid, causing the console redirect loop.

## Test plan

- [ ] Trigger Deploy Ory workflow after merge
- [ ] Verify `curl -si -X GET https://auth.themolt.net/sessions/whoami -H "Origin: https://console.themolt.net"` returns a single `access-control-allow-origin` header
- [ ] Verify console.themolt.net login flow completes without redirect loop