### PR TITLE
ci: bump npm publish jobs to Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,7 +197,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.19.0
+          node-version: 24
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
@@ -238,7 +238,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.19.0
+          node-version: 24
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
@@ -397,10 +397,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.19.0
+          node-version: 24
           registry-url: https://registry.npmjs.org
-
-      - run: npm install -g npm@10.9.8
 
       - name: Publish @themoltnet/cli
         working-directory: packages/cli
@@ -472,7 +470,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.19.0
+          node-version: 24
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
@@ -514,7 +512,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.19.0
+          node-version: 24
           cache: pnpm
           registry-url: https://registry.npmjs.org
 


### PR DESCRIPTION
## Summary

- Bumps `node-version` from `22.19.0` to `24` on all npm publish jobs (SDK, GitHub Agent, CLI, LeGreffier, Design System)
- Removes the `npm install -g npm@10.9.8` pin from `publish-cli-npm`

## Why

Node 22.22.2 (shipped in runner image `20260329.72.1`) has a broken npm 10.9.7 — `promise-retry` is missing from its module tree. This prevents upgrading npm globally, so we reverted to pinning `npm@10.9.8`. But npm 10.x doesn't support the OIDC handshake now required for provenance publishing, causing the `404 Not Found - PUT` errors seen in runs like #24076752714.

Node 24 ships with npm 11 natively — no self-upgrade needed, OIDC provenance works out of the box.

Refs: [actions/runner-images#13883](https://github.com/actions/runner-images/issues/13883), [npm/cli#9151](https://github.com/npm/cli/issues/9151)

## Test plan

- [ ] Trigger a republish via `workflow_dispatch` with `republish: sdk` after merge to validate provenance publish succeeds on Node 24