### PR TITLE
fix: auto-resolve GitHub App installation_id during port

### DIFF
--- a/packages/github-agent/__tests__/find-installation.integration.test.ts
+++ b/packages/github-agent/__tests__/find-installation.integration.test.ts
@@ -1,0 +1,290 @@
+import { generateKeyPairSync } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { findInstallationForOwner } from '../src/token.js';
+
+function createTempRsaKeyFile(): string {
+  const { privateKey } = generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'github-agent-test-'));
+  const keyPath = path.join(tmpDir, 'private-key.pem');
+  fs.writeFileSync(keyPath, privateKey, 'utf8');
+  return keyPath;
+}
+
+/**
+ * Integration tests for findInstallationForOwner.
+ *
+ * Exercises the real implementation (JWT creation, pagination loop,
+ * owner matching) with stubbed HTTP responses.
+ */
+describe('findInstallationForOwner (integration)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('creates a valid JWT and sends correct headers', async () => {
+    // Arrange
+    const privateKeyPath = createTempRsaKeyFile();
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      json: async () => [
+        {
+          id: 42,
+          account: { login: 'target-org' },
+          target_type: 'Organization',
+        },
+      ],
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    // Act
+    await findInstallationForOwner({
+      appId: '99999',
+      privateKeyPath,
+      owner: 'target-org',
+    });
+
+    // Assert — verify the request was well-formed
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe(
+      'https://api.github.com/app/installations?per_page=100',
+    );
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers.Authorization).toMatch(/^Bearer [^.]+\.[^.]+\.[^.]+$/);
+    expect(headers.Accept).toBe('application/vnd.github+json');
+    expect(headers['X-GitHub-Api-Version']).toBe('2022-11-28');
+  });
+
+  it('selects the correct installation among multiple orgs and users', async () => {
+    // Arrange
+    const privateKeyPath = createTempRsaKeyFile();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        json: async () => [
+          {
+            id: 100,
+            account: { login: 'personal-user' },
+            target_type: 'User',
+          },
+          {
+            id: 200,
+            account: { login: 'getlarge' },
+            target_type: 'Organization',
+          },
+          {
+            id: 300,
+            account: { login: 'innovation-system' },
+            target_type: 'Organization',
+          },
+        ],
+      })),
+    );
+
+    // Act
+    const result = await findInstallationForOwner({
+      appId: '12345',
+      privateKeyPath,
+      owner: 'innovation-system',
+    });
+
+    // Assert
+    expect(result).toEqual({ installationId: '300' });
+  });
+
+  it('paginates across multiple pages to find the target installation', async () => {
+    // Arrange
+    const privateKeyPath = createTempRsaKeyFile();
+    const fetchMock = vi.fn();
+
+    // Page 1 — 100 installations, none matching
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: {
+        get: (name: string) =>
+          name.toLowerCase() === 'link'
+            ? '<https://api.github.com/app/installations?per_page=100&page=2>; rel="next"'
+            : null,
+      },
+      json: async () =>
+        Array.from({ length: 100 }, (_, i) => ({
+          id: 1000 + i,
+          account: { login: `org-${i}` },
+          target_type: 'Organization',
+        })),
+    });
+
+    // Page 2 — target found
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      json: async () => [
+        {
+          id: 5555,
+          account: { login: 'innovation-system' },
+          target_type: 'Organization',
+        },
+      ],
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    // Act
+    const result = await findInstallationForOwner({
+      appId: '12345',
+      privateKeyPath,
+      owner: 'innovation-system',
+    });
+
+    // Assert
+    expect(result).toEqual({ installationId: '5555' });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns null after exhausting all pages without a match', async () => {
+    // Arrange
+    const privateKeyPath = createTempRsaKeyFile();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        json: async () => [
+          {
+            id: 100,
+            account: { login: 'some-other-org' },
+            target_type: 'Organization',
+          },
+        ],
+      })),
+    );
+
+    // Act
+    const result = await findInstallationForOwner({
+      appId: '12345',
+      privateKeyPath,
+      owner: 'nonexistent-org',
+    });
+
+    // Assert
+    expect(result).toBeNull();
+  });
+
+  it('handles installations with null account gracefully', async () => {
+    // Arrange
+    const privateKeyPath = createTempRsaKeyFile();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        json: async () => [
+          { id: 100, account: null, target_type: 'Organization' },
+          {
+            id: 200,
+            account: { login: 'target-org' },
+            target_type: 'Organization',
+          },
+        ],
+      })),
+    );
+
+    // Act
+    const result = await findInstallationForOwner({
+      appId: '12345',
+      privateKeyPath,
+      owner: 'target-org',
+    });
+
+    // Assert
+    expect(result).toEqual({ installationId: '200' });
+  });
+
+  it('propagates GitHub API errors with status code', async () => {
+    // Arrange
+    const privateKeyPath = createTempRsaKeyFile();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: false,
+        status: 401,
+        text: async () => '{"message":"Bad credentials"}',
+      })),
+    );
+
+    // Act & Assert
+    await expect(
+      findInstallationForOwner({
+        appId: '12345',
+        privateKeyPath,
+        owner: 'target-org',
+      }),
+    ).rejects.toThrow(/401/);
+  });
+});
+
+/**
+ * E2E test — hits the real GitHub API.
+ *
+ * Set these env vars to run:
+ *   GITHUB_APP_ID         — the App's numeric ID
+ *   GITHUB_APP_PEM_PATH   — absolute path to the App's PEM private key
+ *   GITHUB_APP_OWNER      — an account/org where the App is installed
+ */
+const appId = process.env.GITHUB_APP_ID;
+const pemPath = process.env.GITHUB_APP_PEM_PATH;
+const owner = process.env.GITHUB_APP_OWNER;
+const canRunE2E = appId && pemPath && owner;
+
+describe.skipIf(!canRunE2E)('findInstallationForOwner (e2e)', () => {
+  it('finds the installation for a known owner', async () => {
+    const result = await findInstallationForOwner({
+      appId: appId!,
+      privateKeyPath: pemPath!,
+      owner: owner!,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.installationId).toMatch(/^\d+$/);
+  });
+
+  it('returns null for a non-existent owner', async () => {
+    const result = await findInstallationForOwner({
+      appId: appId!,
+      privateKeyPath: pemPath!,
+      owner: 'this-org-definitely-does-not-exist-xyzzy-42',
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('matches owner case-insensitively', async () => {
+    const result = await findInstallationForOwner({
+      appId: appId!,
+      privateKeyPath: pemPath!,
+      owner: owner!.toUpperCase(),
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.installationId).toMatch(/^\d+$/);
+  });
+});

--- a/packages/github-agent/src/index.ts
+++ b/packages/github-agent/src/index.ts
@@ -6,4 +6,4 @@ export {
   type SetupGitHubAgentOptions,
   type SetupGitHubAgentResult,
 } from './setup.js';
-export { getInstallationToken } from './token.js';
+export { findInstallationForOwner, getInstallationToken } from './token.js';

--- a/packages/github-agent/src/token.ts
+++ b/packages/github-agent/src/token.ts
@@ -68,6 +68,73 @@ async function writeTokenCache(
  * Uses a file-based cache next to the private key to avoid
  * hitting the GitHub API on every call.
  */
+interface AppInstallation {
+  id: number;
+  account: { login: string } | null;
+  target_type: string;
+}
+
+/**
+ * List all installations of this GitHub App and return the one whose
+ * `account.login` matches the given owner (case-insensitive).
+ *
+ * Uses the App JWT (not an installation token), so it works even when
+ * `installation_id` is missing or stale.
+ */
+export async function findInstallationForOwner(opts: {
+  appId: string;
+  privateKeyPath: string;
+  owner: string;
+}): Promise<{ installationId: string } | null> {
+  const privateKeyPem = await readFile(opts.privateKeyPath, 'utf-8');
+  const jwt = createAppJWT(opts.appId, privateKeyPem);
+  const ownerLower = opts.owner.toLowerCase();
+
+  let nextUrl: string | null =
+    'https://api.github.com/app/installations?per_page=100';
+  let pageCount = 0;
+  const MAX_PAGES = 10;
+
+  while (nextUrl && pageCount < MAX_PAGES) {
+    pageCount++;
+    const res: Response = await fetch(nextUrl, {
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    });
+
+    if (!res.ok) {
+      throw new Error(
+        `GitHub API error listing installations (${res.status}): ${await res.text()}`,
+      );
+    }
+
+    const installations = (await res.json()) as AppInstallation[];
+    const match = installations.find(
+      (i) => i.account?.login.toLowerCase() === ownerLower,
+    );
+    if (match) {
+      return { installationId: String(match.id) };
+    }
+
+    // Follow pagination
+    const linkHeader: string | null = res.headers.get('link');
+    nextUrl = linkHeader ? parseNextLinkHeader(linkHeader) : null;
+  }
+
+  return null;
+}
+
+function parseNextLinkHeader(header: string): string | null {
+  for (const part of header.split(',')) {
+    const match = part.match(/<([^>]+)>\s*;\s*rel="next"/);
+    if (match) return match[1];
+  }
+  return null;
+}
+
 export async function getInstallationToken(opts: {
   appId: string;
   privateKeyPath: string;

--- a/packages/github-agent/src/token.ts
+++ b/packages/github-agent/src/token.ts
@@ -93,6 +93,8 @@ export async function findInstallationForOwner(opts: {
   let nextUrl: string | null =
     'https://api.github.com/app/installations?per_page=100';
   let pageCount = 0;
+  // 10 × 100 = 1000 installations — generous for app installations
+  // (unlike repo pagination which uses 20 pages for per-installation repos).
   const MAX_PAGES = 10;
 
   while (nextUrl && pageCount < MAX_PAGES) {

--- a/packages/legreffier-cli/src/PortApp.tsx
+++ b/packages/legreffier-cli/src/PortApp.tsx
@@ -136,13 +136,16 @@ export function PortApp({
         filesWritten.push(rewriteResult.gitConfigPath);
         filesWritten.push(join(targetDir, 'env'));
 
-        // P3b — resolve installation_id for the target owner
+        // P3b — resolve installation_id for the target owner.
+        // Read the rewritten config from disk so private_key_path points
+        // to the copied PEM in targetDir, not the source machine path.
         setPhase('resolving_installation');
         const currentRepo = detectCurrentRepo(targetRepoDir);
         const prefix = toEnvPrefix(name);
+        const rewrittenConfig = (await readConfig(targetDir)) ?? config;
         const resolveResult = await runPortResolveInstallationPhase({
           targetDir,
-          config,
+          config: rewrittenConfig,
           currentRepo: currentRepo ?? undefined,
           envPrefix: prefix,
         });

--- a/packages/legreffier-cli/src/PortApp.tsx
+++ b/packages/legreffier-cli/src/PortApp.tsx
@@ -15,6 +15,7 @@ import {
   readSourceDiaryId,
   runPortDiaryPhase,
 } from './phases/portDiary.js';
+import { runPortResolveInstallationPhase } from './phases/portResolveInstallation.js';
 import { runPortRewritePhase } from './phases/portRewrite.js';
 import {
   type PortValidateResult,
@@ -37,6 +38,7 @@ type PortPhase =
   | 'validating'
   | 'copying'
   | 'rewriting'
+  | 'resolving_installation'
   | 'diary'
   | 'agent_setup'
   | 'verifying'
@@ -134,6 +136,23 @@ export function PortApp({
         filesWritten.push(rewriteResult.gitConfigPath);
         filesWritten.push(join(targetDir, 'env'));
 
+        // P3b — resolve installation_id for the target owner
+        setPhase('resolving_installation');
+        const currentRepo = detectCurrentRepo(targetRepoDir);
+        const prefix = toEnvPrefix(name);
+        const resolveResult = await runPortResolveInstallationPhase({
+          targetDir,
+          config,
+          currentRepo: currentRepo ?? undefined,
+          envPrefix: prefix,
+        });
+        if (
+          resolveResult.status === 'not-installed' ||
+          resolveResult.status === 'skipped'
+        ) {
+          warnings.push(resolveResult.message);
+        }
+
         // P4
         setPhase('diary');
         const sourceDiaryId = await readSourceDiaryId(sourceDir);
@@ -146,7 +165,6 @@ export function PortApp({
         // Per-agent tool files (claude/codex): skills, settings, rules.
         // Mirror what SetupApp does — reuse adapters directly.
         setPhase('agent_setup');
-        const prefix = toEnvPrefix(name);
         const mcpUrl =
           config.endpoints?.mcp ??
           apiUrl.replace('://api.', '://mcp.') + '/mcp';
@@ -163,7 +181,7 @@ export function PortApp({
             targetDir,
             basename(config.github?.private_key_path ?? ''),
           ),
-          installationId: config.github?.installation_id ?? '',
+          installationId: resolveResult.installationId,
         };
         for (const agentType of agents) {
           const adapter = adapters[agentType];
@@ -178,13 +196,12 @@ export function PortApp({
         }
 
         // P5 — warning-only. Use the rewritten target config so token
-        // minting reads the *copied* PEM (the source may have been on a
-        // different machine / become unreadable). Fall back to the source
-        // config only if the target read somehow fails.
+        // minting reads the *copied* PEM and the (possibly updated)
+        // installation_id. Fall back to the source config only if the
+        // target read somehow fails.
         setPhase('verifying');
         const targetConfig = await readConfig(targetDir);
         const verifyConfig = targetConfig ?? config;
-        const currentRepo = detectCurrentRepo(targetRepoDir);
         const verifyResult = await runPortVerifyInstallationPhase({
           config: verifyConfig,
           currentRepo: currentRepo ?? undefined,
@@ -236,6 +253,7 @@ export function PortApp({
       validating: `Validating source .moltnet/${name}...`,
       copying: `Copying private material...`,
       rewriting: `Rewriting paths in moltnet.json...`,
+      resolving_installation: `Resolving GitHub App installation for target org...`,
       diary: `Configuring diary (${diaryMode})...`,
       agent_setup: `Installing agent files for ${agents.join(', ')}...`,
       verifying: `Verifying GitHub App installation scope...`,

--- a/packages/legreffier-cli/src/env-file.ts
+++ b/packages/legreffier-cli/src/env-file.ts
@@ -106,11 +106,14 @@ export async function updateEnvVar(
     content = '';
   }
 
-  const pattern = new RegExp(`^${key}=.*$`, 'm');
   const line = `${key}=${q(value)}`;
+  const keyPrefix = `${key}=`;
+  const lines = content === '' ? [] : content.split('\n');
+  const index = lines.findIndex((l) => l.startsWith(keyPrefix));
 
-  if (pattern.test(content)) {
-    content = content.replace(pattern, line);
+  if (index !== -1) {
+    lines[index] = line;
+    content = lines.join('\n');
   } else {
     content = content.endsWith('\n')
       ? content + line + '\n'

--- a/packages/legreffier-cli/src/env-file.ts
+++ b/packages/legreffier-cli/src/env-file.ts
@@ -90,6 +90,37 @@ export async function writeEnvFile(opts: WriteEnvFileOptions): Promise<void> {
 }
 
 /**
+ * Update a single managed key in an existing env file.
+ * If the key exists, its value is replaced; otherwise appended.
+ */
+export async function updateEnvVar(
+  envDir: string,
+  key: string,
+  value: string,
+): Promise<void> {
+  const envPath = join(envDir, 'env');
+  let content: string;
+  try {
+    content = await readFile(envPath, 'utf-8');
+  } catch {
+    content = '';
+  }
+
+  const pattern = new RegExp(`^${key}=.*$`, 'm');
+  const line = `${key}=${q(value)}`;
+
+  if (pattern.test(content)) {
+    content = content.replace(pattern, line);
+  } else {
+    content = content.endsWith('\n')
+      ? content + line + '\n'
+      : content + '\n' + line + '\n';
+  }
+
+  await writeFile(envPath, content, 'utf-8');
+}
+
+/**
  * Resolve the human operator's git identity from global git config.
  * Must be called BEFORE GIT_CONFIG_GLOBAL is set (so it reads the
  * human's config, not the agent's).

--- a/packages/legreffier-cli/src/phases/portResolveInstallation.test.ts
+++ b/packages/legreffier-cli/src/phases/portResolveInstallation.test.ts
@@ -1,0 +1,182 @@
+import { readFile } from 'node:fs/promises';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { findInstallationForOwner } from '@themoltnet/github-agent';
+import type { MoltNetConfig } from '@themoltnet/sdk';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { writeEnvFile } from '../env-file.js';
+import { runPortResolveInstallationPhase } from './portResolveInstallation.js';
+
+vi.mock('@themoltnet/github-agent', () => ({
+  findInstallationForOwner: vi.fn(),
+}));
+
+const baseConfig: MoltNetConfig = {
+  identity_id: '11111111-1111-1111-1111-111111111111',
+  registered_at: '2025-01-01T00:00:00.000Z',
+  oauth2: { client_id: 'cid', client_secret: 'csec' },
+  keys: {
+    public_key: 'ed25519:abc',
+    private_key: 'ed25519:priv',
+    fingerprint: 'ed25519:fp',
+  },
+  endpoints: {
+    api: 'https://api.themolt.net',
+    mcp: 'https://mcp.themolt.net/mcp',
+  },
+  github: {
+    app_id: '2878569',
+    app_slug: 'legreffier',
+    installation_id: '110518607',
+    private_key_path: '/tmp/legreffier.pem',
+  },
+};
+
+let targetDir: string;
+
+beforeEach(async () => {
+  targetDir = await mkdtemp(join(tmpdir(), 'port-resolve-'));
+  // Seed a moltnet.json so updateConfigSection can read it
+  const { writeConfig } = await import('@themoltnet/sdk');
+  await writeConfig(baseConfig, targetDir);
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await rm(targetDir, { recursive: true, force: true });
+});
+
+describe('runPortResolveInstallationPhase', () => {
+  it('skips when currentRepo is absent', async () => {
+    const result = await runPortResolveInstallationPhase({
+      targetDir,
+      config: baseConfig,
+    });
+
+    expect(result.status).toBe('skipped');
+    expect(result.installationId).toBe('110518607');
+  });
+
+  it('skips when github.app_id is missing', async () => {
+    const config = {
+      ...baseConfig,
+      github: undefined,
+    };
+
+    const result = await runPortResolveInstallationPhase({
+      targetDir,
+      config,
+      currentRepo: 'innovation-system/on-board-nx',
+    });
+
+    expect(result.status).toBe('skipped');
+  });
+
+  it('returns not-installed when app has no installation for target owner', async () => {
+    vi.mocked(findInstallationForOwner).mockResolvedValue(null);
+
+    const result = await runPortResolveInstallationPhase({
+      targetDir,
+      config: baseConfig,
+      currentRepo: 'innovation-system/on-board-nx',
+    });
+
+    expect(result.status).toBe('not-installed');
+    expect(result.message).toContain('innovation-system');
+    expect(vi.mocked(findInstallationForOwner)).toHaveBeenCalledWith({
+      appId: '2878569',
+      privateKeyPath: '/tmp/legreffier.pem',
+      owner: 'innovation-system',
+    });
+  });
+
+  it('returns unchanged when installation_id already matches', async () => {
+    vi.mocked(findInstallationForOwner).mockResolvedValue({
+      installationId: '110518607',
+    });
+
+    const result = await runPortResolveInstallationPhase({
+      targetDir,
+      config: baseConfig,
+      currentRepo: 'getlarge/themoltnet',
+    });
+
+    expect(result.status).toBe('unchanged');
+    expect(result.installationId).toBe('110518607');
+  });
+
+  it('updates installation_id when target owner has a different installation', async () => {
+    vi.mocked(findInstallationForOwner).mockResolvedValue({
+      installationId: '999888777',
+    });
+
+    const result = await runPortResolveInstallationPhase({
+      targetDir,
+      config: baseConfig,
+      currentRepo: 'innovation-system/on-board-nx',
+    });
+
+    expect(result.status).toBe('updated');
+    expect(result.installationId).toBe('999888777');
+    expect(result.message).toContain('110518607');
+    expect(result.message).toContain('999888777');
+
+    // Verify moltnet.json was updated on disk
+    const { readConfig } = await import('@themoltnet/sdk');
+    const updated = await readConfig(targetDir);
+    expect(updated?.github?.installation_id).toBe('999888777');
+  });
+
+  it('updates the env file when envPrefix is provided', async () => {
+    vi.mocked(findInstallationForOwner).mockResolvedValue({
+      installationId: '999888777',
+    });
+
+    // Seed an env file with the old installation_id
+    await writeEnvFile({
+      envDir: targetDir,
+      agentName: 'legreffier',
+      prefix: 'LEGREFFIER',
+      clientId: 'cid',
+      clientSecret: 'csec',
+      appId: '2878569',
+      pemPath: '/tmp/legreffier.pem',
+      installationId: '110518607',
+    });
+
+    const result = await runPortResolveInstallationPhase({
+      targetDir,
+      config: baseConfig,
+      currentRepo: 'innovation-system/on-board-nx',
+      envPrefix: 'LEGREFFIER',
+    });
+
+    expect(result.status).toBe('updated');
+
+    const envContent = await readFile(join(targetDir, 'env'), 'utf-8');
+    expect(envContent).toContain(
+      "LEGREFFIER_GITHUB_APP_INSTALLATION_ID='999888777'",
+    );
+    expect(envContent).not.toContain('110518607');
+  });
+
+  it('downgrades to skipped on API errors', async () => {
+    vi.mocked(findInstallationForOwner).mockRejectedValue(
+      new Error(
+        'GitHub API error listing installations (401): Bad credentials',
+      ),
+    );
+
+    const result = await runPortResolveInstallationPhase({
+      targetDir,
+      config: baseConfig,
+      currentRepo: 'innovation-system/on-board-nx',
+    });
+
+    expect(result.status).toBe('skipped');
+    expect(result.message).toContain('401');
+  });
+});

--- a/packages/legreffier-cli/src/phases/portResolveInstallation.test.ts
+++ b/packages/legreffier-cli/src/phases/portResolveInstallation.test.ts
@@ -1,10 +1,9 @@
-import { readFile } from 'node:fs/promises';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { findInstallationForOwner } from '@themoltnet/github-agent';
-import type { MoltNetConfig } from '@themoltnet/sdk';
+import { type MoltNetConfig, readConfig, writeConfig } from '@themoltnet/sdk';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { writeEnvFile } from '../env-file.js';
@@ -40,7 +39,6 @@ let targetDir: string;
 beforeEach(async () => {
   targetDir = await mkdtemp(join(tmpdir(), 'port-resolve-'));
   // Seed a moltnet.json so updateConfigSection can read it
-  const { writeConfig } = await import('@themoltnet/sdk');
   await writeConfig(baseConfig, targetDir);
 });
 
@@ -125,7 +123,6 @@ describe('runPortResolveInstallationPhase', () => {
     expect(result.message).toContain('999888777');
 
     // Verify moltnet.json was updated on disk
-    const { readConfig } = await import('@themoltnet/sdk');
     const updated = await readConfig(targetDir);
     expect(updated?.github?.installation_id).toBe('999888777');
   });

--- a/packages/legreffier-cli/src/phases/portResolveInstallation.ts
+++ b/packages/legreffier-cli/src/phases/portResolveInstallation.ts
@@ -1,0 +1,109 @@
+import { findInstallationForOwner } from '@themoltnet/github-agent';
+import { type MoltNetConfig, updateConfigSection } from '@themoltnet/sdk';
+
+import { updateEnvVar } from '../env-file.js';
+
+export type ResolveInstallationStatus =
+  | 'updated'
+  | 'unchanged'
+  | 'not-installed'
+  | 'skipped';
+
+export interface PortResolveInstallationResult {
+  status: ResolveInstallationStatus;
+  message: string;
+  /** The installation_id now in the config (may be the original or the new one). */
+  installationId: string;
+}
+
+/**
+ * Resolve the correct `installation_id` for the target owner.
+ *
+ * When porting a config across orgs the source `installation_id` is scoped
+ * to the original account. This phase uses the App JWT to list all
+ * installations and find the one matching the target owner, then updates
+ * `moltnet.json` if it differs.
+ */
+export async function runPortResolveInstallationPhase(opts: {
+  targetDir: string;
+  config: MoltNetConfig;
+  /** owner/repo of the target repo, e.g. "innovation-system/on-board-nx". */
+  currentRepo?: string;
+  /** Env var prefix for the agent, e.g. "LEGREFFIER". */
+  envPrefix?: string;
+}): Promise<PortResolveInstallationResult> {
+  const { targetDir, config, currentRepo } = opts;
+
+  if (!currentRepo) {
+    return {
+      status: 'skipped',
+      message:
+        'unable to determine target repo — skipping installation_id resolution',
+      installationId: config.github?.installation_id ?? '',
+    };
+  }
+
+  if (!config.github?.app_id || !config.github?.private_key_path) {
+    return {
+      status: 'skipped',
+      message: 'github.app_id or private_key_path missing — cannot resolve',
+      installationId: config.github?.installation_id ?? '',
+    };
+  }
+
+  const targetOwner = currentRepo.split('/')[0];
+
+  let result: { installationId: string } | null;
+  try {
+    result = await findInstallationForOwner({
+      appId: config.github.app_id,
+      privateKeyPath: config.github.private_key_path,
+      owner: targetOwner,
+    });
+  } catch (err) {
+    return {
+      status: 'skipped',
+      message: `could not list app installations: ${(err as Error).message}`,
+      installationId: config.github?.installation_id ?? '',
+    };
+  }
+
+  if (!result) {
+    return {
+      status: 'not-installed',
+      message: `GitHub App is not installed on ${targetOwner} — install it first`,
+      installationId: config.github?.installation_id ?? '',
+    };
+  }
+
+  const oldId = config.github.installation_id;
+  if (oldId === result.installationId) {
+    return {
+      status: 'unchanged',
+      message: `installation_id ${oldId} already matches ${targetOwner}`,
+      installationId: oldId,
+    };
+  }
+
+  // Update moltnet.json with the resolved installation_id
+  await updateConfigSection(
+    'github',
+    { installation_id: result.installationId },
+    targetDir,
+  );
+
+  // Also patch the env file if a prefix was provided
+  if (opts.envPrefix) {
+    await updateEnvVar(
+      targetDir,
+      `${opts.envPrefix}_GITHUB_APP_INSTALLATION_ID`,
+      result.installationId,
+    );
+  }
+
+  return {
+    status: 'updated',
+    message: `installation_id updated: ${oldId || '(empty)'} → ${result.installationId} (${targetOwner})`,
+    installationId: result.installationId,
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `findInstallationForOwner()` to `@themoltnet/github-agent` — uses the App JWT to call `GET /app/installations` and match by `account.login` (case-insensitive, paginated)
- Adds `portResolveInstallation` phase to the port flow — runs between rewrite and diary, resolves the correct `installation_id` for the target owner and updates both `moltnet.json` and the env file
- Adds `updateEnvVar()` helper to `env-file.ts` for patching a single key in-place
- Adapter opts now use the resolved `installationId` instead of the stale source value

## Test plan

- [x] Unit tests for `findInstallationForOwner` (integration test file: JWT headers, multi-org selection, pagination, null accounts, API errors)
- [x] E2E tests for `findInstallationForOwner` gated behind `GITHUB_APP_ID` / `GITHUB_APP_PEM_PATH` / `GITHUB_APP_OWNER` env vars
- [x] Unit tests for `portResolveInstallation` phase (skip scenarios, not-installed, unchanged, updated with config + env file verification, API error downgrade)
- [ ] Manual: port legreffier config from `getlarge/themoltnet` to `innovation-system/on-board-nx` and verify `installation_id` is auto-updated

Closes #793