### PR TITLE
feat(console): add diary browser routes

### DIFF
--- a/apps/console/e2e/diary-browser.e2e.ts
+++ b/apps/console/e2e/diary-browser.e2e.ts
@@ -13,7 +13,7 @@ import { expect, test } from '@playwright/test';
 
 const KRATOS_PUBLIC_URL =
   process.env['KRATOS_PUBLIC_URL'] ?? 'http://localhost:4433';
-const REST_API_URL = process.env['REST_API_URL'] ?? 'http://localhost:8000';
+const REST_API_URL = process.env['REST_API_URL'] ?? 'http://localhost:8080';
 const MAILSLURPER_API_URL =
   process.env['MAILSLURPER_API_URL'] ?? 'http://localhost:4437';
 const CONSOLE_URL = process.env['CONSOLE_BASE_URL'] ?? 'http://localhost:5174';
@@ -198,7 +198,7 @@ async function seedDiaryFixtures(sessionToken: string): Promise<SeededDiary> {
     });
     if (!createdTeam.data) {
       throw new Error(
-        `Failed to create a team for seeded diary fixtures: ${createdTeam.response.status} ${JSON.stringify(createdTeam.error)}`,
+        `Failed to create a team for seeded diary fixtures: ${createdTeam.response?.status} ${JSON.stringify(createdTeam.error)}`,
       );
     }
 
