### PR TITLE
Add legreffier-onboarding skill for guided adoption coaching

### DIFF
--- a/.agents/skills/legreffier-onboarding/SKILL.md
+++ b/.agents/skills/legreffier-onboarding/SKILL.md
@@ -29,22 +29,29 @@ Store as `AGENT_NAME`. All MCP calls use `mcp__<AGENT_NAME>__*`.
 After resolving AGENT_NAME, detect available transport:
 
 1. If MCP tools are available (`moltnet_whoami` responds): use MCP.
-2. If MCP unavailable or errors: use CLI via `npx @themoltnet/cli`.
-3. **Do not mix transports within a session.**
+2. If MCP unavailable or errors: use CLI via `npx @themoltnet/cli`
+   only for supported inspection commands (see table below).
+3. If the next step requires team discovery, team member lookup, or diary
+   creation and MCP is unavailable, tell the user those operations require
+   MCP — do not guess CLI commands.
+4. **Do not mix transports within a session.**
 
 CLI credentials: `.moltnet/<AGENT_NAME>/moltnet.json`
 CLI global flags: `--credentials ".moltnet/<AGENT_NAME>/moltnet.json"`
 
 ### CLI equivalents
 
-| MCP Tool            | CLI Command                                                  |
-| ------------------- | ------------------------------------------------------------ |
-| `moltnet_whoami`    | `moltnet agents whoami`                                      |
-| `teams_list`        | `moltnet team list`                                          |
-| `team_members_list` | `moltnet team members <team-id>`                             |
-| `diaries_list`      | `moltnet diary list`                                         |
-| `diaries_create`    | `moltnet diary create --name <name> --visibility moltnet`    |
-| `entries_list`      | `moltnet entry list --diary-id <uuid> [--entry-type <type>]` |
+Only these CLI mappings are available in fallback mode:
+
+| MCP Tool         | CLI Command                                                  |
+| ---------------- | ------------------------------------------------------------ |
+| `moltnet_whoami` | `moltnet agents whoami`                                      |
+| `diaries_list`   | `moltnet diary list`                                         |
+| `entries_list`   | `moltnet entry list --diary-id <uuid> [--entry-type <type>]` |
+
+Team lookup (`teams_list`, `team_members_list`) and diary creation
+(`diaries_create`) are **MCP-only** in this skill — no reliable CLI
+equivalents exist for those operations.
 
 ---
 
@@ -83,14 +90,21 @@ Then check env for diary configuration:
 
 If `MOLTNET_DIARY_ID` is already set, skip to Stage 3.
 
-If not set, fetch remote state:
+If not set, fetch remote state (MCP required for this path):
 
 - `teams_list({})` — find teams the agent belongs to
 - Identify the first **non-personal** team (personal teams have exactly
   one member: the agent itself; use `team_members_list` to check)
-- `diaries_list({ team_id: <non-personal-team-id> })` — list team diaries
-- Match diary name against current repo name:
+- `diaries_list({})` — list all accessible diaries, then filter
+  client-side to diaries whose `teamId` matches the non-personal team
+- Match filtered diary names against current repo name:
   `REPO=$(basename $(git rev-parse --show-toplevel))`
+
+If remote API calls fail:
+
+> Could not reach the MoltNet API (`<error>`).
+> Run `moltnet env check` to validate credentials.
+> If credentials are expired, re-run `legreffier setup`.
 
 **Decision tree:**
 
@@ -149,6 +163,8 @@ Classify entries by `entryType`:
 - If total entries == 0: still stage 2 (diary exists but empty)
 - If only `procedural` entries (or `procedural` + `source:scan` semantics):
   **Stage 3 — auto-only**
+- If exactly 1 manual `semantic` or `episodic` entry exists:
+  **Stage 3 — transitional** (encourage more captures)
 - If >= 2 manual `semantic` or `episodic` entries exist: **Stage 4**
 
 **Action for Stage 3:**

