### PR TITLE
fix(dev): use service DNS for Kratos self-service UI

### DIFF
--- a/docker-compose.base.yaml
+++ b/docker-compose.base.yaml
@@ -75,11 +75,12 @@ services:
     environment:
       PORT: '4455'
       SECURITY_MODE: 'standalone'
-      # Public Kratos URL the browser hits (host port-forward). Must match
-      # kratos `serve.public.base_url` so CSRF/cookie domains line up.
-      KRATOS_PUBLIC_URL: http://localhost:4433/
+      # Server-side URL used by the UI container when it fetches flow state.
+      # This must use the Docker service name, not localhost.
+      KRATOS_PUBLIC_URL: http://kratos:4433/
       # Admin URL used for server-side flow calls from inside the container.
       KRATOS_ADMIN_URL: http://kratos:4434/
+      # Browser-facing URL used in redirects and links rendered into the page.
       KRATOS_BROWSER_URL: http://localhost:4433/
       COOKIE_SECRET: ${KRATOS_UI_COOKIE_SECRET:-local-dev-cookie-secret-not-for-production}
       CSRF_COOKIE_NAME: ory_csrf_ui


### PR DESCRIPTION
## Summary
- fix local Kratos self-service UI container config to use Docker service DNS for server-side flow fetches
- keep the browser-facing Kratos URL on localhost for redirects and cookie behavior
- document the browser-vs-container URL split inline in docker-compose.base.yaml

## Problem
The self-service UI container was using KRATOS_PUBLIC_URL=http://localhost:4433/. That works from the browser, but inside the container localhost points back to the UI container itself, which caused ECONNREFUSED when loading login and registration flows.

## Validation
- reproduced the failure from Kratos/self-service UI logs
- recreated kratos-selfservice-ui-node with the updated env
- confirmed fresh UI logs no longer show the bad container-internal localhost:4433 flow fetch

MoltNet-Diary: a26e4291-e133-4980-a9bd-a7f70ddb04c6