@@ -280,7 +280,9 @@ test.describe.serial('Diary browser', () => {
     if (await codeInput.isVisible({ timeout: 2000 }).catch(() => false)) {
       const verification = await waitForVerificationData(user.email);
       if (!verification.code) {
-        throw new Error('Registration flow did not produce a verification code');
+        throw new Error(
+          'Registration flow did not produce a verification code',
+        );
       }
       await codeInput.fill(verification.code);
       await submitKratosForm(page);
@@ -309,7 +311,7 @@ test.describe.serial('Diary browser', () => {
     await expect(
       page.getByRole('heading', { name: seeded.populatedDiaryName }),
     ).toBeVisible();
-    await expect(page.getByText('Tags')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Tags' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Grid' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Timeline' })).toBeVisible();
     await expect(page.getByText(seeded.entryTitle)).toBeVisible();
@@ -319,16 +321,20 @@ test.describe.serial('Diary browser', () => {
     await loginViaBrowser(page, user);
     await page.goto(`${CONSOLE_URL}/diaries/${seeded.populatedDiaryId}`);
 
-    await page.getByText(seeded.entryTag).click();
-    await expect(page).toHaveURL(new RegExp(`tag=${seeded.entryTag}`));
+    await page.getByText(seeded.entryTag).first().click();
+    await expect(page).toHaveURL(
+      new RegExp(`tag=${encodeURIComponent(seeded.entryTag)}`),
+    );
     await expect(page.getByText(seeded.entryTitle)).toBeVisible();
 
     await page.getByText(seeded.entryTitle).click();
-    await expect(page.getByRole('heading', { name: seeded.entryTitle })).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: seeded.entryTitle }),
+    ).toBeVisible();
     await expect(page.getByText('CID')).toBeVisible();
-    await expect(page.getByText('Signed')).toBeVisible();
+    await expect(page.getByText('Signed', { exact: true })).toBeVisible();
     await expect(page.getByText('Tokens')).toBeVisible();
-    await expect(page.getByText(seeded.entryTag)).toBeVisible();
+    await expect(page.getByText(seeded.entryTag).first()).toBeVisible();
   });
 
   test('renders the empty diary state', async ({ page }) => {
@@ -338,7 +344,9 @@ test.describe.serial('Diary browser', () => {
     await expect(
       page.getByRole('heading', { name: seeded.emptyDiaryName }),
     ).toBeVisible();
-    await expect(page.getByText('No entries yet')).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: 'No entries yet' }),
+    ).toBeVisible();
     await expect(
       page.getByText('This diary has no entries yet.'),
     ).toBeVisible();

--- a/apps/console/e2e/diary-browser.e2e.ts
+++ b/apps/console/e2e/diary-browser.e2e.ts
@@ -1,0 +1,346 @@
+import { randomBytes } from 'node:crypto';
+
+import {
+  createClient,
+  createDiary,
+  createDiaryEntry,
+  createTeam,
+  listTeams,
+} from '@moltnet/api-client';
+import { Configuration, FrontendApi } from '@ory/client-fetch';
+import type { Page } from '@playwright/test';
+import { expect, test } from '@playwright/test';
+
+const KRATOS_PUBLIC_URL =
+  process.env['KRATOS_PUBLIC_URL'] ?? 'http://localhost:4433';
+const REST_API_URL = process.env['REST_API_URL'] ?? 'http://localhost:8000';
+const MAILSLURPER_API_URL =
+  process.env['MAILSLURPER_API_URL'] ?? 'http://localhost:4437';
+const CONSOLE_URL = process.env['CONSOLE_BASE_URL'] ?? 'http://localhost:5174';
+
+interface TestUser {
+  email: string;
+  username: string;
+  password: string;
+}
+
+interface SeededDiary {
+  populatedDiaryId: string;
+  populatedDiaryName: string;
+  emptyDiaryId: string;
+  emptyDiaryName: string;
+  entryTitle: string;
+  entryTag: string;
+}
+
+function createTestUser(): TestUser {
+  const nonce = randomBytes(4).toString('hex');
+  return {
+    email: `diary-e2e-${Date.now()}-${nonce}@example.com`,
+    username: `diary_${nonce}`,
+    password: `DiaryE2E!${nonce}abcd`,
+  };
+}
+
+async function submitKratosForm(page: Page): Promise<void> {
+  await page.locator('form button[type="submit"]').first().click();
+}
+
+async function waitForVerificationData(
+  email: string,
+  maxAttempts = 30,
+): Promise<{ code?: string; link?: string }> {
+  for (let i = 0; i < maxAttempts; i++) {
+    const response = await fetch(`${MAILSLURPER_API_URL}/mail?pageNumber=1`);
+    if (!response.ok) {
+      throw new Error(`Failed to query Mailslurper: ${response.status}`);
+    }
+
+    const payload = (await response.json()) as Record<string, unknown>;
+    const items = Array.isArray(payload['mailItems'])
+      ? (payload['mailItems'] as Record<string, unknown>[])
+      : [];
+
+    for (const item of items) {
+      const toAddresses = Array.isArray(item['toAddresses'])
+        ? (item['toAddresses'] as Record<string, unknown>[])
+        : [];
+      const matchesEmail = toAddresses.some((addr) => {
+        const address = addr['address'] ?? addr['Address'];
+        return (
+          typeof address === 'string' &&
+          address.toLowerCase() === email.toLowerCase()
+        );
+      });
+      if (!matchesEmail) continue;
+
+      const body = typeof item['body'] === 'string' ? item['body'] : '';
+      const html = typeof item['Body'] === 'string' ? item['Body'] : '';
+      const code = body.match(/\b\d{6}\b/)?.[0];
+      const link = `${body}\n${html}`
+        .match(/https?:\/\/[^\s"'<>)]*/g)
+        ?.find((candidate) => candidate.includes('/self-service/verification'));
+
+      if (code || link) {
+        return { code, link };
+      }
+    }
+
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 2000);
+    });
+  }
+
+  throw new Error(`Timed out waiting for verification data for ${email}`);
+}
+
+async function registerViaBrowser(page: Page, user: TestUser): Promise<void> {
+  const returnTo = encodeURIComponent(`${CONSOLE_URL}/`);
+  await page.goto(
+    `${KRATOS_PUBLIC_URL}/self-service/registration/browser?return_to=${returnTo}`,
+  );
+
+  await page.locator('input[name="traits.email"]').fill(user.email);
+  await page.locator('input[name="traits.username"]').fill(user.username);
+
+  const passwordField = page.locator('input[name="password"]');
+  if (await passwordField.isVisible({ timeout: 1500 }).catch(() => false)) {
+    await passwordField.fill(user.password);
+  }
+
+  await submitKratosForm(page);
+
+  const followupPasswordField = page.locator('input[name="password"]');
+  if (
+    await followupPasswordField.isVisible({ timeout: 3000 }).catch(() => false)
+  ) {
+    await followupPasswordField.fill(user.password);
+    await submitKratosForm(page);
+  }
+}
+
+async function loginViaBrowser(page: Page, user: TestUser): Promise<void> {
+  const returnTo = encodeURIComponent(`${CONSOLE_URL}/`);
+  await page.goto(
+    `${KRATOS_PUBLIC_URL}/self-service/login/browser?return_to=${returnTo}`,
+  );
+
+  await page.locator('input[name="identifier"]').fill(user.email);
+
+  const passwordField = page.locator('input[name="password"]');
+  if (await passwordField.isVisible({ timeout: 1500 }).catch(() => false)) {
+    await passwordField.fill(user.password);
+    await submitKratosForm(page);
+    return;
+  }
+
+  await submitKratosForm(page);
+
+  const verification = await waitForVerificationData(user.email);
+  if (!verification.code) {
+    throw new Error('Login flow did not produce a verification code');
+  }
+  await page.locator('input[name="code"]').fill(verification.code);
+  await submitKratosForm(page);
+}
+
+async function createNativeSessionToken(user: TestUser): Promise<string> {
+  const kratos = new FrontendApi(
+    new Configuration({ basePath: KRATOS_PUBLIC_URL }),
+  );
+  const loginFlow = await kratos.createNativeLoginFlow();
+  const loginResult = await kratos.updateLoginFlow({
+    flow: loginFlow.id,
+    updateLoginFlowBody: {
+      method: 'password',
+      identifier: user.email,
+      password: user.password,
+    },
+  });
+
+  if (!loginResult.session_token) {
+    throw new Error('Native login did not return a session token');
+  }
+
+  return loginResult.session_token;
+}
+
+function createSessionClient() {
+  return createClient({
+    baseUrl: REST_API_URL,
+  });
+}
+
+async function seedDiaryFixtures(sessionToken: string): Promise<SeededDiary> {
+  const nonce = randomBytes(3).toString('hex');
+  const populatedDiaryName = `ui-seeded-diary-${nonce}`;
+  const emptyDiaryName = `ui-empty-diary-${nonce}`;
+  const entryTitle = `REST API route patterns ${nonce}`;
+  const entryTag = `scope:api-${nonce}`;
+  const client = createSessionClient();
+  client.interceptors.request.use((request) => {
+    request.headers.set('X-Moltnet-Session-Token', sessionToken);
+    return request;
+  });
+
+  let teamsResponse = await listTeams({
+    client,
+  });
+  let team =
+    teamsResponse.data?.items.find((candidate) => candidate.personal) ??
+    teamsResponse.data?.items[0];
+  if (!team) {
+    const createdTeam = await createTeam({
+      client,
+      body: {
+        name: `Diary browser e2e team ${nonce}`,
+      },
+    });
+    if (!createdTeam.data) {
+      throw new Error(
+        `Failed to create a team for seeded diary fixtures: ${createdTeam.response.status} ${JSON.stringify(createdTeam.error)}`,
+      );
+    }
+
+    teamsResponse = await listTeams({ client });
+    team =
+      teamsResponse.data?.items.find(
+        (candidate) => candidate.id === createdTeam.data?.id,
+      ) ?? teamsResponse.data?.items[0];
+  }
+  if (!team) {
+    throw new Error('Expected an accessible team after team bootstrap');
+  }
+
+  const populatedDiaryResponse = await createDiary({
+    client,
+    headers: { 'x-moltnet-team-id': team.id },
+    body: {
+      name: populatedDiaryName,
+      visibility: 'private',
+    },
+  });
+  const emptyDiaryResponse = await createDiary({
+    client,
+    headers: { 'x-moltnet-team-id': team.id },
+    body: {
+      name: emptyDiaryName,
+      visibility: 'private',
+    },
+  });
+
+  if (!populatedDiaryResponse.data || !emptyDiaryResponse.data) {
+    throw new Error('Expected seeded diary creation to succeed');
+  }
+
+  await createDiaryEntry({
+    client,
+    path: { diaryId: populatedDiaryResponse.data.id },
+    body: {
+      title: entryTitle,
+      content:
+        'Seeded entry for the console diary browser test. It should appear in the diary detail page and entry detail view.',
+      tags: ['decision', entryTag],
+      importance: 8,
+      entryType: 'procedural',
+    },
+  });
+
+  await createDiaryEntry({
+    client,
+    path: { diaryId: populatedDiaryResponse.data.id },
+    body: {
+      title: `Auth middleware decision ${nonce}`,
+      content:
+        'Second seeded entry so the page has a real tag cloud and more than one entry card.',
+      tags: ['incident', `source:seed-${nonce}`],
+      importance: 6,
+      entryType: 'semantic',
+    },
+  });
+
+  return {
+    populatedDiaryId: populatedDiaryResponse.data.id,
+    populatedDiaryName,
+    emptyDiaryId: emptyDiaryResponse.data.id,
+    emptyDiaryName,
+    entryTitle,
+    entryTag,
+  };
+}
+
+test.describe.serial('Diary browser', () => {
+  const user = createTestUser();
+  let seeded: SeededDiary;
+
+  test('register and seed deterministic diary data', async ({ page }) => {
+    await registerViaBrowser(page, user);
+
+    const codeInput = page.locator('input[name="code"]');
+    if (await codeInput.isVisible({ timeout: 2000 }).catch(() => false)) {
+      const verification = await waitForVerificationData(user.email);
+      if (!verification.code) {
+        throw new Error('Registration flow did not produce a verification code');
+      }
+      await codeInput.fill(verification.code);
+      await submitKratosForm(page);
+    }
+
+    await page.goto(CONSOLE_URL);
+    await expect(page.getByText('Welcome')).toBeVisible();
+
+    const sessionToken = await createNativeSessionToken(user);
+    seeded = await seedDiaryFixtures(sessionToken);
+  });
+
+  test('lists accessible diaries and opens a populated diary', async ({
+    page,
+  }) => {
+    await loginViaBrowser(page, user);
+    await expect(page).toHaveURL(/localhost:5174/);
+
+    await page.goto(`${CONSOLE_URL}/diaries`);
+    await expect(page.getByRole('heading', { name: 'Diaries' })).toBeVisible();
+    await expect(page.getByText(seeded.populatedDiaryName)).toBeVisible();
+    await expect(page.getByText(seeded.emptyDiaryName)).toBeVisible();
+
+    await page.getByText(seeded.populatedDiaryName).click();
+
+    await expect(
+      page.getByRole('heading', { name: seeded.populatedDiaryName }),
+    ).toBeVisible();
+    await expect(page.getByText('Tags')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Grid' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Timeline' })).toBeVisible();
+    await expect(page.getByText(seeded.entryTitle)).toBeVisible();
+  });
+
+  test('filters by tag and opens entry detail metadata', async ({ page }) => {
+    await loginViaBrowser(page, user);
+    await page.goto(`${CONSOLE_URL}/diaries/${seeded.populatedDiaryId}`);
+
+    await page.getByText(seeded.entryTag).click();
+    await expect(page).toHaveURL(new RegExp(`tag=${seeded.entryTag}`));
+    await expect(page.getByText(seeded.entryTitle)).toBeVisible();
+
+    await page.getByText(seeded.entryTitle).click();
+    await expect(page.getByRole('heading', { name: seeded.entryTitle })).toBeVisible();
+    await expect(page.getByText('CID')).toBeVisible();
+    await expect(page.getByText('Signed')).toBeVisible();
+    await expect(page.getByText('Tokens')).toBeVisible();
+    await expect(page.getByText(seeded.entryTag)).toBeVisible();
+  });
+
+  test('renders the empty diary state', async ({ page }) => {
+    await loginViaBrowser(page, user);
+    await page.goto(`${CONSOLE_URL}/diaries/${seeded.emptyDiaryId}`);
+
+    await expect(
+      page.getByRole('heading', { name: seeded.emptyDiaryName }),
+    ).toBeVisible();
+    await expect(page.getByText('No entries yet')).toBeVisible();
+    await expect(
+      page.getByText('This diary has no entries yet.'),
+    ).toBeVisible();
+  });
+});

--- a/apps/console/e2e/seed-diary-browser.ts
+++ b/apps/console/e2e/seed-diary-browser.ts
@@ -1,0 +1,201 @@
+/* eslint-disable no-console */
+import { randomBytes } from 'node:crypto';
+
+import {
+  createClient,
+  createDiary,
+  createDiaryEntry,
+  createTeam,
+  listTeams,
+} from '@moltnet/api-client';
+import { Configuration, FrontendApi } from '@ory/client-fetch';
+
+const KRATOS_PUBLIC_URL =
+  process.env['KRATOS_PUBLIC_URL'] ?? 'http://localhost:4433';
+const KRATOS_UI_URL = process.env['KRATOS_UI_URL'] ?? 'http://localhost:4455';
+const REST_API_URL = process.env['REST_API_URL'] ?? 'http://localhost:8000';
+const CONSOLE_URL = process.env['CONSOLE_BASE_URL'] ?? 'http://localhost:5174';
+
+interface TestUser {
+  email: string;
+  username: string;
+  password: string;
+}
+
+function createTestUser(): TestUser {
+  const nonce = randomBytes(4).toString('hex');
+  return {
+    email: `diary-browser-${Date.now()}-${nonce}@example.com`,
+    username: `diary_browser_${nonce}`,
+    password: `DiaryBrowser!${nonce}abcd`,
+  };
+}
+
+async function createHumanSession(user: TestUser): Promise<string> {
+  const kratos = new FrontendApi(
+    new Configuration({ basePath: KRATOS_PUBLIC_URL }),
+  );
+
+  const registrationFlow = await kratos.createNativeRegistrationFlow();
+  await kratos.updateRegistrationFlow({
+    flow: registrationFlow.id,
+    updateRegistrationFlowBody: {
+      method: 'password',
+      traits: {
+        email: user.email,
+        username: user.username,
+      },
+      password: user.password,
+    },
+  });
+
+  const loginFlow = await kratos.createNativeLoginFlow();
+  const loginResult = await kratos.updateLoginFlow({
+    flow: loginFlow.id,
+    updateLoginFlowBody: {
+      method: 'password',
+      identifier: user.email,
+      password: user.password,
+    },
+  });
+
+  if (!loginResult.session_token) {
+    throw new Error('Native login did not return a session token');
+  }
+
+  return loginResult.session_token;
+}
+
+function createSessionClient() {
+  return createClient({
+    baseUrl: REST_API_URL,
+  });
+}
+
+async function seedDiaryFixtures(sessionToken: string) {
+  const nonce = randomBytes(3).toString('hex');
+  const client = createSessionClient();
+  client.interceptors.request.use((request) => {
+    request.headers.set('X-Moltnet-Session-Token', sessionToken);
+    return request;
+  });
+
+  let teamsResponse = await listTeams({ client });
+  let team =
+    teamsResponse.data?.items.find((candidate) => candidate.personal) ??
+    teamsResponse.data?.items[0];
+
+  if (!team) {
+    const createdTeam = await createTeam({
+      client,
+      body: {
+        name: `Diary browser demo team ${nonce}`,
+      },
+    });
+    if (!createdTeam.data) {
+      throw new Error(
+        `Failed to create a team for diary seeding: ${createdTeam.response.status} ${JSON.stringify(createdTeam.error)}`,
+      );
+    }
+
+    teamsResponse = await listTeams({ client });
+    team =
+      teamsResponse.data?.items.find(
+        (candidate) => candidate.id === createdTeam.data?.id,
+      ) ?? teamsResponse.data?.items[0];
+  }
+
+  if (!team) {
+    throw new Error('Expected an accessible team after team bootstrap');
+  }
+
+  const overviewDiary = await createDiary({
+    client,
+    headers: { 'x-moltnet-team-id': team.id },
+    body: {
+      name: `UI diary browser demo ${nonce}`,
+      visibility: 'private',
+    },
+  });
+  const emptyDiary = await createDiary({
+    client,
+    headers: { 'x-moltnet-team-id': team.id },
+    body: {
+      name: `Empty diary browser demo ${nonce}`,
+      visibility: 'private',
+    },
+  });
+
+  if (!overviewDiary.data || !emptyDiary.data) {
+    throw new Error('Failed to create demo diaries');
+  }
+
+  await createDiaryEntry({
+    client,
+    path: { diaryId: overviewDiary.data.id },
+    body: {
+      entryType: 'semantic',
+      importance: 8,
+      title: `Dashboard IA review ${nonce}`,
+      content:
+        'This seeded entry exists so the diary browser shows a realistic overview card, tags, and readable metadata immediately after login.',
+      tags: ['ui', 'dashboard', `seed:${nonce}`],
+    },
+  });
+
+  await createDiaryEntry({
+    client,
+    path: { diaryId: overviewDiary.data.id },
+    body: {
+      entryType: 'procedural',
+      importance: 7,
+      title: `Route walk-through ${nonce}`,
+      content:
+        'Open the diaries route, inspect the detail page, switch between grid and timeline, then verify the entry detail metadata panel.',
+      tags: ['ui', 'walkthrough', 'routes'],
+    },
+  });
+
+  await createDiaryEntry({
+    client,
+    path: { diaryId: overviewDiary.data.id },
+    body: {
+      entryType: 'reflection',
+      importance: 5,
+      title: `Tag cloud sample ${nonce}`,
+      content:
+        'The tag cloud becomes useful only once a diary has more than one entry with overlapping and distinct tags.',
+      tags: ['ui', 'tags', 'reflection'],
+    },
+  });
+
+  return {
+    overviewDiaryId: overviewDiary.data.id,
+    overviewDiaryName: overviewDiary.data.name,
+    emptyDiaryId: emptyDiary.data.id,
+    emptyDiaryName: emptyDiary.data.name,
+  };
+}
+
+async function main() {
+  const user = createTestUser();
+  const sessionToken = await createHumanSession(user);
+  const seeded = await seedDiaryFixtures(sessionToken);
+
+  console.log('');
+  console.log('Seeded local diary browser fixtures');
+  console.log(`Console: ${CONSOLE_URL}`);
+  console.log(`Kratos UI: ${KRATOS_UI_URL}`);
+  console.log(`Email: ${user.email}`);
+  console.log(`Username: ${user.username}`);
+  console.log(`Password: ${user.password}`);
+  console.log(`Populated diary: ${seeded.overviewDiaryName}`);
+  console.log(`Empty diary: ${seeded.emptyDiaryName}`);
+  console.log(`${CONSOLE_URL}/diaries/${seeded.overviewDiaryId}`);
+  console.log(`${CONSOLE_URL}/diaries/${seeded.emptyDiaryId}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/apps/console/src/App.tsx
+++ b/apps/console/src/App.tsx
@@ -2,6 +2,9 @@ import { Route, Switch } from 'wouter';
 
 import { AuthGuard } from './auth/AuthGuard.js';
 import { DashboardLayout } from './layout/DashboardLayout.js';
+import { DiariesPage } from './pages/DiariesPage.js';
+import { DiaryDetailPage } from './pages/DiaryDetailPage.js';
+import { EntryDetailPage } from './pages/EntryDetailPage.js';
 import { NotFoundPage } from './pages/NotFoundPage.js';
 import { OverviewPage } from './pages/OverviewPage.js';
 import { TeamPage } from './pages/TeamPage.js';
@@ -12,6 +15,20 @@ export function App() {
       <DashboardLayout>
         <Switch>
           <Route path="/" component={OverviewPage} />
+          <Route path="/diaries" component={DiariesPage} />
+          <Route path="/diaries/:diaryId/entries/:entryId">
+            {(params: { diaryId: string; entryId: string }) => (
+              <EntryDetailPage
+                diaryId={params.diaryId}
+                entryId={params.entryId}
+              />
+            )}
+          </Route>
+          <Route path="/diaries/:id">
+            {(params: { id: string }) => (
+              <DiaryDetailPage id={params.id} />
+            )}
+          </Route>
           <Route path="/team" component={TeamPage} />
           <Route component={NotFoundPage} />
         </Switch>

--- a/apps/console/src/components/TeamSelector.tsx
+++ b/apps/console/src/components/TeamSelector.tsx
@@ -4,13 +4,29 @@ import { useTeam } from '../team/useTeam.js';
 
 export function TeamSelector() {
   const theme = useTheme();
-  const { teams, selectedTeam, selectTeam, isLoading } = useTeam();
+  const { teams, selectedTeam, selectTeam, isLoading, error } = useTeam();
 
   if (isLoading) {
     return (
       <Text variant="caption" color="muted">
         Loading teams...
       </Text>
+    );
+  }
+
+  if (error) {
+    return (
+      <div
+        title={error.message}
+        style={{
+          padding: `${theme.spacing[2]} ${theme.spacing[3]}`,
+          color: theme.color.error.DEFAULT,
+        }}
+      >
+        <Text variant="caption" color="muted">
+          Failed to load teams
+        </Text>
+      </div>
     );
   }
 

--- a/apps/console/src/components/diaries/DiaryCard.tsx
+++ b/apps/console/src/components/diaries/DiaryCard.tsx
@@ -1,0 +1,51 @@
+import { Card, Stack, Text, useTheme } from '@themoltnet/design-system';
+import { Link } from 'wouter';
+
+import type { DiarySummary } from '../../diaries/utils.js';
+import { formatRelativeTime } from '../../diaries/utils.js';
+
+export function DiaryCard({ diary }: { diary: DiarySummary }) {
+  const theme = useTheme();
+
+  return (
+    <Link
+      href={`/diaries/${diary.id}`}
+      style={{ textDecoration: 'none', color: 'inherit' }}
+    >
+      <Card
+        variant="surface"
+        padding="md"
+        style={{
+          height: '100%',
+          transition: `transform ${theme.transition.fast}, box-shadow ${theme.transition.fast}`,
+          cursor: 'pointer',
+        }}
+      >
+        <Stack gap={3}>
+          <Stack gap={1}>
+            <Text variant="h4">{diary.name}</Text>
+            <Text variant="caption" color="muted" mono>
+              {diary.id}
+            </Text>
+          </Stack>
+
+          <Stack direction="row" gap={2} wrap>
+            <Text variant="caption" color="muted">
+              {diary.entryCount} entries
+            </Text>
+            <Text variant="caption" color="muted">
+              {diary.tagCount} tags
+            </Text>
+            <Text variant="caption" color="muted">
+              {diary.visibility}
+            </Text>
+          </Stack>
+
+          <Text color="muted">
+            Last entry: {formatRelativeTime(diary.latestEntryAt)}
+          </Text>
+        </Stack>
+      </Card>
+    </Link>
+  );
+}

--- a/apps/console/src/components/diaries/EntryCard.tsx
+++ b/apps/console/src/components/diaries/EntryCard.tsx
@@ -1,0 +1,107 @@
+import { Card, Stack, Text, useTheme } from '@themoltnet/design-system';
+import { Link } from 'wouter';
+
+import {
+  type EntryType,
+  estimateTokenCount,
+  formatRelativeTime,
+} from '../../diaries/utils.js';
+import { ImportanceIndicator } from './ImportanceIndicator.js';
+import { TagChip } from './TagChip.js';
+import { TypeBadge } from './TypeBadge.js';
+
+interface EntryCardProps {
+  diaryId: string;
+  entry: {
+    id: string;
+    title: string | null;
+    content: string;
+    tags: Array<string> | null;
+    importance: number;
+    entryType: EntryType;
+    createdAt: string;
+  };
+  view?: 'grid' | 'timeline';
+  onTagClick?: (tag: string) => void;
+}
+
+export function EntryCard({
+  diaryId,
+  entry,
+  view = 'grid',
+  onTagClick,
+}: EntryCardProps) {
+  const theme = useTheme();
+
+  return (
+    <Link
+      href={`/diaries/${diaryId}/entries/${entry.id}`}
+      style={{ textDecoration: 'none', color: 'inherit' }}
+    >
+      <Card
+        variant="surface"
+        padding="md"
+        style={{
+          position: 'relative',
+          height: '100%',
+          borderLeft:
+            view === 'timeline'
+              ? `3px solid ${theme.color.accent.DEFAULT}`
+              : undefined,
+          cursor: 'pointer',
+        }}
+      >
+        <Stack gap={3}>
+          <Stack
+            direction="row"
+            align="center"
+            justify="space-between"
+            gap={3}
+            wrap
+          >
+            <TypeBadge type={entry.entryType} />
+            <Text variant="caption" color="muted">
+              {formatRelativeTime(entry.createdAt)}
+            </Text>
+          </Stack>
+
+          <Stack gap={2}>
+            <Text variant="h4">{entry.title ?? 'Untitled entry'}</Text>
+            <Text
+              color="secondary"
+              style={{
+                whiteSpace: 'pre-wrap',
+                display: '-webkit-box',
+                WebkitLineClamp: 4,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden',
+              }}
+            >
+              {entry.content}
+            </Text>
+          </Stack>
+
+          <Stack direction="row" gap={3} wrap align="center">
+            <ImportanceIndicator value={entry.importance} compact />
+            <Text variant="caption" color="muted">
+              ~{estimateTokenCount(entry.content)} tokens
+            </Text>
+          </Stack>
+
+          {entry.tags && entry.tags.length > 0 && (
+            <Stack direction="row" gap={2} wrap>
+              {entry.tags.slice(0, 4).map((tag) => (
+                <TagChip key={tag} tag={tag} onClick={onTagClick} />
+              ))}
+              {entry.tags.length > 4 && (
+                <Text variant="caption" color="muted">
+                  +{entry.tags.length - 4}
+                </Text>
+              )}
+            </Stack>
+          )}
+        </Stack>
+      </Card>
+    </Link>
+  );
+}

--- a/apps/console/src/components/diaries/EntryDetail.tsx
+++ b/apps/console/src/components/diaries/EntryDetail.tsx
@@ -1,0 +1,162 @@
+import { Card, Divider, Stack, Text, useTheme } from '@themoltnet/design-system';
+import { Link } from 'wouter';
+
+import type { EntryDetailData } from '../../diaries/utils.js';
+import {
+  buildDiaryQuery,
+  estimateTokenCount,
+  formatDateTime,
+} from '../../diaries/utils.js';
+import { ImportanceIndicator } from './ImportanceIndicator.js';
+import { TagChip } from './TagChip.js';
+import { TypeBadge } from './TypeBadge.js';
+
+export function EntryDetail({ data }: { data: EntryDetailData }) {
+  const theme = useTheme();
+  const { diary, entry, verification } = data;
+
+  return (
+    <Stack gap={6}>
+      <Link
+        href={`/diaries/${entry.diaryId}`}
+        style={{ color: theme.color.text.muted, textDecoration: 'none' }}
+      >
+        &larr; {diary?.name ?? 'Diary'}
+      </Link>
+
+      <Card variant="elevated" padding="lg">
+        <Stack gap={5}>
+          <Stack gap={3}>
+            <Text variant="h2">{entry.title ?? 'Untitled entry'}</Text>
+            <Stack direction="row" gap={3} wrap align="center">
+              <TypeBadge type={entry.entryType} />
+              <ImportanceIndicator value={entry.importance} />
+            </Stack>
+          </Stack>
+
+          <Stack gap={2}>
+            <MetadataRow
+              label="CID"
+              value={entry.contentHash ?? 'Not computed'}
+              mono
+              accent
+            />
+            <MetadataRow
+              label="Signed"
+              value={
+                verification?.signed
+                  ? verification.agentFingerprint
+                    ? `Yes · ${verification.agentFingerprint}`
+                    : 'Yes'
+                  : 'Unsigned'
+              }
+              mono={!!verification?.agentFingerprint}
+              accent={!!verification?.agentFingerprint}
+            />
+            <MetadataRow
+              label="Created"
+              value={formatDateTime(entry.createdAt)}
+            />
+            <MetadataRow
+              label="Tokens"
+              value={`~${estimateTokenCount(entry.content)}`}
+            />
+          </Stack>
+
+          {entry.tags && entry.tags.length > 0 && (
+            <Stack gap={2}>
+              <Text variant="overline" color="muted">
+                Tags
+              </Text>
+              <Stack direction="row" gap={2} wrap>
+                {entry.tags.map((tag) => (
+                  <Link
+                    key={tag}
+                    href={`/diaries/${entry.diaryId}${buildDiaryQuery({
+                      tag,
+                    })}`}
+                    style={{ textDecoration: 'none' }}
+                  >
+                    <TagChip tag={tag} />
+                  </Link>
+                ))}
+              </Stack>
+            </Stack>
+          )}
+
+          <Divider />
+
+          <Text
+            variant="bodyLarge"
+            color="secondary"
+            style={{ whiteSpace: 'pre-wrap' }}
+          >
+            {entry.content}
+          </Text>
+
+          <Divider />
+
+          <Stack gap={2}>
+            <Text variant="h4">Relations</Text>
+            {entry.relations?.items.length ? (
+              <Stack gap={2}>
+                {entry.relations.items.map((relation) => {
+                  const relatedEntryId =
+                    relation.sourceId === entry.id
+                      ? relation.targetId
+                      : relation.sourceId;
+
+                  return (
+                    <Link
+                      key={relation.id}
+                      href={`/diaries/${entry.diaryId}/entries/${relatedEntryId}`}
+                      style={{ textDecoration: 'none', color: 'inherit' }}
+                    >
+                      <Card variant="surface" padding="sm">
+                        <Stack direction="row" gap={3} wrap align="center">
+                          <Text>{relation.relation}</Text>
+                          <Text variant="caption" color="muted" mono>
+                            {relatedEntryId}
+                          </Text>
+                        </Stack>
+                      </Card>
+                    </Link>
+                  );
+                })}
+              </Stack>
+            ) : (
+              <Text color="muted">No related entries recorded.</Text>
+            )}
+          </Stack>
+        </Stack>
+      </Card>
+    </Stack>
+  );
+}
+
+function MetadataRow({
+  label,
+  value,
+  mono = false,
+  accent = false,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+  accent?: boolean;
+}) {
+  return (
+    <Stack direction="row" gap={3} wrap>
+      <Text variant="caption" color="muted">
+        {label}
+      </Text>
+      <Text
+        variant="caption"
+        mono={mono}
+        color={accent ? 'accent' : 'default'}
+      >
+        {value}
+      </Text>
+    </Stack>
+  );
+}

--- a/apps/console/src/components/diaries/ImportanceIndicator.tsx
+++ b/apps/console/src/components/diaries/ImportanceIndicator.tsx
@@ -1,0 +1,37 @@
+import { Stack, Text, useTheme } from '@themoltnet/design-system';
+
+export function ImportanceIndicator({
+  value,
+  compact = false,
+}: {
+  value: number;
+  compact?: boolean;
+}) {
+  const theme = useTheme();
+
+  return (
+    <Stack direction="row" align="center" gap={compact ? 2 : 3}>
+      <Stack direction="row" gap={1}>
+        {Array.from({ length: 5 }, (_, index) => {
+          const filled = index < Math.ceil(value / 2);
+          return (
+            <div
+              key={index}
+              style={{
+                width: compact ? 8 : 10,
+                height: compact ? 8 : 10,
+                borderRadius: 999,
+                background: filled
+                  ? theme.color.accent.DEFAULT
+                  : theme.color.border.DEFAULT,
+              }}
+            />
+          );
+        })}
+      </Stack>
+      <Text variant="caption" color="muted">
+        {compact ? value : `Importance ${value}/10`}
+      </Text>
+    </Stack>
+  );
+}

--- a/apps/console/src/components/diaries/TagChip.tsx
+++ b/apps/console/src/components/diaries/TagChip.tsx
@@ -1,0 +1,46 @@
+import { Badge, useTheme } from '@themoltnet/design-system';
+import type { KeyboardEvent, MouseEvent } from 'react';
+
+export function TagChip({
+  tag,
+  active = false,
+  onClick,
+}: {
+  tag: string;
+  active?: boolean;
+  onClick?: (tag: string) => void;
+}) {
+  const theme = useTheme();
+
+  function handleClick(event: MouseEvent | KeyboardEvent) {
+    if (!onClick) return;
+    event.preventDefault();
+    event.stopPropagation();
+    onClick(tag);
+  }
+
+  return (
+    <span
+      role={onClick ? 'button' : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onClick={handleClick}
+      onKeyDown={(event) => {
+        if (!onClick) return;
+        if (event.key === 'Enter' || event.key === ' ') {
+          handleClick(event);
+        }
+      }}
+      style={{
+        display: 'inline-flex',
+        cursor: onClick ? 'pointer' : 'default',
+      }}
+    >
+      <Badge
+        variant={active ? 'primary' : 'default'}
+        style={{ transition: `background ${theme.transition.fast}` }}
+      >
+        {tag}
+      </Badge>
+    </span>
+  );
+}

--- a/apps/console/src/components/diaries/TagCloud.tsx
+++ b/apps/console/src/components/diaries/TagCloud.tsx
@@ -1,0 +1,57 @@
+import { Stack, Text, useTheme } from '@themoltnet/design-system';
+
+import { TagChip } from './TagChip.js';
+
+export interface TagCloudItem {
+  tag: string;
+  count: number;
+}
+
+export function TagCloud({
+  items,
+  activeTag,
+  onTagClick,
+}: {
+  items: Array<TagCloudItem>;
+  activeTag?: string | null;
+  onTagClick?: (tag: string | null) => void;
+}) {
+  const theme = useTheme();
+
+  if (items.length === 0) {
+    return <Text color="muted">No tags yet.</Text>;
+  }
+
+  return (
+    <Stack gap={3}>
+      <Stack direction="row" gap={2} wrap>
+        {items.map((item) => (
+          <div
+            key={item.tag}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: theme.spacing[2],
+            }}
+          >
+            <TagChip
+              tag={item.tag}
+              active={item.tag === activeTag}
+              onClick={() =>
+                onTagClick?.(item.tag === activeTag ? null : item.tag)
+              }
+            />
+            <Text variant="caption" color="muted">
+              {item.count}
+            </Text>
+          </div>
+        ))}
+      </Stack>
+      {activeTag && (
+        <Text variant="caption" color="muted">
+          Tag filter active: {activeTag}
+        </Text>
+      )}
+    </Stack>
+  );
+}

--- a/apps/console/src/components/diaries/TypeBadge.tsx
+++ b/apps/console/src/components/diaries/TypeBadge.tsx
@@ -1,0 +1,16 @@
+import { Badge } from '@themoltnet/design-system';
+
+import { ENTRY_TYPE_LABELS, type EntryType } from '../../diaries/utils.js';
+
+const TYPE_VARIANTS: Record<EntryType, 'accent' | 'primary' | 'default' | 'success'> = {
+  procedural: 'accent',
+  semantic: 'primary',
+  episodic: 'success',
+  reflection: 'default',
+  identity: 'primary',
+  soul: 'accent',
+};
+
+export function TypeBadge({ type }: { type: EntryType }) {
+  return <Badge variant={TYPE_VARIANTS[type]}>{ENTRY_TYPE_LABELS[type]}</Badge>;
+}

--- a/apps/console/src/diaries/api.ts
+++ b/apps/console/src/diaries/api.ts
@@ -1,0 +1,128 @@
+import {
+  type DiaryCatalog,
+  type DiaryEntry,
+  getDiary,
+  getDiaryEntryById,
+  listDiaries,
+  listDiaryEntries,
+  listDiaryTags,
+  verifyDiaryEntryById,
+} from '@moltnet/api-client';
+
+import { getApiClient } from '../api.js';
+import type { DiarySummary, EntryDetailData, EntryType } from './utils.js';
+
+export async function fetchDiarySummaries(): Promise<Array<DiarySummary>> {
+  const { data } = await listDiaries({
+    client: getApiClient(),
+  });
+
+  const diaries = data?.items ?? [];
+
+  const summaries = await Promise.all(
+    diaries.map(async (diary) => {
+      const [entriesResponse, tagsResponse] = await Promise.all([
+        listDiaryEntries({
+          client: getApiClient(),
+          path: { diaryId: diary.id },
+          query: { limit: 1, offset: 0 },
+        }),
+        listDiaryTags({
+          client: getApiClient(),
+          path: { diaryId: diary.id },
+        }),
+      ]);
+
+      return {
+        ...diary,
+        entryCount: entriesResponse.data?.total ?? 0,
+        tagCount: tagsResponse.data?.total ?? 0,
+        latestEntryAt: entriesResponse.data?.items[0]?.createdAt ?? null,
+      } satisfies DiarySummary;
+    }),
+  );
+
+  return summaries.sort((left, right) => {
+    const rightTime = right.latestEntryAt
+      ? new Date(right.latestEntryAt).getTime()
+      : 0;
+    const leftTime = left.latestEntryAt
+      ? new Date(left.latestEntryAt).getTime()
+      : 0;
+
+    return rightTime - leftTime || left.name.localeCompare(right.name);
+  });
+}
+
+export async function fetchDiaryDetails(diaryId: string): Promise<DiaryCatalog> {
+  const { data } = await getDiary({
+    client: getApiClient(),
+    path: { id: diaryId },
+  });
+
+  if (!data) throw new Error('Diary not found');
+  return data;
+}
+
+export async function fetchDiaryEntries(input: {
+  diaryId: string;
+  limit?: number;
+  offset?: number;
+  tag?: string | null;
+  entryType?: EntryType | null;
+}): Promise<{ items: Array<DiaryEntry>; total: number; limit: number; offset: number }> {
+  const { data } = await listDiaryEntries({
+    client: getApiClient(),
+    path: { diaryId: input.diaryId },
+    query: {
+      limit: input.limit ?? 20,
+      offset: input.offset ?? 0,
+      tags: input.tag ?? undefined,
+      entryType: input.entryType ?? undefined,
+    },
+  });
+
+  if (!data) {
+    return { items: [], total: 0, limit: input.limit ?? 20, offset: input.offset ?? 0 };
+  }
+
+  return data;
+}
+
+export async function fetchDiaryTagCloud(diaryId: string) {
+  const { data } = await listDiaryTags({
+    client: getApiClient(),
+    path: { diaryId },
+  });
+
+  return data?.tags ?? [];
+}
+
+export async function fetchEntryDetail(
+  diaryId: string,
+  entryId: string,
+): Promise<EntryDetailData> {
+  const [diaryResponse, entryResponse, verifyResponse] = await Promise.all([
+    getDiary({
+      client: getApiClient(),
+      path: { id: diaryId },
+    }),
+    getDiaryEntryById({
+      client: getApiClient(),
+      path: { entryId },
+      query: { expand: 'relations', depth: 2 },
+    }),
+    verifyDiaryEntryById({
+      client: getApiClient(),
+      path: { entryId },
+    }),
+  ]);
+
+  if (!entryResponse.data) throw new Error('Entry not found');
+
+  return {
+    diary: diaryResponse.data ?? null,
+    entry: entryResponse.data,
+    verification: verifyResponse.data ?? null,
+  };
+}

--- a/apps/console/src/diaries/utils.ts
+++ b/apps/console/src/diaries/utils.ts
@@ -1,0 +1,92 @@
+import type {
+  DiaryCatalog,
+  DiaryEntry,
+  DiaryEntryWithRelations,
+  EntryVerifyResult,
+} from '@moltnet/api-client';
+
+export type EntryType = DiaryEntry['entryType'];
+
+export interface DiarySummary extends DiaryCatalog {
+  entryCount: number;
+  tagCount: number;
+  latestEntryAt: string | null;
+}
+
+export interface EntryDetailData {
+  diary: DiaryCatalog | null;
+  entry: DiaryEntryWithRelations;
+  verification: EntryVerifyResult | null;
+}
+
+export const ENTRY_TYPE_OPTIONS: EntryType[] = [
+  'procedural',
+  'semantic',
+  'episodic',
+  'reflection',
+  'identity',
+  'soul',
+];
+
+export const ENTRY_TYPE_LABELS: Record<EntryType, string> = {
+  procedural: 'Procedural',
+  semantic: 'Semantic',
+  episodic: 'Episodic',
+  reflection: 'Reflection',
+  identity: 'Identity',
+  soul: 'Soul',
+};
+
+export function formatRelativeTime(dateStr: string | null): string {
+  if (!dateStr) return 'No entries yet';
+
+  const now = Date.now();
+  const then = new Date(dateStr).getTime();
+  const diffSeconds = Math.max(0, Math.floor((now - then) / 1000));
+
+  if (diffSeconds < 60) return 'just now';
+  if (diffSeconds < 3600) return `${Math.floor(diffSeconds / 60)}m ago`;
+  if (diffSeconds < 86400) return `${Math.floor(diffSeconds / 3600)}h ago`;
+  if (diffSeconds < 604800) return `${Math.floor(diffSeconds / 86400)}d ago`;
+
+  return new Date(dateStr).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+export function formatDateTime(dateStr: string): string {
+  return new Date(dateStr).toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+}
+
+export function estimateTokenCount(content: string): number {
+  return Math.max(1, Math.round(content.length / 4));
+}
+
+export function getEntryTypeQuery(
+  value: string | null,
+): EntryType | null {
+  if (!value) return null;
+  return ENTRY_TYPE_OPTIONS.includes(value as EntryType)
+    ? (value as EntryType)
+    : null;
+}
+
+export function buildDiaryQuery(params: {
+  tag?: string | null;
+  type?: EntryType | null;
+  view?: 'grid' | 'timeline' | null;
+}): string {
+  const search = new URLSearchParams();
+
+  if (params.tag) search.set('tag', params.tag);
+  if (params.type) search.set('type', params.type);
+  if (params.view) search.set('view', params.view);
+
+  const query = search.toString();
+  return query ? `?${query}` : '';
+}

--- a/apps/console/src/layout/Sidebar.tsx
+++ b/apps/console/src/layout/Sidebar.tsx
@@ -18,6 +18,7 @@ interface NavItem {
 
 const navItems: NavItem[] = [
   { label: 'Overview', path: '/' },
+  { label: 'Diaries', path: '/diaries' },
   { label: 'Team', path: '/team' },
 ];
 

--- a/apps/console/src/pages/DiariesPage.tsx
+++ b/apps/console/src/pages/DiariesPage.tsx
@@ -1,0 +1,127 @@
+import { Button, Card, Stack, Text, useTheme } from '@themoltnet/design-system';
+import { type ChangeEvent, useEffect, useMemo, useState } from 'react';
+
+import { DiaryCard } from '../components/diaries/DiaryCard.js';
+import { fetchDiarySummaries } from '../diaries/api.js';
+import type { DiarySummary } from '../diaries/utils.js';
+
+export function DiariesPage() {
+  const theme = useTheme();
+  const [diaries, setDiaries] = useState<Array<DiarySummary>>([]);
+  const [query, setQuery] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const items = await fetchDiarySummaries();
+        if (!cancelled) setDiaries(items);
+      } catch (err) {
+        if (!cancelled) {
+          setError(
+            err instanceof Error ? err : new Error('Failed to load diaries'),
+          );
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    }
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const filtered = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return diaries;
+
+    return diaries.filter((diary) =>
+      [diary.name, diary.id, diary.visibility].some((value) =>
+        value.toLowerCase().includes(normalized),
+      ),
+    );
+  }, [diaries, query]);
+
+  return (
+    <Stack gap={6}>
+      <Stack
+        direction="row"
+        align="center"
+        justify="space-between"
+        gap={4}
+        wrap
+      >
+        <Stack gap={1}>
+          <Text variant="h2">Diaries</Text>
+          <Text color="muted">
+            Browse every diary available in the current team scope.
+          </Text>
+        </Stack>
+
+        <input
+          type="search"
+          value={query}
+          onChange={(event: ChangeEvent<HTMLInputElement>) =>
+            setQuery(event.target.value)
+          }
+          placeholder="Search diaries"
+          aria-label="Search diaries"
+          style={{
+            minWidth: 260,
+            padding: `${theme.spacing[3]} ${theme.spacing[4]}`,
+            borderRadius: theme.radius.md,
+            border: `1px solid ${theme.color.border.DEFAULT}`,
+            background: theme.color.bg.surface,
+            color: theme.color.text.DEFAULT,
+            fontFamily: theme.font.family.sans,
+            fontSize: theme.font.size.sm,
+          }}
+        />
+      </Stack>
+
+      {isLoading ? (
+        <Text color="muted">Loading diaries…</Text>
+      ) : error ? (
+        <Card style={{ padding: '1.5rem' }}>
+          <Stack gap={3}>
+            <Text color="muted">Failed to load diaries.</Text>
+            <Button variant="secondary" size="sm" onClick={() => window.location.reload()}>
+              Retry
+            </Button>
+          </Stack>
+        </Card>
+      ) : filtered.length === 0 ? (
+        <Card style={{ padding: '1.5rem' }}>
+          <Stack gap={2}>
+            <Text variant="h4">No diaries found</Text>
+            <Text color="muted">
+              {query
+                ? 'Try a broader search query.'
+                : 'No diaries are visible in this team scope yet.'}
+            </Text>
+          </Stack>
+        </Card>
+      ) : (
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
+            gap: theme.spacing[4],
+          }}
+        >
+          {filtered.map((diary) => (
+            <DiaryCard key={diary.id} diary={diary} />
+          ))}
+        </div>
+      )}
+    </Stack>
+  );
+}

--- a/apps/console/src/pages/DiariesPage.tsx
+++ b/apps/console/src/pages/DiariesPage.tsx
@@ -1,12 +1,20 @@
-import { Button, Card, Stack, Text, useTheme } from '@themoltnet/design-system';
+import {
+  Button,
+  Card,
+  Stack,
+  Text,
+  useTheme,
+} from '@themoltnet/design-system';
 import { type ChangeEvent, useEffect, useMemo, useState } from 'react';
 
 import { DiaryCard } from '../components/diaries/DiaryCard.js';
 import { fetchDiarySummaries } from '../diaries/api.js';
 import type { DiarySummary } from '../diaries/utils.js';
+import { useTeam } from '../team/useTeam.js';
 
 export function DiariesPage() {
   const theme = useTheme();
+  const { error: teamError, refreshTeams } = useTeam();
   const [diaries, setDiaries] = useState<Array<DiarySummary>>([]);
   const [query, setQuery] = useState('');
   const [isLoading, setIsLoading] = useState(true);
@@ -87,7 +95,20 @@ export function DiariesPage() {
         />
       </Stack>
 
-      {isLoading ? (
+      {teamError ? (
+        <Card style={{ padding: '1.5rem' }}>
+          <Stack gap={3}>
+            <Text variant="h4">Team scope unavailable</Text>
+            <Text color="muted">
+              The console could not load your teams, so diary queries have no
+              valid scope. Check API connectivity and retry.
+            </Text>
+            <Button variant="secondary" size="sm" onClick={() => void refreshTeams()}>
+              Retry team load
+            </Button>
+          </Stack>
+        </Card>
+      ) : isLoading ? (
         <Text color="muted">Loading diaries…</Text>
       ) : error ? (
         <Card style={{ padding: '1.5rem' }}>

--- a/apps/console/src/pages/DiaryDetailPage.tsx
+++ b/apps/console/src/pages/DiaryDetailPage.tsx
@@ -1,0 +1,268 @@
+import type { DiaryEntry } from '@moltnet/api-client';
+import { Button, Card, Stack, Text, useTheme } from '@themoltnet/design-system';
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useLocation, useSearch } from 'wouter';
+
+import { EntryCard } from '../components/diaries/EntryCard.js';
+import { TagCloud,type TagCloudItem } from '../components/diaries/TagCloud.js';
+import { fetchDiaryDetails, fetchDiaryEntries, fetchDiaryTagCloud } from '../diaries/api.js';
+import {
+  buildDiaryQuery,
+  type EntryType,
+  formatRelativeTime,
+  getEntryTypeQuery,
+} from '../diaries/utils.js';
+
+const PAGE_SIZE = 20;
+
+export function DiaryDetailPage({ id }: { id: string }) {
+  const theme = useTheme();
+  const [, navigate] = useLocation();
+  const search = useSearch();
+  const params = useMemo(() => new URLSearchParams(search), [search]);
+
+  const activeTag = params.get('tag');
+  const activeType = getEntryTypeQuery(params.get('type'));
+  const view = params.get('view') === 'timeline' ? 'timeline' : 'grid';
+
+  const [diaryName, setDiaryName] = useState<string>('Diary');
+  const [diaryVisibility, setDiaryVisibility] = useState<string>('private');
+  const [entries, setEntries] = useState<Array<DiaryEntry>>([]);
+  const [total, setTotal] = useState(0);
+  const [tags, setTags] = useState<Array<TagCloudItem>>([]);
+  const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+
+  function updateFilters(next: {
+    tag?: string | null;
+    type?: EntryType | null;
+    view?: 'grid' | 'timeline' | null;
+  }) {
+    const hasTag = Object.prototype.hasOwnProperty.call(next, 'tag');
+    const hasType = Object.prototype.hasOwnProperty.call(next, 'type');
+    const hasView = Object.prototype.hasOwnProperty.call(next, 'view');
+
+    navigate(
+      `/diaries/${id}${buildDiaryQuery({
+        tag: hasTag ? next.tag ?? null : activeTag,
+        type: hasType ? next.type ?? null : activeType,
+        view: hasView ? next.view ?? null : view,
+      })}`,
+    );
+  }
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadMeta() {
+      try {
+        const [diary, diaryTags] = await Promise.all([
+          fetchDiaryDetails(id),
+          fetchDiaryTagCloud(id),
+        ]);
+
+        if (cancelled) return;
+        setDiaryName(diary.name);
+        setDiaryVisibility(diary.visibility);
+        setTags(diaryTags);
+      } catch {
+        if (!cancelled) setStatus('error');
+      }
+    }
+
+    void loadMeta();
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadEntries() {
+      setStatus('loading');
+
+      try {
+        const response = await fetchDiaryEntries({
+          diaryId: id,
+          limit: PAGE_SIZE,
+          offset: 0,
+          tag: activeTag,
+          entryType: activeType,
+        });
+
+        if (cancelled) return;
+        setEntries(response.items);
+        setTotal(response.total);
+        setStatus('ready');
+      } catch {
+        if (!cancelled) setStatus('error');
+      }
+    }
+
+    void loadEntries();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeTag, activeType, id]);
+
+  async function loadMore() {
+    setIsLoadingMore(true);
+
+    try {
+      const response = await fetchDiaryEntries({
+        diaryId: id,
+        limit: PAGE_SIZE,
+        offset: entries.length,
+        tag: activeTag,
+        entryType: activeType,
+      });
+
+      setEntries((current) => [...current, ...response.items]);
+      setTotal(response.total);
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }
+
+  return (
+    <Stack gap={6}>
+      <Stack gap={2}>
+        <Link
+          href="/diaries"
+          style={{ color: theme.color.text.muted, textDecoration: 'none' }}
+        >
+          &larr; Diaries
+        </Link>
+        <Text variant="h2">{diaryName}</Text>
+        <Text color="muted">
+          {total} entries · {tags.length} tags · {diaryVisibility}
+        </Text>
+      </Stack>
+
+      <Card variant="surface" padding="md">
+        <Stack gap={3}>
+          <Text variant="h4">Tags</Text>
+          <TagCloud
+            items={tags}
+            activeTag={activeTag}
+            onTagClick={(tag) => updateFilters({ tag })}
+          />
+        </Stack>
+      </Card>
+
+      <Stack
+        direction="row"
+        align="center"
+        justify="space-between"
+        gap={4}
+        wrap
+      >
+        <Stack direction="row" gap={2}>
+          <FilterButton
+            active={view === 'grid'}
+            onClick={() => updateFilters({ view: 'grid' })}
+          >
+            Grid
+          </FilterButton>
+          <FilterButton
+            active={view === 'timeline'}
+            onClick={() => updateFilters({ view: 'timeline' })}
+          >
+            Timeline
+          </FilterButton>
+        </Stack>
+
+        <Stack direction="row" gap={2} wrap>
+          <FilterButton
+            active={!activeType}
+            onClick={() => updateFilters({ type: null })}
+          >
+            All types
+          </FilterButton>
+          {(['procedural', 'semantic', 'episodic'] as Array<EntryType>).map(
+            (type) => (
+              <FilterButton
+                key={type}
+                active={activeType === type}
+                onClick={() => updateFilters({ type })}
+              >
+                {type}
+              </FilterButton>
+            ),
+          )}
+        </Stack>
+      </Stack>
+
+      {status === 'loading' ? (
+        <Text color="muted">Loading entries…</Text>
+      ) : status === 'error' ? (
+        <Card style={{ padding: '1.5rem' }}>
+          <Text color="muted">Failed to load this diary.</Text>
+        </Card>
+      ) : entries.length === 0 ? (
+        <Card style={{ padding: '1.5rem' }}>
+          <Stack gap={2}>
+            <Text variant="h4">
+              {activeTag || activeType ? 'No matching entries' : 'No entries yet'}
+            </Text>
+            <Text color="muted">
+              {activeTag || activeType
+                ? 'Clear filters to see the full diary.'
+                : 'This diary has no entries yet.'}
+            </Text>
+          </Stack>
+        </Card>
+      ) : (
+        <>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns:
+                view === 'grid'
+                  ? 'repeat(auto-fit, minmax(280px, 1fr))'
+                  : '1fr',
+              gap: theme.spacing[4],
+            }}
+          >
+            {entries.map((entry) => (
+              <EntryCard
+                key={entry.id}
+                diaryId={id}
+                entry={entry}
+                view={view}
+                onTagClick={(tag) => updateFilters({ tag })}
+              />
+            ))}
+          </div>
+
+          {entries.length < total && (
+            <Button variant="secondary" onClick={loadMore} disabled={isLoadingMore}>
+              {isLoadingMore ? 'Loading…' : 'Load more'}
+            </Button>
+          )}
+
+          <Text variant="caption" color="muted">
+            Latest visible entry: {formatRelativeTime(entries[0]?.createdAt ?? null)}
+          </Text>
+        </>
+      )}
+    </Stack>
+  );
+}
+
+function FilterButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: string;
+}) {
+  return (
+    <Button variant={active ? 'primary' : 'ghost'} size="sm" onClick={onClick}>
+      {children}
+    </Button>
+  );
+}

--- a/apps/console/src/pages/EntryDetailPage.tsx
+++ b/apps/console/src/pages/EntryDetailPage.tsx
@@ -1,0 +1,59 @@
+import { Card, Stack, Text } from '@themoltnet/design-system';
+import { useEffect, useState } from 'react';
+
+import { EntryDetail } from '../components/diaries/EntryDetail.js';
+import { fetchEntryDetail } from '../diaries/api.js';
+import type { EntryDetailData } from '../diaries/utils.js';
+
+export function EntryDetailPage({
+  diaryId,
+  entryId,
+}: {
+  diaryId: string;
+  entryId: string;
+}) {
+  const [data, setData] = useState<EntryDetailData | null>(null);
+  const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      setStatus('loading');
+
+      try {
+        const result = await fetchEntryDetail(diaryId, entryId);
+        if (!cancelled) {
+          setData(result);
+          setStatus('ready');
+        }
+      } catch {
+        if (!cancelled) setStatus('error');
+      }
+    }
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [diaryId, entryId]);
+
+  if (status === 'loading') {
+    return <Text color="muted">Loading entry…</Text>;
+  }
+
+  if (status === 'error' || !data) {
+    return (
+      <Card style={{ padding: '1.5rem' }}>
+        <Stack gap={2}>
+          <Text variant="h4">Entry unavailable</Text>
+          <Text color="muted">
+            The entry could not be loaded or is no longer accessible.
+          </Text>
+        </Stack>
+      </Card>
+    );
+  }
+
+  return <EntryDetail data={data} />;
+}

--- a/apps/console/src/pages/OverviewPage.tsx
+++ b/apps/console/src/pages/OverviewPage.tsx
@@ -23,6 +23,26 @@ export function OverviewPage() {
       <Stack direction="row" gap={4} style={{ flexWrap: 'wrap' }}>
         <button
           type="button"
+          onClick={() => navigate('/diaries')}
+          style={{
+            flex: '1 1 280px',
+            cursor: 'pointer',
+            background: 'none',
+            border: 'none',
+            padding: 0,
+            textAlign: 'left',
+          }}
+        >
+          <Card style={{ flex: '1 1 280px', padding: '1.5rem' }}>
+            <Stack gap={2}>
+              <Text variant="h3">Diaries</Text>
+              <Text color="muted">Browse diary entries and context packs</Text>
+            </Stack>
+          </Card>
+        </button>
+
+        <button
+          type="button"
           style={{
             flex: '1 1 280px',
             cursor: 'pointer',
@@ -40,13 +60,6 @@ export function OverviewPage() {
             </Stack>
           </Card>
         </button>
-
-        <Card style={{ flex: '1 1 280px', padding: '1.5rem' }}>
-          <Stack gap={2}>
-            <Text variant="h3">Diaries</Text>
-            <Text color="muted">Browse diary entries and context packs</Text>
-          </Stack>
-        </Card>
       </Stack>
     </Stack>
   );

--- a/apps/console/src/pages/OverviewPage.tsx
+++ b/apps/console/src/pages/OverviewPage.tsx
@@ -6,7 +6,7 @@ import { useTeam } from '../team/useTeam.js';
 
 export function OverviewPage() {
   const { username } = useAuth();
-  const { selectedTeam } = useTeam();
+  const { selectedTeam, error } = useTeam();
   const [, navigate] = useLocation();
 
   return (
@@ -14,7 +14,9 @@ export function OverviewPage() {
       <Stack gap={1}>
         <Text variant="h2">Welcome{username ? `, ${username}` : ''}</Text>
         <Text color="muted">
-          {selectedTeam
+          {error
+            ? 'Team scope failed to load. Check console-to-API connectivity.'
+            : selectedTeam
             ? `Team: ${selectedTeam.name}`
             : 'Your MoltNet dashboard overview.'}
         </Text>

--- a/apps/console/src/team/TeamProvider.tsx
+++ b/apps/console/src/team/TeamProvider.tsx
@@ -23,6 +23,7 @@ export interface TeamContextValue {
   selectTeam: (teamId: string) => void;
   isLoading: boolean;
   error: Error | null;
+  refreshTeams: () => Promise<void>;
 }
 
 export const TeamContext = createContext<TeamContextValue | null>(null);
@@ -37,38 +38,48 @@ export function TeamProvider({ children }: { children: ReactNode }) {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
+  const loadTeams = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const { data } = await listTeams({ client: getApiClient() });
+      const items = data?.items ?? [];
+      setTeams(items);
+
+      const stored = localStorage.getItem(STORAGE_KEY);
+      const valid = items.find((t) => t.id === stored);
+      if (valid) {
+        setSelectedTeamId(valid.id);
+        return;
+      }
+
+      if (items.length > 0) {
+        setSelectedTeamId(items[0].id);
+        localStorage.setItem(STORAGE_KEY, items[0].id);
+      } else {
+        setSelectedTeamId(null);
+        localStorage.removeItem(STORAGE_KEY);
+      }
+    } catch (err) {
+      setTeams([]);
+      setSelectedTeamId(null);
+      setError(err instanceof Error ? err : new Error('Failed to load teams'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
-    async function load() {
-      setIsLoading(true);
-      setError(null);
-      try {
-        const { data } = await listTeams({ client: getApiClient() });
-        if (cancelled || !data) return;
-        const items = data.items;
-        setTeams(items);
 
-        const stored = localStorage.getItem(STORAGE_KEY);
-        const valid = items.find((t) => t.id === stored);
-        if (!valid && items.length > 0) {
-          setSelectedTeamId(items[0].id);
-          localStorage.setItem(STORAGE_KEY, items[0].id);
-        }
-      } catch (err) {
-        if (!cancelled) {
-          setError(
-            err instanceof Error ? err : new Error('Failed to load teams'),
-          );
-        }
-      } finally {
-        if (!cancelled) setIsLoading(false);
-      }
-    }
-    void load();
+    void loadTeams().then(() => {
+      if (cancelled) return;
+    });
+
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [loadTeams]);
 
   const selectTeam = useCallback((teamId: string) => {
     setSelectedTeamId(teamId);
@@ -88,6 +99,7 @@ export function TeamProvider({ children }: { children: ReactNode }) {
     selectTeam,
     isLoading,
     error,
+    refreshTeams: loadTeams,
   };
 
   return <TeamContext.Provider value={value}>{children}</TeamContext.Provider>;

--- a/env.local.example
+++ b/env.local.example
@@ -33,7 +33,7 @@ RECOVERY_CHALLENGE_SECRET=local-dev-recovery-secret-16chars
 # ── Server ──────────────────────────────────────────────────────
 PORT=8000
 NODE_ENV=development
-CORS_ORIGINS=http://localhost:3000,http://localhost:5173,http://localhost:8000
+CORS_ORIGINS=http://localhost:3000,http://localhost:5173,http://localhost:5174,http://localhost:8000
 
 # ── Landing app (Vite) ─────────────────────────────────────────
 VITE_API_BASE_URL=http://localhost:8000


### PR DESCRIPTION
## Summary
- add the console diary browser for issue #653, including diary list, detail, and entry detail routes - Closes #563
- add deterministic console e2e coverage plus a local seeder using the API client and native Kratos session tokens
- surface team-loading failures in the console instead of showing misleading empty team/diary states
- update the local dev CORS example to include the console port used in this workflow

## Included Commits
- feat(console): add diary browser routes
- fix(console): surface team scope failures

## Validation
- corepack pnpm --filter @moltnet/console typecheck
- corepack pnpm --filter @moltnet/console lint
- corepack pnpm --filter @moltnet/console test:e2e -- team-selector.e2e.ts
- corepack pnpm --filter @moltnet/console test:e2e -- diary-browser.e2e.ts

## Notes
- the local browser failure was traced to REST API CORS config missing http://localhost:5174 in .env.local
- CI e2e uses docker-compose.e2e.yaml with port 5174 already allowed, so that specific local mismatch should not reproduce there
- local-only noise left out intentionally: packages/cli/bin/CHANGELOG.md and apps/rest-api/models