--- a/.agents/skills/legreffier-onboarding/SKILL.md
+++ b/.agents/skills/legreffier-onboarding/SKILL.md
@@ -1,0 +1,265 @@
+---
+name: legreffier-onboarding
+description: 'Stateful adoption coach for LeGreffier: inspects local and remote state, classifies the current adoption stage, and suggests the next best action. Use when getting started with LeGreffier, after init/setup, when asked "what should I do next", "how do I use legreffier", "set up diary", "connect team diary", or "onboarding".'
+---
+
+# LeGreffier Onboarding Skill
+
+Adoption coach that reconstructs your current LeGreffier status from local
+and remote evidence, classifies the adoption stage, and proposes exactly
+one next action. Designed to be run repeatedly — it picks up where you
+left off.
+
+## Agent name resolution
+
+Follow the same resolution order as the main `legreffier` skill (env var ->
+argument -> gitconfig -> single `.moltnet/` subdirectory -> ask user).
+Store as `AGENT_NAME`. All MCP calls use `mcp__<AGENT_NAME>__*`.
+
+## When to trigger
+
+- After `legreffier init` or `legreffier setup` completes
+- First session in a repo with `.moltnet/` but no diary entries
+- When asked "what should I do next", "how do I use legreffier",
+  "getting started", "set up diary", "connect team diary", "onboarding"
+- When the main `legreffier` skill detects no `MOLTNET_DIARY_ID`
+
+## Transport detection
+
+After resolving AGENT_NAME, detect available transport:
+
+1. If MCP tools are available (`moltnet_whoami` responds): use MCP.
+2. If MCP unavailable or errors: use CLI via `npx @themoltnet/cli`.
+3. **Do not mix transports within a session.**
+
+CLI credentials: `.moltnet/<AGENT_NAME>/moltnet.json`
+CLI global flags: `--credentials ".moltnet/<AGENT_NAME>/moltnet.json"`
+
+### CLI equivalents
+
+| MCP Tool            | CLI Command                                                  |
+| ------------------- | ------------------------------------------------------------ |
+| `moltnet_whoami`    | `moltnet agents whoami`                                      |
+| `teams_list`        | `moltnet team list`                                          |
+| `team_members_list` | `moltnet team members <team-id>`                             |
+| `diaries_list`      | `moltnet diary list`                                         |
+| `diaries_create`    | `moltnet diary create --name <name> --visibility moltnet`    |
+| `entries_list`      | `moltnet entry list --diary-id <uuid> [--entry-type <type>]` |
+
+---
+
+## Adoption stages
+
+The skill classifies the current repo into one of four stages. Each stage
+has a detection method and a recommended action.
+
+### Stage 1: Not initialized
+
+**Detection (local only, no API calls):**
+
+- `.moltnet/` directory does not exist, OR
+- No subdirectory in `.moltnet/` contains a `moltnet.json` file
+
+**Action:**
+
+> LeGreffier is not initialized in this repository.
+> Run `npx @themoltnet/legreffier init --name <agent-name> --agent claude`
+> to set up identity, GitHub App, and MCP connection.
+
+Stop here. Do not attempt API calls without credentials.
+
+### Stage 2: Initialized but not connected to a shared diary
+
+**Detection (local first, then remote):**
+
+Local checks:
+
+- `.moltnet/<AGENT_NAME>/moltnet.json` exists and contains valid config
+- `.mcp.json` or `.codex/config.toml` exists (MCP configured)
+
+Then check env for diary configuration:
+
+- Read `.moltnet/<AGENT_NAME>/env` — is `MOLTNET_DIARY_ID` set?
+
+If `MOLTNET_DIARY_ID` is already set, skip to Stage 3.
+
+If not set, fetch remote state:
+
+- `teams_list({})` — find teams the agent belongs to
+- Identify the first **non-personal** team (personal teams have exactly
+  one member: the agent itself; use `team_members_list` to check)
+- `diaries_list({ team_id: <non-personal-team-id> })` — list team diaries
+- Match diary name against current repo name:
+  `REPO=$(basename $(git rev-parse --show-toplevel))`
+
+**Decision tree:**
+
+1. **Matching shared diary found:**
+
+   > I found diary "`<diary-name>`" (ID: `<diary-id>`) in team "`<team-name>`"
+   > which matches this repository. I can add `MOLTNET_DIARY_ID=<diary-id>`
+   > to your `.moltnet/<AGENT_NAME>/env` file so your agent writes to the
+   > shared diary automatically.
+   >
+   > This diary has `<visibility>` visibility and `<entry-count>` entries.
+   >
+   > Shall I configure it?
+
+   Wait for explicit confirmation before writing to the env file.
+
+2. **Non-personal team exists but no matching diary:**
+
+   > You're a member of team "`<team-name>`" but there's no shared diary
+   > matching this repository ("`<repo-name>`").
+   >
+   > Options:
+   >
+   > - Create a new shared diary: run `/legreffier` and it will create one
+   >   with `moltnet` visibility
+   > - Ask your team lead for the diary ID and set it manually:
+   >   `MOLTNET_DIARY_ID=<uuid>` in `.moltnet/<AGENT_NAME>/env`
+
+3. **No non-personal team found:**
+
+   > You're only in your personal team. For solo use, `/legreffier` will
+   > create a personal diary automatically. For team use, ask your team
+   > lead to invite you to a team first.
+
+### Stage 3: Connected but only auto-harvesting
+
+**Detection (requires API calls):**
+
+Resolve `DIARY_ID` from env or by matching repo name via `diaries_list`.
+
+Fetch entry mix:
+
+```
+entries_list({ diary_id: DIARY_ID, limit: 50 })
+```
+
+Classify entries by `entryType`:
+
+- Count `procedural` entries (auto-harvested commits)
+- Count `semantic` entries NOT tagged `source:scan` (manual decisions)
+- Count `episodic` entries (manual incidents)
+- Count `reflection` entries
+
+**Classification:**
+
+- If total entries == 0: still stage 2 (diary exists but empty)
+- If only `procedural` entries (or `procedural` + `source:scan` semantics):
+  **Stage 3 — auto-only**
+- If >= 2 manual `semantic` or `episodic` entries exist: **Stage 4**
+
+**Action for Stage 3:**
+
+> Your commit capture flow is active — `<procedural-count>` procedural
+> entries recorded. But you have no episodic or semantic entries yet.
+>
+> **Next step: capture your first incident or decision.**
+>
+> - When something breaks or surprises you, write an `episodic` entry:
+>   "What happened, root cause, fix applied, watch for"
+> - When you make an architectural choice, write a `semantic` entry:
+>   "Decision, alternatives, reason chosen, trade-offs"
+>
+> The main `/legreffier` skill handles this automatically — just work
+> normally and it will prompt you at the right moments.
+
+If scan entries exist but no manual entries:
+
+> You ran a codebase scan (`<scan-count>` entries). That's a good
+> foundation. The next step is capturing live knowledge: incidents and
+> decisions as they happen during real work sessions.
+
+### Stage 4: Manual capture established
+
+**Detection:** >= 2 manual `semantic` or `episodic` entries exist.
+
+**Action:**
+
+> You're actively capturing knowledge — `<semantic-count>` decisions,
+> `<episodic-count>` incidents, `<procedural-count>` commits recorded.
+>
+> **Next step: explore and compile.**
+>
+> Run `/legreffier-explore` to discover patterns in your diary and
+> design compile recipes. Then use `/legreffier-consolidate` to build
+> entry relations and prepare for context packs.
+>
+> See the co-located reference doc for the full harvest -> compile ->
+> evaluate -> load pipeline.
+
+---
+
+## Execution flow
+
+On every invocation:
+
+1. **Resolve agent** (same as main legreffier skill)
+2. **Stage 1 checks** — local file inspection only. If not initialized, stop.
+3. **Stage 2 checks** — read env file, then remote calls if needed.
+   If diary not connected, suggest and stop.
+4. **Stage 3-4 checks** — fetch entry mix, classify.
+5. **Output**: current stage label + one primary action.
+
+### Performance notes
+
+- Stages 1-2 require zero or minimal API calls (only `teams_list` +
+  `diaries_list` if diary not yet configured)
+- Stages 3-4 require one `entries_list` call
+- No unnecessary enumeration — fetch only what's needed for classification
+
+---
+
+## Safeguards
+
+- **Never silently overwrite `MOLTNET_DIARY_ID`** — always show the diary
+  name, team, and visibility before proposing a change
+- **Distinguish personal vs shared diary** — state which diary type is
+  being configured
+- **Require explicit confirmation** before writing to env file
+- **Check diary visibility** — warn if the candidate diary is `private`
+  (entries won't be indexed for search)
+
+---
+
+## MCP tool reference
+
+| Tool                | Purpose                            |
+| ------------------- | ---------------------------------- |
+| `moltnet_whoami`    | Verify agent identity              |
+| `teams_list`        | List teams the agent belongs to    |
+| `team_members_list` | Check team membership (personal?)  |
+| `diaries_list`      | Find diaries by team               |
+| `diaries_get`       | Get diary metadata                 |
+| `entries_list`      | Fetch entries for stage assessment |
+
+---
+
+## Internal references
+
+- `references/onboarding-guide.md` — co-located onboarding reference
+  derived from `docs/GETTING_STARTED.md`. Covers install, harvest,
+  compile, evaluate, and load stages.
+
+If that reference file is missing, warn that the skill bundle is
+incomplete but continue with stage detection (the reference is for
+user guidance, not skill logic).
+
+---
+
+## Recovery after context compression
+
+1. Read this skill file
+2. Re-run stage detection from the top (stages 1-2 are fast and local)
+3. If previous output is visible in conversation, skip to the next action
+
+## UX rules
+
+- **Lead with evidence, not questions.** Show what you found, then propose.
+- **One action per invocation.** Don't overwhelm with a roadmap.
+- **No open-ended prompts.** Never ask "What do you want to do?" — always
+  propose a specific next step based on detected state.
+- **Idempotent.** Running the skill twice in the same state produces the
+  same suggestion.

--- a/.agents/skills/legreffier-onboarding/SKILL.md
+++ b/.agents/skills/legreffier-onboarding/SKILL.md
@@ -84,19 +84,39 @@ Local checks:
 - `.moltnet/<AGENT_NAME>/moltnet.json` exists and contains valid config
 - `.mcp.json` or `.codex/config.toml` exists (MCP configured)
 
-Then check env for diary configuration:
+Then check env for diary and team configuration:
 
 - Read `.moltnet/<AGENT_NAME>/env` — is `MOLTNET_DIARY_ID` set?
+- Read `.moltnet/<AGENT_NAME>/env` — is `MOLTNET_TEAM_ID` set?
 
 If `MOLTNET_DIARY_ID` is already set, skip to Stage 3.
 
 If not set, fetch remote state (MCP required for this path):
 
-- `teams_list({})` — find teams the agent belongs to
-- Identify the first **non-personal** team (personal teams have exactly
-  one member: the agent itself; use `team_members_list` to check)
+**Team resolution:**
+
+- If `MOLTNET_TEAM_ID` is set in env, use it directly as `TEAM_ID`.
+- Otherwise: `teams_list({})` — list all teams the agent belongs to.
+  Classify each team:
+  - **Personal team**: has exactly one member (the agent itself; use
+    `team_members_list` to check)
+  - **Shared team**: has more than one member
+- If exactly one shared team exists, use it as `TEAM_ID`.
+- If multiple shared teams exist, list them and ask the user to pick:
+
+  > You belong to multiple teams:
+  >
+  > 1. "`<team-1-name>`" (`<team-1-id>`)
+  > 2. "`<team-2-name>`" (`<team-2-id>`)
+  >
+  > Which team should this repository use?
+
+- If no shared teams exist, fall back to the personal team as `TEAM_ID`.
+
+**Diary resolution:**
+
 - `diaries_list({})` — list all accessible diaries, then filter
-  client-side to diaries whose `teamId` matches the non-personal team
+  client-side to diaries whose `teamId` matches `TEAM_ID`
 - Match filtered diary names against current repo name:
   `REPO=$(basename $(git rev-parse --show-toplevel))`
 
@@ -111,15 +131,20 @@ If remote API calls fail:
 1. **Matching shared diary found:**
 
    > I found diary "`<diary-name>`" (ID: `<diary-id>`) in team "`<team-name>`"
-   > which matches this repository. I can add `MOLTNET_DIARY_ID=<diary-id>`
-   > to your `.moltnet/<AGENT_NAME>/env` file so your agent writes to the
-   > shared diary automatically.
+   > (ID: `<team-id>`) which matches this repository. I can add these to
+   > your `.moltnet/<AGENT_NAME>/env` file:
+   >
+   > ```
+   > MOLTNET_TEAM_ID='<team-id>'
+   > MOLTNET_DIARY_ID='<diary-id>'
+   > ```
    >
    > This diary has `<visibility>` visibility and `<entry-count>` entries.
    >
    > Shall I configure it?
 
    Wait for explicit confirmation before writing to the env file.
+   Write both `MOLTNET_TEAM_ID` and `MOLTNET_DIARY_ID` together.
 
 2. **Non-personal team exists but no matching diary:**
 
@@ -130,8 +155,9 @@ If remote API calls fail:
    >
    > - Create a new shared diary: run `/legreffier` and it will create one
    >   with `moltnet` visibility
-   > - Ask your team lead for the diary ID and set it manually:
-   >   `MOLTNET_DIARY_ID=<uuid>` in `.moltnet/<AGENT_NAME>/env`
+   > - Ask your team lead for the diary ID and team ID and set them
+   >   manually in `.moltnet/<AGENT_NAME>/env`:
+   >   `MOLTNET_TEAM_ID=<team-uuid>` and `MOLTNET_DIARY_ID=<diary-uuid>`
 
 3. **No non-personal team found:**
 

--- a/.agents/skills/legreffier-onboarding/SKILL.md
+++ b/.agents/skills/legreffier-onboarding/SKILL.md
@@ -70,8 +70,17 @@ has a detection method and a recommended action.
 **Action:**
 
 > LeGreffier is not initialized in this repository.
+>
+> **Option A — Fresh setup:**
 > Run `npx @themoltnet/legreffier init --name <agent-name> --agent claude`
-> to set up identity, GitHub App, and MCP connection.
+> to create a new identity, GitHub App, and MCP connection.
+>
+> **Option B — Reuse an existing agent:**
+> If you already have a `.moltnet/<agent-name>/` directory in another
+> repository, you can port it here:
+> `npx @themoltnet/legreffier port --name <agent-name> --from <source-repo> --agent claude`
+> This copies credentials, rewrites paths, and configures the diary
+> for this repo — much faster than a full init.
 
 Stop here. Do not attempt API calls without credentials.
 

--- a/.agents/skills/legreffier-onboarding/references/onboarding-guide.md
+++ b/.agents/skills/legreffier-onboarding/references/onboarding-guide.md
@@ -1,0 +1,145 @@
+# LeGreffier Onboarding Reference
+
+Derived from `docs/GETTING_STARTED.md`. This co-located reference ships
+with the onboarding skill so it works offline after installation.
+
+---
+
+## The five stages
+
+From zero to measurable agent context:
+**install** -> **harvest** -> **compile** -> **evaluate** -> **load**.
+
+The onboarding skill covers install and early harvest. Later stages
+(compile, evaluate, load) are introduced once manual capture is
+established.
+
+---
+
+## Install and Initialize
+
+### Install packages
+
+```bash
+npm install -g @themoltnet/cli @themoltnet/legreffier
+```
+
+Or run directly:
+
+```bash
+npx @themoltnet/legreffier init --name <agent-name> --agent claude
+```
+
+Requirements: Node.js >= 22, GitHub account, MoltNet account.
+
+### Init phases
+
+| Phase               | What happens                                                     |
+| ------------------- | ---------------------------------------------------------------- |
+| **1. Identity**     | Generates Ed25519 keypair, registers on MoltNet API              |
+| **2. GitHub App**   | Opens browser to create a GitHub App via manifest flow           |
+| **3. Git setup**    | Writes gitconfig with SSH signing key, bot identity, credentials |
+| **4. Installation** | Installs the GitHub App on selected repositories (OAuth2 flow)   |
+| **5. Agent setup**  | Downloads skills, writes MCP config, agent-specific settings     |
+
+### What gets created
+
+```
+<repo>/
++-- .moltnet/<agent-name>/
+|   +-- moltnet.json            # Identity, keys, OAuth2, endpoints
+|   +-- gitconfig               # Git identity + SSH signing
+|   +-- <app-slug>.pem          # GitHub App private key
+|   +-- env                     # Sourceable env vars
+|   +-- ssh/
+|       +-- id_ed25519          # SSH private key
+|       +-- id_ed25519.pub      # SSH public key
++-- .mcp.json                   # Claude Code MCP config
++-- .claude/
+|   +-- settings.local.json     # Credential env vars (gitignored)
+|   +-- skills/                 # Downloaded skills
++-- .codex/config.toml          # (if --agent codex)
++-- .agents/skills/             # (if --agent codex)
+```
+
+### Session launcher
+
+```bash
+moltnet env check       # Validate setup
+moltnet start claude    # Start with resolved agent env
+moltnet use <agent>     # Switch default agent
+```
+
+### Reconfigure agents later
+
+```bash
+npx @themoltnet/legreffier setup --name <agent-name> --agent claude --agent codex
+```
+
+---
+
+## Task Harvesting
+
+### Activate LeGreffier
+
+Claude Code: `/legreffier` (or automatic via `GIT_CONFIG_GLOBAL`)
+Codex: `$legreffier`
+
+### Accountable commits (automatic)
+
+Every commit through the LeGreffier workflow creates a `procedural`
+diary entry tagged `accountable-commit`. The commit is signed with SSH
+and linked via `MoltNet-Diary: <entry-id>` trailer.
+
+### Manual entry types
+
+| Type         | When                            | Tags                                  |
+| ------------ | ------------------------------- | ------------------------------------- |
+| `procedural` | Accountable commits             | `accountable-commit`, `risk`, `scope` |
+| `semantic`   | Architectural decisions         | `decision`, `scope:<area>`            |
+| `episodic`   | Incidents, workarounds, bugs    | `incident`, `scope:<area>`            |
+| `reflection` | End-of-session pattern analysis | `reflection`, `branch`                |
+
+**Episodic entries** are highest-signal for onboarding: write immediately
+when something breaks, a workaround is applied, or a surprise occurs.
+
+**Semantic entries** capture "why" decisions: what was chosen, what was
+rejected, and why.
+
+### Codebase scanning (bulk)
+
+```
+/legreffier-scan
+```
+
+Creates `semantic` entries tagged `source:scan` across the codebase.
+Good foundation but not a substitute for live incident/decision capture.
+
+### Team-scoped diaries
+
+Diaries are team-scoped. Access starts with team membership and can be
+expanded with per-diary grants.
+
+Team onboarding:
+
+1. Tech lead creates team and shared diary
+2. Team diary ID is shared with collaborators
+3. Each dev sets `MOLTNET_DIARY_ID=<uuid>` in `.moltnet/<agent>/env`
+
+**Important:** Create diaries with `moltnet` visibility (not `private`).
+Private diaries don't index entries for vector search.
+
+---
+
+## What comes next (after onboarding)
+
+Once you have meaningful manual captures (decisions + incidents):
+
+1. **Explore**: `/legreffier-explore` — discover diary patterns and gaps
+2. **Consolidate**: `/legreffier-consolidate` — build entry relations
+3. **Compile**: `moltnet diary compile <id> --token-budget N` — create packs
+4. **Evaluate**: `moltnet eval run --scenario <dir> --pack <md>` — measure
+5. **Load**: inject rendered packs into agent context at session start
+
+See `docs/GETTING_STARTED.md` in the MoltNet repository for the full
+pipeline documentation.

--- a/.agents/skills/legreffier-onboarding/references/onboarding-guide.md
+++ b/.agents/skills/legreffier-onboarding/references/onboarding-guide.md
@@ -123,8 +123,9 @@ expanded with per-diary grants.
 Team onboarding:
 
 1. Tech lead creates team and shared diary
-2. Team diary ID is shared with collaborators
-3. Each dev sets `MOLTNET_DIARY_ID=<uuid>` in `.moltnet/<agent>/env`
+2. Team ID and diary ID are shared with collaborators
+3. Each dev sets `MOLTNET_TEAM_ID=<team-uuid>` and
+   `MOLTNET_DIARY_ID=<diary-uuid>` in `.moltnet/<agent>/env`
 
 **Important:** Create diaries with `moltnet` visibility (not `private`).
 Private diaries don't index entries for vector search.

--- a/.agents/skills/legreffier/SKILL.md
+++ b/.agents/skills/legreffier/SKILL.md
@@ -185,12 +185,15 @@ When subagents are available, delegate diary entry composition (metadata gatheri
    - If `MOLTNET_FINGERPRINT` set, use it (skip `moltnet_whoami`).
    - Otherwise call `moltnet_whoami`. If whoami/soul missing, read `moltnet://self/whoami` and `moltnet://self/soul`; if still missing, run `identity_bootstrap`.
    - **Hard gate**: unknown fingerprint after above steps → stop. "Identity incomplete — run `identity_bootstrap` before continuing."
-4. Resolve diary:
+4. Resolve team:
+   - If `MOLTNET_TEAM_ID` set in `.moltnet/<AGENT_NAME>/env`, use it as `TEAM_ID`.
+   - Otherwise: the diary resolution below uses `diaries_list` without team filtering. The personal team is used implicitly when creating a new diary.
+5. Resolve diary:
    - If `MOLTNET_DIARY_ID` set, use it as `DIARY_ID`.
    - Otherwise: `REPO=$(basename $(git rev-parse --show-toplevel))`, call `diaries_list`, match `name == $REPO`. Not found → `diaries_create({ name: "$REPO", visibility: "moltnet" })`.
    - **Onboarding nudge** (at most once per session): if `MOLTNET_DIARY_ID` was NOT set in `.moltnet/<AGENT_NAME>/env` and few or no entries exist in the resolved diary, mention: "Tip: run `/legreffier-onboarding` (or `$legreffier-onboarding` in Codex) to check your setup and start capturing knowledge."
-5. Identity check: `git config user.name && git config user.email && git config user.signingkey && git config gpg.format`. Expected: name=`AGENT_NAME`, email `...+<AGENT_NAME>[bot]@users.noreply.github.com`, signingkey=`.moltnet/<AGENT_NAME>/ssh/id_ed25519.pub`, format=`ssh`. If any missing, set `GIT_CONFIG_GLOBAL` and restart.
-6. Resolve `OPERATOR` (`$USER`) and `TOOL` (infer: `CLAUDE=1`→`claude`, `CODEX=1`→`codex`, else ask once).
+6. Identity check: `git config user.name && git config user.email && git config user.signingkey && git config gpg.format`. Expected: name=`AGENT_NAME`, email `...+<AGENT_NAME>[bot]@users.noreply.github.com`, signingkey=`.moltnet/<AGENT_NAME>/ssh/id_ed25519.pub`, format=`ssh`. If any missing, set `GIT_CONFIG_GLOBAL` and restart.
+7. Resolve `OPERATOR` (`$USER`) and `TOOL` (infer: `CLAUDE=1`→`claude`, `CODEX=1`→`codex`, else ask once).
 
 ## Transport detection
 

--- a/.agents/skills/legreffier/SKILL.md
+++ b/.agents/skills/legreffier/SKILL.md
@@ -188,7 +188,7 @@ When subagents are available, delegate diary entry composition (metadata gatheri
 4. Resolve diary:
    - If `MOLTNET_DIARY_ID` set, use it as `DIARY_ID`.
    - Otherwise: `REPO=$(basename $(git rev-parse --show-toplevel))`, call `diaries_list`, match `name == $REPO`. Not found → `diaries_create({ name: "$REPO", visibility: "moltnet" })`.
-   - **Onboarding nudge**: if `MOLTNET_DIARY_ID` was NOT set in `.moltnet/<AGENT_NAME>/env` and few or no entries exist in the resolved diary, mention once: "Tip: run `/legreffier-onboarding` to connect your team diary and get started with manual captures."
+   - **Onboarding nudge** (at most once per session): if `MOLTNET_DIARY_ID` was NOT set in `.moltnet/<AGENT_NAME>/env` and few or no entries exist in the resolved diary, mention: "Tip: run `/legreffier-onboarding` (or `$legreffier-onboarding` in Codex) to check your setup and start capturing knowledge."
 5. Identity check: `git config user.name && git config user.email && git config user.signingkey && git config gpg.format`. Expected: name=`AGENT_NAME`, email `...+<AGENT_NAME>[bot]@users.noreply.github.com`, signingkey=`.moltnet/<AGENT_NAME>/ssh/id_ed25519.pub`, format=`ssh`. If any missing, set `GIT_CONFIG_GLOBAL` and restart.
 6. Resolve `OPERATOR` (`$USER`) and `TOOL` (infer: `CLAUDE=1`→`claude`, `CODEX=1`→`codex`, else ask once).
 

--- a/.agents/skills/legreffier/SKILL.md
+++ b/.agents/skills/legreffier/SKILL.md
@@ -188,6 +188,7 @@ When subagents are available, delegate diary entry composition (metadata gatheri
 4. Resolve diary:
    - If `MOLTNET_DIARY_ID` set, use it as `DIARY_ID`.
    - Otherwise: `REPO=$(basename $(git rev-parse --show-toplevel))`, call `diaries_list`, match `name == $REPO`. Not found → `diaries_create({ name: "$REPO", visibility: "moltnet" })`.
+   - **Onboarding nudge**: if `MOLTNET_DIARY_ID` was NOT set in `.moltnet/<AGENT_NAME>/env` and few or no entries exist in the resolved diary, mention once: "Tip: run `/legreffier-onboarding` to connect your team diary and get started with manual captures."
 5. Identity check: `git config user.name && git config user.email && git config user.signingkey && git config gpg.format`. Expected: name=`AGENT_NAME`, email `...+<AGENT_NAME>[bot]@users.noreply.github.com`, signingkey=`.moltnet/<AGENT_NAME>/ssh/id_ed25519.pub`, format=`ssh`. If any missing, set `GIT_CONFIG_GLOBAL` and restart.
 6. Resolve `OPERATOR` (`$USER`) and `TOOL` (infer: `CLAUDE=1`→`claude`, `CODEX=1`→`codex`, else ask once).
 

--- a/.agents/skills/pre-publish/SKILL.md
+++ b/.agents/skills/pre-publish/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: pre-publish
+description: 'Validate a package before publishing to npm. Catches workspace dependency leaks, missing dist files, source leaks, and bundling issues. TRIGGER when: publishing to npm, modifying package.json dependencies of a publishable package, changing bundler config (vite.config, tsup.config), debugging npm install failures (E404, missing packages), or reviewing release-please PRs.'
+---
+
+# Pre-Publish Validation Skill
+
+Mandatory checklist before publishing any package to npm. This skill exists
+because workspace dependencies have leaked into published packages before,
+breaking `npm install` for consumers.
+
+## When to trigger
+
+- Before running `pnpm publish` or `npm publish` on any package
+- Before merging a PR that modifies `package.json` of a publishable package
+- When adding or moving dependencies in a publishable package
+- When modifying a package's Vite/bundler config
+- Any time release-please creates a release PR
+
+## Publishable packages
+
+A package is publishable if it has a `files` field in `package.json` and is
+not marked `"private": true`. Current published packages:
+
+- `@themoltnet/sdk` (libs/sdk)
+- `@themoltnet/design-system` (libs/design-system)
+- `@themoltnet/cli` (packages/cli)
+- `@themoltnet/github-agent` (packages/github-agent)
+- `@themoltnet/legreffier` (packages/legreffier-cli)
+
+## Checklist
+
+### 1. Workspace dependency placement
+
+Private workspace packages (`@moltnet/*`) must NEVER appear in `dependencies`
+of a publishable package. They are not published to npm and will cause
+`npm install` to fail.
+
+**Rule**: If a `@moltnet/*` package is imported in source code and the build
+bundles it (Vite SSR, esbuild, etc.), it belongs in `devDependencies`.
+
+Check:
+
+```bash
+grep -n '@moltnet/' <package>/package.json
+```
+
+Expected: `@moltnet/*` entries appear only under `devDependencies`, never
+under `dependencies`.
+
+**Published workspace packages** (`@themoltnet/*`) with `workspace:*` are fine
+in `dependencies` — pnpm rewrites `workspace:*` to concrete versions on
+publish.
+
+### 2. Build produces a valid bundle
+
+For bundled packages (Vite SSR), verify the bundle doesn't contain runtime
+imports to private workspace packages:
+
+```bash
+# Build the package and its workspace deps first
+pnpm --filter <package> build
+
+# Check the bundle has no @moltnet/ imports
+grep '@moltnet/' <package>/dist/index.js
+```
+
+Expected: zero matches. All `@moltnet/*` code should be inlined.
+
+### 3. Run check:pack
+
+```bash
+pnpm --filter <package> run check:pack
+```
+
+This validates:
+
+- `dist/index.js` exists in the tarball
+- `dist/index.d.ts` exists (for library packages)
+- No `src/` files leak into the tarball
+- No `@moltnet/` imports in `.d.ts` files
+- No `@moltnet/` packages in `dependencies`
+
+### 4. Verify the tarball contents
+
+```bash
+npm pack --dry-run --json 2>/dev/null | jq '.[0].files[].path'
+```
+
+Check that:
+
+- Only expected files are included (typically `dist/` and `package.json`)
+- No source files, test files, or config files leaked
+
+### 5. Test install (optional but recommended for major releases)
+
+```bash
+npm pack
+mkdir /tmp/test-install && cd /tmp/test-install
+npm init -y
+npm install <tarball-path>
+node -e "import('<package-name>')"
+```
+
+## Common mistakes and how they happen
+
+### Workspace deps in dependencies (the legreffier incident)
+
+**What happened**: `@moltnet/api-client`, `@moltnet/crypto-service`, and
+`@themoltnet/design-system` were listed in `dependencies` instead of
+`devDependencies` in `@themoltnet/legreffier`. Vite correctly bundled them
+into `dist/index.js`, but `pnpm publish` rewrote `workspace:*` to version
+numbers and shipped a `package.json` that referenced unpublished packages.
+
+**Why it wasn't caught**: The `check:pack` script only checked for
+`@moltnet/` imports in `.d.ts` files and `src/` leaks in the tarball. It
+didn't check the `dependencies` field itself.
+
+**Prevention**: The `check:pack` script now validates that no `@moltnet/*`
+packages appear in `dependencies`. Run it before every publish.
+
+### SDK pattern (correct)
+
+`@themoltnet/sdk` does it right:
+
+- `@moltnet/api-client` and `@moltnet/crypto-service` in `devDependencies`
+- `ssr.noExternal: [/@moltnet\//]` in `vite.config.ts` to explicitly bundle
+- Only `@noble/*` (published) packages in `dependencies`
+
+## Integration with CI
+
+The `check:pack` step runs in the release workflow before `pnpm publish`.
+If it fails, the publish is blocked. This is the last line of defense.
+
+```yaml
+# From .github/workflows/release.yml
+- run: pnpm --filter <package> run check:pack
+- run: pnpm --filter <package> publish --no-git-checks --access public --provenance
+```
+
+## Reminders
+
+- Moving a dependency from `dependencies` to `devDependencies` requires
+  updating the lockfile (`pnpm install`)
+- Vite SSR mode bundles workspace-symlinked packages by default (no explicit
+  `noExternal` needed), but explicit is better than implicit
+- The `files` field in `package.json` controls what goes in the tarball —
+  keep it minimal

--- a/.claude/skills/legreffier-onboarding/SKILL.md
+++ b/.claude/skills/legreffier-onboarding/SKILL.md
@@ -29,22 +29,29 @@ Store as `AGENT_NAME`. All MCP calls use `mcp__<AGENT_NAME>__*`.
 After resolving AGENT_NAME, detect available transport:
 
 1. If MCP tools are available (`moltnet_whoami` responds): use MCP.
-2. If MCP unavailable or errors: use CLI via `npx @themoltnet/cli`.
-3. **Do not mix transports within a session.**
+2. If MCP unavailable or errors: use CLI via `npx @themoltnet/cli`
+   only for supported inspection commands (see table below).
+3. If the next step requires team discovery, team member lookup, or diary
+   creation and MCP is unavailable, tell the user those operations require
+   MCP — do not guess CLI commands.
+4. **Do not mix transports within a session.**
 
 CLI credentials: `.moltnet/<AGENT_NAME>/moltnet.json`
 CLI global flags: `--credentials ".moltnet/<AGENT_NAME>/moltnet.json"`
 
 ### CLI equivalents
 
-| MCP Tool            | CLI Command                                                  |
-| ------------------- | ------------------------------------------------------------ |
-| `moltnet_whoami`    | `moltnet agents whoami`                                      |
-| `teams_list`        | `moltnet team list`                                          |
-| `team_members_list` | `moltnet team members <team-id>`                             |
-| `diaries_list`      | `moltnet diary list`                                         |
-| `diaries_create`    | `moltnet diary create --name <name> --visibility moltnet`    |
-| `entries_list`      | `moltnet entry list --diary-id <uuid> [--entry-type <type>]` |
+Only these CLI mappings are available in fallback mode:
+
+| MCP Tool         | CLI Command                                                  |
+| ---------------- | ------------------------------------------------------------ |
+| `moltnet_whoami` | `moltnet agents whoami`                                      |
+| `diaries_list`   | `moltnet diary list`                                         |
+| `entries_list`   | `moltnet entry list --diary-id <uuid> [--entry-type <type>]` |
+
+Team lookup (`teams_list`, `team_members_list`) and diary creation
+(`diaries_create`) are **MCP-only** in this skill — no reliable CLI
+equivalents exist for those operations.
 
 ---
 
@@ -83,14 +90,21 @@ Then check env for diary configuration:
 
 If `MOLTNET_DIARY_ID` is already set, skip to Stage 3.
 
-If not set, fetch remote state:
+If not set, fetch remote state (MCP required for this path):
 
 - `teams_list({})` — find teams the agent belongs to
 - Identify the first **non-personal** team (personal teams have exactly
   one member: the agent itself; use `team_members_list` to check)
-- `diaries_list({ team_id: <non-personal-team-id> })` — list team diaries
-- Match diary name against current repo name:
+- `diaries_list({})` — list all accessible diaries, then filter
+  client-side to diaries whose `teamId` matches the non-personal team
+- Match filtered diary names against current repo name:
   `REPO=$(basename $(git rev-parse --show-toplevel))`
+
+If remote API calls fail:
+
+> Could not reach the MoltNet API (`<error>`).
+> Run `moltnet env check` to validate credentials.
+> If credentials are expired, re-run `legreffier setup`.
 
 **Decision tree:**
 
@@ -149,6 +163,8 @@ Classify entries by `entryType`:
 - If total entries == 0: still stage 2 (diary exists but empty)
 - If only `procedural` entries (or `procedural` + `source:scan` semantics):
   **Stage 3 — auto-only**
+- If exactly 1 manual `semantic` or `episodic` entry exists:
+  **Stage 3 — transitional** (encourage more captures)
 - If >= 2 manual `semantic` or `episodic` entries exist: **Stage 4**
 
 **Action for Stage 3:**

--- a/.claude/skills/legreffier-onboarding/SKILL.md
+++ b/.claude/skills/legreffier-onboarding/SKILL.md
@@ -1,0 +1,265 @@
+---
+name: legreffier-onboarding
+description: 'Stateful adoption coach for LeGreffier: inspects local and remote state, classifies the current adoption stage, and suggests the next best action. Use when getting started with LeGreffier, after init/setup, when asked "what should I do next", "how do I use legreffier", "set up diary", "connect team diary", or "onboarding".'
+---
+
+# LeGreffier Onboarding Skill
+
+Adoption coach that reconstructs your current LeGreffier status from local
+and remote evidence, classifies the adoption stage, and proposes exactly
+one next action. Designed to be run repeatedly — it picks up where you
+left off.
+
+## Agent name resolution
+
+Follow the same resolution order as the main `legreffier` skill (env var ->
+argument -> gitconfig -> single `.moltnet/` subdirectory -> ask user).
+Store as `AGENT_NAME`. All MCP calls use `mcp__<AGENT_NAME>__*`.
+
+## When to trigger
+
+- After `legreffier init` or `legreffier setup` completes
+- First session in a repo with `.moltnet/` but no diary entries
+- When asked "what should I do next", "how do I use legreffier",
+  "getting started", "set up diary", "connect team diary", "onboarding"
+- When the main `legreffier` skill detects no `MOLTNET_DIARY_ID`
+
+## Transport detection
+
+After resolving AGENT_NAME, detect available transport:
+
+1. If MCP tools are available (`moltnet_whoami` responds): use MCP.
+2. If MCP unavailable or errors: use CLI via `npx @themoltnet/cli`.
+3. **Do not mix transports within a session.**
+
+CLI credentials: `.moltnet/<AGENT_NAME>/moltnet.json`
+CLI global flags: `--credentials ".moltnet/<AGENT_NAME>/moltnet.json"`
+
+### CLI equivalents
+
+| MCP Tool            | CLI Command                                                  |
+| ------------------- | ------------------------------------------------------------ |
+| `moltnet_whoami`    | `moltnet agents whoami`                                      |
+| `teams_list`        | `moltnet team list`                                          |
+| `team_members_list` | `moltnet team members <team-id>`                             |
+| `diaries_list`      | `moltnet diary list`                                         |
+| `diaries_create`    | `moltnet diary create --name <name> --visibility moltnet`    |
+| `entries_list`      | `moltnet entry list --diary-id <uuid> [--entry-type <type>]` |
+
+---
+
+## Adoption stages
+
+The skill classifies the current repo into one of four stages. Each stage
+has a detection method and a recommended action.
+
+### Stage 1: Not initialized
+
+**Detection (local only, no API calls):**
+
+- `.moltnet/` directory does not exist, OR
+- No subdirectory in `.moltnet/` contains a `moltnet.json` file
+
+**Action:**
+
+> LeGreffier is not initialized in this repository.
+> Run `npx @themoltnet/legreffier init --name <agent-name> --agent claude`
+> to set up identity, GitHub App, and MCP connection.
+
+Stop here. Do not attempt API calls without credentials.
+
+### Stage 2: Initialized but not connected to a shared diary
+
+**Detection (local first, then remote):**
+
+Local checks:
+
+- `.moltnet/<AGENT_NAME>/moltnet.json` exists and contains valid config
+- `.mcp.json` or `.codex/config.toml` exists (MCP configured)
+
+Then check env for diary configuration:
+
+- Read `.moltnet/<AGENT_NAME>/env` — is `MOLTNET_DIARY_ID` set?
+
+If `MOLTNET_DIARY_ID` is already set, skip to Stage 3.
+
+If not set, fetch remote state:
+
+- `teams_list({})` — find teams the agent belongs to
+- Identify the first **non-personal** team (personal teams have exactly
+  one member: the agent itself; use `team_members_list` to check)
+- `diaries_list({ team_id: <non-personal-team-id> })` — list team diaries
+- Match diary name against current repo name:
+  `REPO=$(basename $(git rev-parse --show-toplevel))`
+
+**Decision tree:**
+
+1. **Matching shared diary found:**
+
+   > I found diary "`<diary-name>`" (ID: `<diary-id>`) in team "`<team-name>`"
+   > which matches this repository. I can add `MOLTNET_DIARY_ID=<diary-id>`
+   > to your `.moltnet/<AGENT_NAME>/env` file so your agent writes to the
+   > shared diary automatically.
+   >
+   > This diary has `<visibility>` visibility and `<entry-count>` entries.
+   >
+   > Shall I configure it?
+
+   Wait for explicit confirmation before writing to the env file.
+
+2. **Non-personal team exists but no matching diary:**
+
+   > You're a member of team "`<team-name>`" but there's no shared diary
+   > matching this repository ("`<repo-name>`").
+   >
+   > Options:
+   >
+   > - Create a new shared diary: run `/legreffier` and it will create one
+   >   with `moltnet` visibility
+   > - Ask your team lead for the diary ID and set it manually:
+   >   `MOLTNET_DIARY_ID=<uuid>` in `.moltnet/<AGENT_NAME>/env`
+
+3. **No non-personal team found:**
+
+   > You're only in your personal team. For solo use, `/legreffier` will
+   > create a personal diary automatically. For team use, ask your team
+   > lead to invite you to a team first.
+
+### Stage 3: Connected but only auto-harvesting
+
+**Detection (requires API calls):**
+
+Resolve `DIARY_ID` from env or by matching repo name via `diaries_list`.
+
+Fetch entry mix:
+
+```
+entries_list({ diary_id: DIARY_ID, limit: 50 })
+```
+
+Classify entries by `entryType`:
+
+- Count `procedural` entries (auto-harvested commits)
+- Count `semantic` entries NOT tagged `source:scan` (manual decisions)
+- Count `episodic` entries (manual incidents)
+- Count `reflection` entries
+
+**Classification:**
+
+- If total entries == 0: still stage 2 (diary exists but empty)
+- If only `procedural` entries (or `procedural` + `source:scan` semantics):
+  **Stage 3 — auto-only**
+- If >= 2 manual `semantic` or `episodic` entries exist: **Stage 4**
+
+**Action for Stage 3:**
+
+> Your commit capture flow is active — `<procedural-count>` procedural
+> entries recorded. But you have no episodic or semantic entries yet.
+>
+> **Next step: capture your first incident or decision.**
+>
+> - When something breaks or surprises you, write an `episodic` entry:
+>   "What happened, root cause, fix applied, watch for"
+> - When you make an architectural choice, write a `semantic` entry:
+>   "Decision, alternatives, reason chosen, trade-offs"
+>
+> The main `/legreffier` skill handles this automatically — just work
+> normally and it will prompt you at the right moments.
+
+If scan entries exist but no manual entries:
+
+> You ran a codebase scan (`<scan-count>` entries). That's a good
+> foundation. The next step is capturing live knowledge: incidents and
+> decisions as they happen during real work sessions.
+
+### Stage 4: Manual capture established
+
+**Detection:** >= 2 manual `semantic` or `episodic` entries exist.
+
+**Action:**
+
+> You're actively capturing knowledge — `<semantic-count>` decisions,
+> `<episodic-count>` incidents, `<procedural-count>` commits recorded.
+>
+> **Next step: explore and compile.**
+>
+> Run `/legreffier-explore` to discover patterns in your diary and
+> design compile recipes. Then use `/legreffier-consolidate` to build
+> entry relations and prepare for context packs.
+>
+> See the co-located reference doc for the full harvest -> compile ->
+> evaluate -> load pipeline.
+
+---
+
+## Execution flow
+
+On every invocation:
+
+1. **Resolve agent** (same as main legreffier skill)
+2. **Stage 1 checks** — local file inspection only. If not initialized, stop.
+3. **Stage 2 checks** — read env file, then remote calls if needed.
+   If diary not connected, suggest and stop.
+4. **Stage 3-4 checks** — fetch entry mix, classify.
+5. **Output**: current stage label + one primary action.
+
+### Performance notes
+
+- Stages 1-2 require zero or minimal API calls (only `teams_list` +
+  `diaries_list` if diary not yet configured)
+- Stages 3-4 require one `entries_list` call
+- No unnecessary enumeration — fetch only what's needed for classification
+
+---
+
+## Safeguards
+
+- **Never silently overwrite `MOLTNET_DIARY_ID`** — always show the diary
+  name, team, and visibility before proposing a change
+- **Distinguish personal vs shared diary** — state which diary type is
+  being configured
+- **Require explicit confirmation** before writing to env file
+- **Check diary visibility** — warn if the candidate diary is `private`
+  (entries won't be indexed for search)
+
+---
+
+## MCP tool reference
+
+| Tool                | Purpose                            |
+| ------------------- | ---------------------------------- |
+| `moltnet_whoami`    | Verify agent identity              |
+| `teams_list`        | List teams the agent belongs to    |
+| `team_members_list` | Check team membership (personal?)  |
+| `diaries_list`      | Find diaries by team               |
+| `diaries_get`       | Get diary metadata                 |
+| `entries_list`      | Fetch entries for stage assessment |
+
+---
+
+## Internal references
+
+- `references/onboarding-guide.md` — co-located onboarding reference
+  derived from `docs/GETTING_STARTED.md`. Covers install, harvest,
+  compile, evaluate, and load stages.
+
+If that reference file is missing, warn that the skill bundle is
+incomplete but continue with stage detection (the reference is for
+user guidance, not skill logic).
+
+---
+
+## Recovery after context compression
+
+1. Read this skill file
+2. Re-run stage detection from the top (stages 1-2 are fast and local)
+3. If previous output is visible in conversation, skip to the next action
+
+## UX rules
+
+- **Lead with evidence, not questions.** Show what you found, then propose.
+- **One action per invocation.** Don't overwhelm with a roadmap.
+- **No open-ended prompts.** Never ask "What do you want to do?" — always
+  propose a specific next step based on detected state.
+- **Idempotent.** Running the skill twice in the same state produces the
+  same suggestion.

--- a/.claude/skills/legreffier-onboarding/SKILL.md
+++ b/.claude/skills/legreffier-onboarding/SKILL.md
@@ -84,19 +84,39 @@ Local checks:
 - `.moltnet/<AGENT_NAME>/moltnet.json` exists and contains valid config
 - `.mcp.json` or `.codex/config.toml` exists (MCP configured)
 
-Then check env for diary configuration:
+Then check env for diary and team configuration:
 
 - Read `.moltnet/<AGENT_NAME>/env` — is `MOLTNET_DIARY_ID` set?
+- Read `.moltnet/<AGENT_NAME>/env` — is `MOLTNET_TEAM_ID` set?
 
 If `MOLTNET_DIARY_ID` is already set, skip to Stage 3.
 
 If not set, fetch remote state (MCP required for this path):
 
-- `teams_list({})` — find teams the agent belongs to
-- Identify the first **non-personal** team (personal teams have exactly
-  one member: the agent itself; use `team_members_list` to check)
+**Team resolution:**
+
+- If `MOLTNET_TEAM_ID` is set in env, use it directly as `TEAM_ID`.
+- Otherwise: `teams_list({})` — list all teams the agent belongs to.
+  Classify each team:
+  - **Personal team**: has exactly one member (the agent itself; use
+    `team_members_list` to check)
+  - **Shared team**: has more than one member
+- If exactly one shared team exists, use it as `TEAM_ID`.
+- If multiple shared teams exist, list them and ask the user to pick:
+
+  > You belong to multiple teams:
+  >
+  > 1. "`<team-1-name>`" (`<team-1-id>`)
+  > 2. "`<team-2-name>`" (`<team-2-id>`)
+  >
+  > Which team should this repository use?
+
+- If no shared teams exist, fall back to the personal team as `TEAM_ID`.
+
+**Diary resolution:**
+
 - `diaries_list({})` — list all accessible diaries, then filter
-  client-side to diaries whose `teamId` matches the non-personal team
+  client-side to diaries whose `teamId` matches `TEAM_ID`
 - Match filtered diary names against current repo name:
   `REPO=$(basename $(git rev-parse --show-toplevel))`
 
@@ -111,15 +131,20 @@ If remote API calls fail:
 1. **Matching shared diary found:**
 
    > I found diary "`<diary-name>`" (ID: `<diary-id>`) in team "`<team-name>`"
-   > which matches this repository. I can add `MOLTNET_DIARY_ID=<diary-id>`
-   > to your `.moltnet/<AGENT_NAME>/env` file so your agent writes to the
-   > shared diary automatically.
+   > (ID: `<team-id>`) which matches this repository. I can add these to
+   > your `.moltnet/<AGENT_NAME>/env` file:
+   >
+   > ```
+   > MOLTNET_TEAM_ID='<team-id>'
+   > MOLTNET_DIARY_ID='<diary-id>'
+   > ```
    >
    > This diary has `<visibility>` visibility and `<entry-count>` entries.
    >
    > Shall I configure it?
 
    Wait for explicit confirmation before writing to the env file.
+   Write both `MOLTNET_TEAM_ID` and `MOLTNET_DIARY_ID` together.
 
 2. **Non-personal team exists but no matching diary:**
 
@@ -130,8 +155,9 @@ If remote API calls fail:
    >
    > - Create a new shared diary: run `/legreffier` and it will create one
    >   with `moltnet` visibility
-   > - Ask your team lead for the diary ID and set it manually:
-   >   `MOLTNET_DIARY_ID=<uuid>` in `.moltnet/<AGENT_NAME>/env`
+   > - Ask your team lead for the diary ID and team ID and set them
+   >   manually in `.moltnet/<AGENT_NAME>/env`:
+   >   `MOLTNET_TEAM_ID=<team-uuid>` and `MOLTNET_DIARY_ID=<diary-uuid>`
 
 3. **No non-personal team found:**
 

--- a/.claude/skills/legreffier-onboarding/SKILL.md
+++ b/.claude/skills/legreffier-onboarding/SKILL.md
@@ -70,8 +70,17 @@ has a detection method and a recommended action.
 **Action:**
 
 > LeGreffier is not initialized in this repository.
+>
+> **Option A — Fresh setup:**
 > Run `npx @themoltnet/legreffier init --name <agent-name> --agent claude`
-> to set up identity, GitHub App, and MCP connection.
+> to create a new identity, GitHub App, and MCP connection.
+>
+> **Option B — Reuse an existing agent:**
+> If you already have a `.moltnet/<agent-name>/` directory in another
+> repository, you can port it here:
+> `npx @themoltnet/legreffier port --name <agent-name> --from <source-repo> --agent claude`
+> This copies credentials, rewrites paths, and configures the diary
+> for this repo — much faster than a full init.
 
 Stop here. Do not attempt API calls without credentials.
 

--- a/.claude/skills/legreffier-onboarding/references/onboarding-guide.md
+++ b/.claude/skills/legreffier-onboarding/references/onboarding-guide.md
@@ -1,0 +1,145 @@
+# LeGreffier Onboarding Reference
+
+Derived from `docs/GETTING_STARTED.md`. This co-located reference ships
+with the onboarding skill so it works offline after installation.
+
+---
+
+## The five stages
+
+From zero to measurable agent context:
+**install** -> **harvest** -> **compile** -> **evaluate** -> **load**.
+
+The onboarding skill covers install and early harvest. Later stages
+(compile, evaluate, load) are introduced once manual capture is
+established.
+
+---
+
+## Install and Initialize
+
+### Install packages
+
+```bash
+npm install -g @themoltnet/cli @themoltnet/legreffier
+```
+
+Or run directly:
+
+```bash
+npx @themoltnet/legreffier init --name <agent-name> --agent claude
+```
+
+Requirements: Node.js >= 22, GitHub account, MoltNet account.
+
+### Init phases
+
+| Phase               | What happens                                                     |
+| ------------------- | ---------------------------------------------------------------- |
+| **1. Identity**     | Generates Ed25519 keypair, registers on MoltNet API              |
+| **2. GitHub App**   | Opens browser to create a GitHub App via manifest flow           |
+| **3. Git setup**    | Writes gitconfig with SSH signing key, bot identity, credentials |
+| **4. Installation** | Installs the GitHub App on selected repositories (OAuth2 flow)   |
+| **5. Agent setup**  | Downloads skills, writes MCP config, agent-specific settings     |
+
+### What gets created
+
+```
+<repo>/
++-- .moltnet/<agent-name>/
+|   +-- moltnet.json            # Identity, keys, OAuth2, endpoints
+|   +-- gitconfig               # Git identity + SSH signing
+|   +-- <app-slug>.pem          # GitHub App private key
+|   +-- env                     # Sourceable env vars
+|   +-- ssh/
+|       +-- id_ed25519          # SSH private key
+|       +-- id_ed25519.pub      # SSH public key
++-- .mcp.json                   # Claude Code MCP config
++-- .claude/
+|   +-- settings.local.json     # Credential env vars (gitignored)
+|   +-- skills/                 # Downloaded skills
++-- .codex/config.toml          # (if --agent codex)
++-- .agents/skills/             # (if --agent codex)
+```
+
+### Session launcher
+
+```bash
+moltnet env check       # Validate setup
+moltnet start claude    # Start with resolved agent env
+moltnet use <agent>     # Switch default agent
+```
+
+### Reconfigure agents later
+
+```bash
+npx @themoltnet/legreffier setup --name <agent-name> --agent claude --agent codex
+```
+
+---
+
+## Task Harvesting
+
+### Activate LeGreffier
+
+Claude Code: `/legreffier` (or automatic via `GIT_CONFIG_GLOBAL`)
+Codex: `$legreffier`
+
+### Accountable commits (automatic)
+
+Every commit through the LeGreffier workflow creates a `procedural`
+diary entry tagged `accountable-commit`. The commit is signed with SSH
+and linked via `MoltNet-Diary: <entry-id>` trailer.
+
+### Manual entry types
+
+| Type         | When                            | Tags                                  |
+| ------------ | ------------------------------- | ------------------------------------- |
+| `procedural` | Accountable commits             | `accountable-commit`, `risk`, `scope` |
+| `semantic`   | Architectural decisions         | `decision`, `scope:<area>`            |
+| `episodic`   | Incidents, workarounds, bugs    | `incident`, `scope:<area>`            |
+| `reflection` | End-of-session pattern analysis | `reflection`, `branch`                |
+
+**Episodic entries** are highest-signal for onboarding: write immediately
+when something breaks, a workaround is applied, or a surprise occurs.
+
+**Semantic entries** capture "why" decisions: what was chosen, what was
+rejected, and why.
+
+### Codebase scanning (bulk)
+
+```
+/legreffier-scan
+```
+
+Creates `semantic` entries tagged `source:scan` across the codebase.
+Good foundation but not a substitute for live incident/decision capture.
+
+### Team-scoped diaries
+
+Diaries are team-scoped. Access starts with team membership and can be
+expanded with per-diary grants.
+
+Team onboarding:
+
+1. Tech lead creates team and shared diary
+2. Team diary ID is shared with collaborators
+3. Each dev sets `MOLTNET_DIARY_ID=<uuid>` in `.moltnet/<agent>/env`
+
+**Important:** Create diaries with `moltnet` visibility (not `private`).
+Private diaries don't index entries for vector search.
+
+---
+
+## What comes next (after onboarding)
+
+Once you have meaningful manual captures (decisions + incidents):
+
+1. **Explore**: `/legreffier-explore` — discover diary patterns and gaps
+2. **Consolidate**: `/legreffier-consolidate` — build entry relations
+3. **Compile**: `moltnet diary compile <id> --token-budget N` — create packs
+4. **Evaluate**: `moltnet eval run --scenario <dir> --pack <md>` — measure
+5. **Load**: inject rendered packs into agent context at session start
+
+See `docs/GETTING_STARTED.md` in the MoltNet repository for the full
+pipeline documentation.

--- a/.claude/skills/legreffier-onboarding/references/onboarding-guide.md
+++ b/.claude/skills/legreffier-onboarding/references/onboarding-guide.md
@@ -123,8 +123,9 @@ expanded with per-diary grants.
 Team onboarding:
 
 1. Tech lead creates team and shared diary
-2. Team diary ID is shared with collaborators
-3. Each dev sets `MOLTNET_DIARY_ID=<uuid>` in `.moltnet/<agent>/env`
+2. Team ID and diary ID are shared with collaborators
+3. Each dev sets `MOLTNET_TEAM_ID=<team-uuid>` and
+   `MOLTNET_DIARY_ID=<diary-uuid>` in `.moltnet/<agent>/env`
 
 **Important:** Create diaries with `moltnet` visibility (not `private`).
 Private diaries don't index entries for vector search.

--- a/.claude/skills/legreffier/SKILL.md
+++ b/.claude/skills/legreffier/SKILL.md
@@ -185,12 +185,15 @@ When subagents are available, delegate diary entry composition (metadata gatheri
    - If `MOLTNET_FINGERPRINT` set, use it (skip `moltnet_whoami`).
    - Otherwise call `moltnet_whoami`. If whoami/soul missing, read `moltnet://self/whoami` and `moltnet://self/soul`; if still missing, run `identity_bootstrap`.
    - **Hard gate**: unknown fingerprint after above steps → stop. "Identity incomplete — run `identity_bootstrap` before continuing."
-4. Resolve diary:
+4. Resolve team:
+   - If `MOLTNET_TEAM_ID` set in `.moltnet/<AGENT_NAME>/env`, use it as `TEAM_ID`.
+   - Otherwise: the diary resolution below uses `diaries_list` without team filtering. The personal team is used implicitly when creating a new diary.
+5. Resolve diary:
    - If `MOLTNET_DIARY_ID` set, use it as `DIARY_ID`.
    - Otherwise: `REPO=$(basename $(git rev-parse --show-toplevel))`, call `diaries_list`, match `name == $REPO`. Not found → `diaries_create({ name: "$REPO", visibility: "moltnet" })`.
    - **Onboarding nudge** (at most once per session): if `MOLTNET_DIARY_ID` was NOT set in `.moltnet/<AGENT_NAME>/env` and few or no entries exist in the resolved diary, mention: "Tip: run `/legreffier-onboarding` (or `$legreffier-onboarding` in Codex) to check your setup and start capturing knowledge."
-5. Identity check: `git config user.name && git config user.email && git config user.signingkey && git config gpg.format`. Expected: name=`AGENT_NAME`, email `...+<AGENT_NAME>[bot]@users.noreply.github.com`, signingkey=`.moltnet/<AGENT_NAME>/ssh/id_ed25519.pub`, format=`ssh`. If any missing, set `GIT_CONFIG_GLOBAL` and restart.
-6. Resolve `OPERATOR` (`$USER`) and `TOOL` (infer: `CLAUDE=1`→`claude`, `CODEX=1`→`codex`, else ask once).
+6. Identity check: `git config user.name && git config user.email && git config user.signingkey && git config gpg.format`. Expected: name=`AGENT_NAME`, email `...+<AGENT_NAME>[bot]@users.noreply.github.com`, signingkey=`.moltnet/<AGENT_NAME>/ssh/id_ed25519.pub`, format=`ssh`. If any missing, set `GIT_CONFIG_GLOBAL` and restart.
+7. Resolve `OPERATOR` (`$USER`) and `TOOL` (infer: `CLAUDE=1`→`claude`, `CODEX=1`→`codex`, else ask once).
 
 ## Transport detection
 

--- a/.claude/skills/legreffier/SKILL.md
+++ b/.claude/skills/legreffier/SKILL.md
@@ -188,7 +188,7 @@ When subagents are available, delegate diary entry composition (metadata gatheri
 4. Resolve diary:
    - If `MOLTNET_DIARY_ID` set, use it as `DIARY_ID`.
    - Otherwise: `REPO=$(basename $(git rev-parse --show-toplevel))`, call `diaries_list`, match `name == $REPO`. Not found → `diaries_create({ name: "$REPO", visibility: "moltnet" })`.
-   - **Onboarding nudge**: if `MOLTNET_DIARY_ID` was NOT set in `.moltnet/<AGENT_NAME>/env` and few or no entries exist in the resolved diary, mention once: "Tip: run `/legreffier-onboarding` to connect your team diary and get started with manual captures."
+   - **Onboarding nudge** (at most once per session): if `MOLTNET_DIARY_ID` was NOT set in `.moltnet/<AGENT_NAME>/env` and few or no entries exist in the resolved diary, mention: "Tip: run `/legreffier-onboarding` (or `$legreffier-onboarding` in Codex) to check your setup and start capturing knowledge."
 5. Identity check: `git config user.name && git config user.email && git config user.signingkey && git config gpg.format`. Expected: name=`AGENT_NAME`, email `...+<AGENT_NAME>[bot]@users.noreply.github.com`, signingkey=`.moltnet/<AGENT_NAME>/ssh/id_ed25519.pub`, format=`ssh`. If any missing, set `GIT_CONFIG_GLOBAL` and restart.
 6. Resolve `OPERATOR` (`$USER`) and `TOOL` (infer: `CLAUDE=1`→`claude`, `CODEX=1`→`codex`, else ask once).
 

--- a/.claude/skills/legreffier/SKILL.md
+++ b/.claude/skills/legreffier/SKILL.md
@@ -188,6 +188,7 @@ When subagents are available, delegate diary entry composition (metadata gatheri
 4. Resolve diary:
    - If `MOLTNET_DIARY_ID` set, use it as `DIARY_ID`.
    - Otherwise: `REPO=$(basename $(git rev-parse --show-toplevel))`, call `diaries_list`, match `name == $REPO`. Not found → `diaries_create({ name: "$REPO", visibility: "moltnet" })`.
+   - **Onboarding nudge**: if `MOLTNET_DIARY_ID` was NOT set in `.moltnet/<AGENT_NAME>/env` and few or no entries exist in the resolved diary, mention once: "Tip: run `/legreffier-onboarding` to connect your team diary and get started with manual captures."
 5. Identity check: `git config user.name && git config user.email && git config user.signingkey && git config gpg.format`. Expected: name=`AGENT_NAME`, email `...+<AGENT_NAME>[bot]@users.noreply.github.com`, signingkey=`.moltnet/<AGENT_NAME>/ssh/id_ed25519.pub`, format=`ssh`. If any missing, set `GIT_CONFIG_GLOBAL` and restart.
 6. Resolve `OPERATOR` (`$USER`) and `TOOL` (infer: `CLAUDE=1`→`claude`, `CODEX=1`→`codex`, else ask once).
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -196,11 +196,12 @@ registry for discovery and distribution.
 
 ### 1.10 Guided onboarding (recommended after init)
 
-After init, run the onboarding skill in your next coding session to connect
-your team diary and start capturing knowledge:
+After init, run the onboarding skill in your next coding session to check
+your setup and start capturing knowledge:
 
 ```
-/legreffier-onboarding
+/legreffier-onboarding     # Claude Code
+$legreffier-onboarding     # Codex
 ```
 
 The onboarding skill inspects your local and remote state, classifies your

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -194,6 +194,19 @@ The advantage of Tessl tiles over direct skill download: they are versioned,
 carry eval scenarios for quality measurement, and integrate with the Tessl
 registry for discovery and distribution.
 
+### 1.10 Guided onboarding (recommended after init)
+
+After init, run the onboarding skill in your next coding session to connect
+your team diary and start capturing knowledge:
+
+```
+/legreffier-onboarding
+```
+
+The onboarding skill inspects your local and remote state, classifies your
+adoption stage, and suggests exactly one next action. It works repeatedly —
+run it any time to check where you are in the adoption flow.
+
 ---
 
 ## Stage 2: Task Harvesting

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -154,8 +154,9 @@ The env file is merge-updated by `legreffier init/setup`:
 Team onboarding flow:
 
 1. Tech lead creates team and shared diary
-2. Team diary ID is shared with collaborators
-3. Each dev sets `MOLTNET_DIARY_ID=<shared-diary-uuid>` in `.moltnet/<agent>/env`
+2. Team ID and diary ID are shared with collaborators
+3. Each dev sets `MOLTNET_TEAM_ID=<team-uuid>` and
+   `MOLTNET_DIARY_ID=<shared-diary-uuid>` in `.moltnet/<agent>/env`
 4. Each dev runs `moltnet start claude` (or `moltnet start codex`)
 
 Solo flow:

--- a/libs/design-system/src/cli/CliSummaryBox.tsx
+++ b/libs/design-system/src/cli/CliSummaryBox.tsx
@@ -62,6 +62,17 @@ export function CliSummaryBox({
           {'  '}Run <Text color={cliTheme.color.accent}>git commit</Text>
           {' in any repo where the app is installed.'}
         </Text>
+        <Text> </Text>
+        <Text color={cliTheme.color.text}>
+          {'  '}
+          <Text color={cliTheme.color.primary}>Next step:</Text>
+          {' run '}
+          <Text color={cliTheme.color.accent}>/legreffier-onboarding</Text>
+          {' in your next session'}
+        </Text>
+        <Text color={cliTheme.color.muted}>
+          {'  '}to connect your team diary and start capturing knowledge.
+        </Text>
       </Box>
     </Box>
   );

--- a/libs/design-system/src/cli/CliSummaryBox.tsx
+++ b/libs/design-system/src/cli/CliSummaryBox.tsx
@@ -68,6 +68,8 @@ export function CliSummaryBox({
           <Text color={cliTheme.color.primary}>Next step:</Text>
           {' run '}
           <Text color={cliTheme.color.accent}>/legreffier-onboarding</Text>
+          {' or '}
+          <Text color={cliTheme.color.accent}>$legreffier-onboarding</Text>
           {' in your next session'}
         </Text>
         <Text color={cliTheme.color.muted}>

--- a/packages/legreffier-cli/src/setup.ts
+++ b/packages/legreffier-cli/src/setup.ts
@@ -29,6 +29,10 @@ const SKILLS: SkillDefinition[] = [
     name: 'legreffier-explore',
     files: ['SKILL.md', 'references/exploration-pack-plan.yaml'],
   },
+  {
+    name: 'legreffier-onboarding',
+    files: ['SKILL.md', 'references/onboarding-guide.md'],
+  },
 ];
 
 async function downloadSkillFiles(

--- a/tiles/legreffier-explore/skills/legreffier-explore/SKILL.md
+++ b/tiles/legreffier-explore/skills/legreffier-explore/SKILL.md
@@ -359,6 +359,28 @@ The preview uses the server-side renderer to produce each entry with title,
 content, CID, compression level, and token counts. This deterministic output
 can be reformatted into structured documentation for a Tessl docs tile.
 
+### Exporting provenance
+
+Export the provenance graph for a pack to trace which entries were included
+and which prior packs it supersedes:
+
+```bash
+npx @themoltnet/cli pack provenance --pack-id <uuid>
+npx @themoltnet/cli pack provenance --pack-id <uuid> --out provenance.json
+npx @themoltnet/cli pack provenance --pack-cid <cid>
+```
+
+Generate a shareable viewer URL:
+
+```bash
+npx @themoltnet/cli pack provenance --pack-id <uuid> \
+  --share-url https://themolt.net/labs/provenance
+```
+
+The `--depth` flag (default 2) controls how many levels of pack supersession
+ancestry to follow. The output conforms to the `moltnet.provenance-graph/v1`
+format and can be pasted into the viewer at `https://themolt.net/labs/provenance`.
+
 ## Recovery after context compression
 
 1. Read this skill file

--- a/tiles/legreffier/skills/legreffier/SKILL.md
+++ b/tiles/legreffier/skills/legreffier/SKILL.md
@@ -185,12 +185,15 @@ When subagents are available, delegate diary entry composition (metadata gatheri
    - If `MOLTNET_FINGERPRINT` set, use it (skip `moltnet_whoami`).
    - Otherwise call `moltnet_whoami`. If whoami/soul missing, read `moltnet://self/whoami` and `moltnet://self/soul`; if still missing, run `identity_bootstrap`.
    - **Hard gate**: unknown fingerprint after above steps → stop. "Identity incomplete — run `identity_bootstrap` before continuing."
-4. Resolve diary:
+4. Resolve team:
+   - If `MOLTNET_TEAM_ID` set in `.moltnet/<AGENT_NAME>/env`, use it as `TEAM_ID`.
+   - Otherwise: the diary resolution below uses `diaries_list` without team filtering. The personal team is used implicitly when creating a new diary.
+5. Resolve diary:
    - If `MOLTNET_DIARY_ID` set, use it as `DIARY_ID`.
    - Otherwise: `REPO=$(basename $(git rev-parse --show-toplevel))`, call `diaries_list`, match `name == $REPO`. Not found → `diaries_create({ name: "$REPO", visibility: "moltnet" })`.
    - **Onboarding nudge** (at most once per session): if `MOLTNET_DIARY_ID` was NOT set in `.moltnet/<AGENT_NAME>/env` and few or no entries exist in the resolved diary, mention: "Tip: run `/legreffier-onboarding` (or `$legreffier-onboarding` in Codex) to check your setup and start capturing knowledge."
-5. Identity check: `git config user.name && git config user.email && git config user.signingkey && git config gpg.format`. Expected: name=`AGENT_NAME`, email `...+<AGENT_NAME>[bot]@users.noreply.github.com`, signingkey=`.moltnet/<AGENT_NAME>/ssh/id_ed25519.pub`, format=`ssh`. If any missing, set `GIT_CONFIG_GLOBAL` and restart.
-6. Resolve `OPERATOR` (`$USER`) and `TOOL` (infer: `CLAUDE=1`→`claude`, `CODEX=1`→`codex`, else ask once).
+6. Identity check: `git config user.name && git config user.email && git config user.signingkey && git config gpg.format`. Expected: name=`AGENT_NAME`, email `...+<AGENT_NAME>[bot]@users.noreply.github.com`, signingkey=`.moltnet/<AGENT_NAME>/ssh/id_ed25519.pub`, format=`ssh`. If any missing, set `GIT_CONFIG_GLOBAL` and restart.
+7. Resolve `OPERATOR` (`$USER`) and `TOOL` (infer: `CLAUDE=1`→`claude`, `CODEX=1`→`codex`, else ask once).
 
 ## Transport detection
 

--- a/tiles/legreffier/skills/legreffier/SKILL.md
+++ b/tiles/legreffier/skills/legreffier/SKILL.md
@@ -188,7 +188,7 @@ When subagents are available, delegate diary entry composition (metadata gatheri
 4. Resolve diary:
    - If `MOLTNET_DIARY_ID` set, use it as `DIARY_ID`.
    - Otherwise: `REPO=$(basename $(git rev-parse --show-toplevel))`, call `diaries_list`, match `name == $REPO`. Not found → `diaries_create({ name: "$REPO", visibility: "moltnet" })`.
-   - **Onboarding nudge**: if `MOLTNET_DIARY_ID` was NOT set in `.moltnet/<AGENT_NAME>/env` and few or no entries exist in the resolved diary, mention once: "Tip: run `/legreffier-onboarding` to connect your team diary and get started with manual captures."
+   - **Onboarding nudge** (at most once per session): if `MOLTNET_DIARY_ID` was NOT set in `.moltnet/<AGENT_NAME>/env` and few or no entries exist in the resolved diary, mention: "Tip: run `/legreffier-onboarding` (or `$legreffier-onboarding` in Codex) to check your setup and start capturing knowledge."
 5. Identity check: `git config user.name && git config user.email && git config user.signingkey && git config gpg.format`. Expected: name=`AGENT_NAME`, email `...+<AGENT_NAME>[bot]@users.noreply.github.com`, signingkey=`.moltnet/<AGENT_NAME>/ssh/id_ed25519.pub`, format=`ssh`. If any missing, set `GIT_CONFIG_GLOBAL` and restart.
 6. Resolve `OPERATOR` (`$USER`) and `TOOL` (infer: `CLAUDE=1`→`claude`, `CODEX=1`→`codex`, else ask once).
 

--- a/tiles/legreffier/skills/legreffier/SKILL.md
+++ b/tiles/legreffier/skills/legreffier/SKILL.md
@@ -188,6 +188,7 @@ When subagents are available, delegate diary entry composition (metadata gatheri
 4. Resolve diary:
    - If `MOLTNET_DIARY_ID` set, use it as `DIARY_ID`.
    - Otherwise: `REPO=$(basename $(git rev-parse --show-toplevel))`, call `diaries_list`, match `name == $REPO`. Not found → `diaries_create({ name: "$REPO", visibility: "moltnet" })`.
+   - **Onboarding nudge**: if `MOLTNET_DIARY_ID` was NOT set in `.moltnet/<AGENT_NAME>/env` and few or no entries exist in the resolved diary, mention once: "Tip: run `/legreffier-onboarding` to connect your team diary and get started with manual captures."
 5. Identity check: `git config user.name && git config user.email && git config user.signingkey && git config gpg.format`. Expected: name=`AGENT_NAME`, email `...+<AGENT_NAME>[bot]@users.noreply.github.com`, signingkey=`.moltnet/<AGENT_NAME>/ssh/id_ed25519.pub`, format=`ssh`. If any missing, set `GIT_CONFIG_GLOBAL` and restart.
 6. Resolve `OPERATOR` (`$USER`) and `TOOL` (infer: `CLAUDE=1`→`claude`, `CODEX=1`→`codex`, else ask once).
 


### PR DESCRIPTION
## Summary

- Add new `legreffier-onboarding` skill that provides stateful adoption coaching for LeGreffier users
- Skill inspects local and remote state, classifies adoption stage (1-4), and suggests exactly one next action
- Includes comprehensive reference guide for install, harvest, compile, evaluate, and load pipeline stages
- Update init summary to direct users to run onboarding skill in their next session

## Changes

**New skill files:**
- `.agents/skills/legreffier-onboarding/SKILL.md` and `.claude/skills/legreffier-onboarding/SKILL.md` — Complete skill specification covering:
  - Agent name resolution and transport detection (MCP vs CLI)
  - Four adoption stages with detection methods and recommended actions
  - Stage 1: Not initialized (local checks only)
  - Stage 2: Initialized but no shared diary (remote team/diary matching)
  - Stage 3: Connected but auto-harvesting only (entry classification)
  - Stage 4: Manual capture established (ready for explore/consolidate)
  - Execution flow, performance notes, and safeguards
  - UX rules: evidence-first, one action per invocation, idempotent

- `.agents/skills/legreffier-onboarding/references/onboarding-guide.md` and `.claude/skills/legreffier-onboarding/references/onboarding-guide.md` — Offline reference guide covering:
  - Five-stage pipeline: install → harvest → compile → evaluate → load
  - Init phases and directory structure created
  - Task harvesting: accountable commits, manual entry types, codebase scanning
  - Team-scoped diary setup and visibility requirements

**Updated files:**
- `docs/GETTING_STARTED.md` — Added section 1.10 recommending onboarding skill after init
- `libs/design-system/src/cli/CliSummaryBox.tsx` — Updated init summary to prompt users to run `/legreffier-onboarding` in next session
- `packages/legreffier-cli/src/setup.ts` — Registered onboarding skill in skill download list
- `.agents/skills/legreffier/SKILL.md` and `.claude/skills/legreffier/SKILL.md` — Added reference to onboarding skill when `MOLTNET_DIARY_ID` is not set

## Test plan

- Skill files are documentation-driven; no automated tests needed
- Verify skill is registered in setup.ts and downloads correctly
- Manual verification: run `/legreffier-onboarding` after init to confirm stage detection and action suggestions work as documented

Related to #737 