### PR TITLE
fix: add missing diary entry createdBy in API response

### DIFF
--- a/.agents/skills/legreffier-eval/SKILL.md
+++ b/.agents/skills/legreffier-eval/SKILL.md
@@ -12,7 +12,7 @@ and **author** (write + validate gap-test scenarios).
 ## Why subagent isolation matters
 
 An agent that writes a scenario knows the trap it designed. When it
-estimates baselines, it projects what it *thinks* the model will miss —
+estimates baselines, it projects what it _thinks_ the model will miss —
 not what actually happens. This produces fabricated baselines that
 collapse when measured.
 
@@ -81,6 +81,7 @@ file format details and examples.
 ### Steps
 
 1. If given a pack ID instead of a file, render it locally:
+
    ```bash
    npx @themoltnet/cli pack render --preview <pack-id> --out /tmp/pack.md
    ```
@@ -91,10 +92,10 @@ file format details and examples.
 
 3. Collect results into a delta report:
 
-   | Scenario | Baseline | With pack | Delta |
-   |----------|----------|-----------|-------|
-   | scenario-a | 20% | 75% | +55% |
-   | scenario-b | 90% | 95% | +5% |
+   | Scenario   | Baseline | With pack | Delta |
+   | ---------- | -------- | --------- | ----- |
+   | scenario-a | 20%      | 75%       | +55%  |
+   | scenario-b | 90%      | 95%       | +5%   |
 
 4. Record results as a diary entry if `DIARY_ID` is available:
    - `episodic` for surprising results (large delta, regression, 0% with-context)
@@ -164,7 +165,8 @@ before spawning the AUTHOR subagent.
 Two discovery paths: **diary-first** (browse incidents/decisions → follow
 relations to commits → validate ref) and **git-first** (search git for a
 code state → check for diary trailers). Both converge at a validated ref
-+ scenario seed content.
+
+- scenario seed content.
 
 See [references/fixture-ref-discovery.md](references/fixture-ref-discovery.md)
 for the full procedure with bash examples.
@@ -172,6 +174,7 @@ for the full procedure with bash examples.
 #### Step 1: Spawn AUTHOR subagent
 
 The author subagent receives:
+
 - Full project context (diary entries, rendered pack, codebase)
 - The gap-test design principles (from references/)
 - The gold standard scenario (`evals/moltnet-practices/dbos-after-commit/`)
@@ -179,6 +182,7 @@ The author subagent receives:
   (score only, NOT which criteria passed/failed)
 
 The author subagent produces:
+
 - `task.md`, `criteria.json`, `eval.json`, `fixtures/*`
 - An intent declaration in `rewrite-log.md`:
 
@@ -186,6 +190,7 @@ The author subagent produces:
 ## Iteration N
 
 ### Intent
+
 - **Trap**: what incorrect pattern am I tempting the model toward?
 - **Leak closed** (if rewrite): what hint did I remove vs previous iteration?
 - **Expected failure**: which criteria should the model fail, and why?
@@ -194,6 +199,7 @@ The author subagent produces:
 ```
 
 The author subagent does NOT:
+
 - Run any eval commands
 - Estimate or project baseline scores
 - Access previous iteration's criteria breakdown
@@ -227,30 +233,34 @@ the gate check (Step 3).
 
 The orchestrator (this conversation) applies the gate:
 
-| Mean baseline | Action |
-|--------------|--------|
-| ≤ 60% | **PASS** — scenario is a valid gap-test. Proceed to with-context validation. |
-| 61-80% | **MARGINAL** — compare author's expected failures vs actual. If the model passed criteria the author expected it to fail, the scenario leaks information. Rewrite. |
-| > 80% | **FAIL** — the model already knows the answer. Rewrite. |
+| Mean baseline | Action                                                                                                                                                             |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| ≤ 60%         | **PASS** — scenario is a valid gap-test. Proceed to with-context validation.                                                                                       |
+| 61-80%        | **MARGINAL** — compare author's expected failures vs actual. If the model passed criteria the author expected it to fail, the scenario leaks information. Rewrite. |
+| > 80%         | **FAIL** — the model already knows the answer. Rewrite.                                                                                                            |
 
 #### Step 4: Iterate or accept
 
 If the gate fails, spawn a new AUTHOR subagent with:
+
 - The iteration number
 - The aggregate score (e.g., "mean 75% across 2 runs")
 - NOT the per-criteria breakdown (to prevent reverse-engineering the judge)
 - The previous rewrite-log (so the author can see its own intent history)
 
 If the gate passes, optionally run with-context validation:
+
 ```bash
 npx @themoltnet/cli eval run --scenario <path> --pack <rendered-pack.md>
 ```
+
 - A positive delta (baseline → with-pack improvement ≥ 15 points) confirms
   the pack contains knowledge the scenario tests
 
 #### Step 5: Finalize
 
 When a scenario passes the gate:
+
 1. Remove `rewrite-log.md` (process artifact, not committed)
 2. Commit the scenario files
 3. Record the measured baseline + delta in a diary entry
@@ -277,6 +287,7 @@ AUTHOR (subagent):                 ORCHESTRATOR (main session):
 
 See [references/author-subagent-prompt.md](references/author-subagent-prompt.md)
 for the full template. Key constraints:
+
 - Must produce an intent declaration before writing files
 - Must NOT run eval commands or estimate scores
 - Must follow gap-test design principles from references/
@@ -286,6 +297,7 @@ for the full template. Key constraints:
 `evals/moltnet-practices/dbos-after-commit/` — scores 20% baseline.
 
 Properties that make it work:
+
 - TODOs placed inside the transaction callback (the wrong location)
 - Task never mentions "separate connections" or "DBOS"
 - 60% of score requires naming specific systems and failure modes
@@ -300,6 +312,7 @@ Study this before writing new scenarios.
 When `DIARY_ID` is available, record eval results as diary entries:
 
 **After pack evaluation (run mode):**
+
 ```
 entry_type: episodic (if delta > 20% or delta < 0)
 entry_type: semantic (if stable, expected results)
@@ -308,6 +321,7 @@ importance: 7 (surprising results) or 5 (expected results)
 ```
 
 **After scenario authoring:**
+
 ```
 entry_type: procedural
 tags: [scope:evals, eval:gap-test-design, branch:<current-branch>]

--- a/.agents/skills/legreffier-eval/references/fixture-ref-discovery.md
+++ b/.agents/skills/legreffier-eval/references/fixture-ref-discovery.md
@@ -9,31 +9,35 @@ Start from an episodic incident or semantic decision that represents
 knowledge the model wouldn't have from training data:
 
 1. Browse diary for seed entries:
+
    ```bash
    # Incidents where something broke unexpectedly
    npx @themoltnet/cli entry list --diary-id $DIARY_ID \
      --tags incident --limit 20
-   
+
    # Architectural decisions with non-obvious reasoning
    npx @themoltnet/cli entry list --diary-id $DIARY_ID \
      --tags decision --limit 20
    ```
 
 2. Follow relations from the seed entry to accountable commits:
+
    ```bash
    # Find procedural entries linked to the seed
    npx @themoltnet/cli relations list --entry-id <seed-entry-id>
-   
+
    # Search git for the commit that references the procedural entry
    git log --all --grep="MoltNet-Diary: <procedural-entry-id>" \
      --format="%H %s"
    ```
 
 3. Validate the candidate commit as a fixture.ref:
+
    ```bash
    git rev-parse --verify <candidate-hash>
    git show <candidate-hash>:<path/to/relevant/file> | head -20
    ```
+
    Verify the code state at that ref exhibits the precondition the
    scenario needs (e.g., a field that doesn't exist yet, a bug that
    hasn't been fixed).
@@ -46,18 +50,21 @@ knowledge the model wouldn't have from training data:
 ## Path B: Git-first (fallback — when you have a specific code state)
 
 1. Search git for a commit matching a condition:
+
    ```bash
    # Find commits that touched the relevant file
    git log --all --oneline -- <path/to/file> | head -20
-   
+
    # Check each candidate for the precondition
    git show <hash>:<path> | grep -c "pattern"
    ```
 
 2. Check for diary trailers on the candidate commit:
+
    ```bash
    git log -1 --format="%(trailers:key=MoltNet-Diary)" <hash>
    ```
+
    If present, fetch the diary entry for context enrichment (same as
    Path A step 4).
 

--- a/.agents/skills/legreffier-eval/references/gap-test-principles.md
+++ b/.agents/skills/legreffier-eval/references/gap-test-principles.md
@@ -40,7 +40,8 @@ from the provided code. If reading the fixtures reveals both the problem
 and the solution, you've given away the answer.
 
 **Test:** Have someone read only task.md + fixtures. If they can score
->70% without domain knowledge, the scenario leaks.
+
+> 70% without domain knowledge, the scenario leaks.
 
 ### 4. Criteria require articulation, not just correct code
 
@@ -98,7 +99,7 @@ answer. The former requires diagnosis; the latter is copy-paste.
 The `context` field in criteria.json is judge-only, but it shapes how
 the author designs criteria. If the context says "the correct timestamp
 is 1774560400011", the criteria will test for that exact value — and the
-fixture's _journal.json already shows the sequence. The scenario becomes
+fixture's \_journal.json already shows the sequence. The scenario becomes
 a lookup.
 
 ### Showing both patterns in fixtures

--- a/.agents/skills/legreffier-eval/references/scenario-format.md
+++ b/.agents/skills/legreffier-eval/references/scenario-format.md
@@ -6,12 +6,10 @@ Declares isolation mode and fixture injection.
 
 ```json
 {
-  "mode": "vitro",
   "fixture": {
-    "inject": [
-      { "from": "fixtures/some-file.ts", "to": "path/in/worktree.ts" }
-    ]
-  }
+    "inject": [{ "from": "fixtures/some-file.ts", "to": "path/in/worktree.ts" }]
+  },
+  "mode": "vitro"
 }
 ```
 
@@ -19,16 +17,17 @@ Declares isolation mode and fixture injection.
 
 ```json
 {
-  "mode": "vivo",
   "fixture": {
-    "ref": "abc123def456",
-    "exclude": ["node_modules/**", ".env*"]
-  }
+    "exclude": ["node_modules/**", ".env*"],
+    "ref": "abc123def456"
+  },
+  "mode": "vivo"
 }
 ```
 
 Vivo scenarios operate on the real repository at `fixture.ref`. The agent
 sees the full file tree (minus excluded patterns). Use vivo when:
+
 - The scenario tests multi-step workflows where step ordering matters
 - The agent needs to discover project structure (codegen chains, build deps)
 - Vitro isolation can't reproduce the failure (frontier models ace the
@@ -38,11 +37,13 @@ sees the full file tree (minus excluded patterns). Use vivo when:
 via `git rev-parse --verify` at runtime.
 
 **Modes:**
+
 - `vitro` — sparse worktree. Filesystem starts empty. Only injected
   fixtures are present. Agent receives task via prompt. Default.
 - `vivo` — real repo at a specific commit. Requires `fixture.ref`.
 
 **Choosing vitro vs vivo:**
+
 - **Vitro**: the knowledge being tested can be isolated to a few files.
   The agent receives only injected fixtures. Faster, cheaper, more
   deterministic.
@@ -64,6 +65,7 @@ What the agent under test receives. This is the entire prompt — the
 agent sees nothing else except the injected fixtures.
 
 Structure:
+
 ```markdown
 # <imperative title>
 
@@ -112,6 +114,7 @@ Weighted checklist scored by the judge. Scores must sum to 100.
 ```
 
 **The `context` field** is critical. It tells the judge:
+
 - What the scenario is actually testing
 - What the correct answer looks like
 - Why the intuitive/wrong answer fails
@@ -120,6 +123,7 @@ Weighted checklist scored by the judge. Scores must sum to 100.
 This context is visible to the judge but NOT to the agent under test.
 
 **Score distribution guidelines:**
+
 - ≥ 40% on articulation criteria (notes.md explains the WHY)
 - ≤ 60% on code-correctness criteria (code alone shouldn't pass)
 - Each criterion should be independently scorable (pass/fail)
@@ -143,18 +147,21 @@ Tracks the author's intent across iterations. Format:
 ## Iteration 1
 
 ### Intent
+
 - **Trap**: <what incorrect pattern am I tempting the model toward?>
 - **Leak closed**: <what hint did I remove vs previous iteration?>
 - **Expected failure**: <which criteria should the model fail, and why?>
 - **Knowledge required**: <what specific knowledge isn't in the fixtures?>
 
 ### Baseline result
+
 - **Score**: <measured, not estimated>
 - **Criteria passed**: [list]
 - **Criteria failed**: [list]
 - **Verdict**: PASS / MARGINAL / FAIL
 
 ### Intent vs reality
+
 - <Did the model fail where expected? If not, why?>
 ```
 
@@ -166,11 +173,11 @@ The eval runner writes results to a temp directory. Key fields:
 {
   "scenario": { "name": "...", "variant": "without-context" },
   "scores": {
-    "normalized_reward": 0.6,
     "criteria": {
-      "criterion_name_snake_case": 1,
-      "another_criterion": 0
-    }
+      "another_criterion": 0,
+      "criterion_name_snake_case": 1
+    },
+    "normalized_reward": 0.6
   },
   "usage": { "total_cost_usd": 0.128 }
 }

--- a/.agents/skills/legreffier-onboarding/SKILL.md
+++ b/.agents/skills/legreffier-onboarding/SKILL.md
@@ -78,22 +78,24 @@ context usage proportional to where the user actually is.
 ### Stage classification (from entry mix)
 
 After resolving `DIARY_ID`, fetch:
+
 ```
 entries_list({ diary_id: DIARY_ID, limit: 50 })
 ```
 
 Classify by `entryType`:
+
 - `procedural` (auto-harvested commits)
 - `semantic` NOT tagged `source:scan` (manual decisions)
 - `episodic` (manual incidents)
 - `reflection`
 
-| Condition | Stage |
-|-----------|-------|
-| total entries == 0 | Stage 2 (diary empty) |
-| only procedural + `source:scan` semantics | Stage 3 — auto-only |
-| exactly 1 manual semantic/episodic | Stage 3 — transitional |
-| >= 2 manual semantic/episodic | Stage 4 |
+| Condition                                 | Stage                  |
+| ----------------------------------------- | ---------------------- |
+| total entries == 0                        | Stage 2 (diary empty)  |
+| only procedural + `source:scan` semantics | Stage 3 — auto-only    |
+| exactly 1 manual semantic/episodic        | Stage 3 — transitional |
+| >= 2 manual semantic/episodic             | Stage 4                |
 
 ### Step continuation
 
@@ -126,6 +128,7 @@ remember to re-run the skill.
 
 For deeper context ("how does commit capture work", "full pipeline"),
 fetch on demand:
+
 ```
 https://raw.githubusercontent.com/getlarge/themoltnet/main/docs/GETTING_STARTED.md
 ```

--- a/.agents/skills/legreffier-onboarding/references/stage-3-auto-harvesting.md
+++ b/.agents/skills/legreffier-onboarding/references/stage-3-auto-harvesting.md
@@ -36,7 +36,7 @@ Classify by `entryType`:
 - total == 0 → still Stage 2
 - only procedural (+ `source:scan` semantics) → **Stage 3 — auto-only**
 - exactly 1 manual semantic/episodic → **Stage 3 — transitional**
-- > = 2 manual semantic/episodic → **Stage 4**
+- 2+ manual semantic/episodic → **Stage 4**
 
 ## Actions (in order, one at a time)
 

--- a/.agents/skills/legreffier-onboarding/references/stage-3-auto-harvesting.md
+++ b/.agents/skills/legreffier-onboarding/references/stage-3-auto-harvesting.md
@@ -3,6 +3,7 @@
 ## Signals
 
 Compute from `entries_list` response:
+
 - `LAST_ENTRY_AT` = max `createdAt`
 - `LAST_MANUAL_ENTRY_AT` = max `createdAt` filtered to non-`source:scan` semantic/episodic
 
@@ -10,6 +11,7 @@ Print: `<procedural-count> procedural entries. Last entry <N> days ago. No manua
 
 **Refinement — "auto-only stalled":** If only procedural/scan entries
 and `LAST_ENTRY_AT` > `STALE_MANUAL_DAYS`:
+
 > Commit capture is running but the last entry was `<N>` days ago.
 > If work has slowed here, that's fine; if not, check whether
 > `/legreffier` is firing on commits.
@@ -23,16 +25,18 @@ entries_list({ diary_id: DIARY_ID, limit: 50 })
 ```
 
 Classify by `entryType`:
+
 - `procedural` (auto-harvested commits)
 - `semantic` NOT tagged `source:scan` (manual decisions)
 - `episodic` (manual incidents)
 - `reflection`
 
 **Classification:**
+
 - total == 0 → still Stage 2
 - only procedural (+ `source:scan` semantics) → **Stage 3 — auto-only**
 - exactly 1 manual semantic/episodic → **Stage 3 — transitional**
-- >= 2 manual semantic/episodic → **Stage 4**
+- > = 2 manual semantic/episodic → **Stage 4**
 
 ## Actions (in order, one at a time)
 
@@ -45,10 +49,13 @@ Check `git status` for uncommitted setup files: `.claude/skills/`,
 `.agents/skills/`, `.mcp.json`, `.codex/config.toml`, `.gitignore`.
 
 If found:
+
 > You have uncommitted setup files from LeGreffier initialization:
+>
 > ```
 > <git status --short filtered to setup files>
 > ```
+>
 > Want to commit these? This will be your first accountable commit.
 
 **Commit workflow (minimal for onboarding):**
@@ -72,10 +79,12 @@ If found:
      -m "MoltNet-Diary: <entry-id>"
    ```
 4. **Push and verify signature:**
+
    ```bash
    git push origin HEAD
    git verify-commit HEAD
    ```
+
    - Signature valid → `Commit pushed and signature verified.`
    - Signature NOT valid → warn:
      > The commit was pushed but its signature is **not verified**.
@@ -92,6 +101,7 @@ entries_list({ diary_id: DIARY_ID, tags: ["system", "identity"], limit: 1 })
 ```
 
 If none:
+
 > You don't have an identity entry in this diary yet. This anchors
 > who you are for anyone reading this repo's history. Shall I create one?
 
@@ -131,6 +141,7 @@ git log --oneline -10
 ```
 
 Heuristics:
+
 - `refactor`, `migrate`, `redesign`, `rework` → semantic candidate
 - `fix`, `hotfix`, `revert`, `workaround` → episodic candidate
 - Large diffs (>200 lines) → worth capturing
@@ -140,9 +151,11 @@ Propose specifically if found. Skip silently if nothing interesting.
 ### Fallback
 
 No actions available:
+
 > Your commit capture flow is active — `<count>` procedural entries.
 > Next time something breaks, `/legreffier` captures it as episodic.
 
 Scan entries but no manual:
+
 > You ran a codebase scan (`<count>` entries). Next step: capture
 > live knowledge during real work sessions.

--- a/.agents/skills/legreffier-onboarding/references/stage-4-manual-capture.md
+++ b/.agents/skills/legreffier-onboarding/references/stage-4-manual-capture.md
@@ -2,7 +2,7 @@
 
 ## Detection
 
-> = 2 manual `semantic` or `episodic` entries exist.
+At least 2 manual `semantic` or `episodic` entries exist.
 
 ## Action
 

--- a/.agents/skills/legreffier-onboarding/references/stage-4-manual-capture.md
+++ b/.agents/skills/legreffier-onboarding/references/stage-4-manual-capture.md
@@ -2,7 +2,7 @@
 
 ## Detection
 
->= 2 manual `semantic` or `episodic` entries exist.
+> = 2 manual `semantic` or `episodic` entries exist.
 
 ## Action
 

--- a/.claude/skills/legreffier-eval/SKILL.md
+++ b/.claude/skills/legreffier-eval/SKILL.md
@@ -12,7 +12,7 @@ and **author** (write + validate gap-test scenarios).
 ## Why subagent isolation matters
 
 An agent that writes a scenario knows the trap it designed. When it
-estimates baselines, it projects what it *thinks* the model will miss —
+estimates baselines, it projects what it _thinks_ the model will miss —
 not what actually happens. This produces fabricated baselines that
 collapse when measured.
 
@@ -81,6 +81,7 @@ file format details and examples.
 ### Steps
 
 1. If given a pack ID instead of a file, render it locally:
+
    ```bash
    npx @themoltnet/cli pack render --preview <pack-id> --out /tmp/pack.md
    ```
@@ -91,10 +92,10 @@ file format details and examples.
 
 3. Collect results into a delta report:
 
-   | Scenario | Baseline | With pack | Delta |
-   |----------|----------|-----------|-------|
-   | scenario-a | 20% | 75% | +55% |
-   | scenario-b | 90% | 95% | +5% |
+   | Scenario   | Baseline | With pack | Delta |
+   | ---------- | -------- | --------- | ----- |
+   | scenario-a | 20%      | 75%       | +55%  |
+   | scenario-b | 90%      | 95%       | +5%   |
 
 4. Record results as a diary entry if `DIARY_ID` is available:
    - `episodic` for surprising results (large delta, regression, 0% with-context)
@@ -164,7 +165,8 @@ before spawning the AUTHOR subagent.
 Two discovery paths: **diary-first** (browse incidents/decisions → follow
 relations to commits → validate ref) and **git-first** (search git for a
 code state → check for diary trailers). Both converge at a validated ref
-+ scenario seed content.
+
+- scenario seed content.
 
 See [references/fixture-ref-discovery.md](references/fixture-ref-discovery.md)
 for the full procedure with bash examples.
@@ -172,6 +174,7 @@ for the full procedure with bash examples.
 #### Step 1: Spawn AUTHOR subagent
 
 The author subagent receives:
+
 - Full project context (diary entries, rendered pack, codebase)
 - The gap-test design principles (from references/)
 - The gold standard scenario (`evals/moltnet-practices/dbos-after-commit/`)
@@ -179,6 +182,7 @@ The author subagent receives:
   (score only, NOT which criteria passed/failed)
 
 The author subagent produces:
+
 - `task.md`, `criteria.json`, `eval.json`, `fixtures/*`
 - An intent declaration in `rewrite-log.md`:
 
@@ -186,6 +190,7 @@ The author subagent produces:
 ## Iteration N
 
 ### Intent
+
 - **Trap**: what incorrect pattern am I tempting the model toward?
 - **Leak closed** (if rewrite): what hint did I remove vs previous iteration?
 - **Expected failure**: which criteria should the model fail, and why?
@@ -194,6 +199,7 @@ The author subagent produces:
 ```
 
 The author subagent does NOT:
+
 - Run any eval commands
 - Estimate or project baseline scores
 - Access previous iteration's criteria breakdown
@@ -227,30 +233,34 @@ the gate check (Step 3).
 
 The orchestrator (this conversation) applies the gate:
 
-| Mean baseline | Action |
-|--------------|--------|
-| ≤ 60% | **PASS** — scenario is a valid gap-test. Proceed to with-context validation. |
-| 61-80% | **MARGINAL** — compare author's expected failures vs actual. If the model passed criteria the author expected it to fail, the scenario leaks information. Rewrite. |
-| > 80% | **FAIL** — the model already knows the answer. Rewrite. |
+| Mean baseline | Action                                                                                                                                                             |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| ≤ 60%         | **PASS** — scenario is a valid gap-test. Proceed to with-context validation.                                                                                       |
+| 61-80%        | **MARGINAL** — compare author's expected failures vs actual. If the model passed criteria the author expected it to fail, the scenario leaks information. Rewrite. |
+| > 80%         | **FAIL** — the model already knows the answer. Rewrite.                                                                                                            |
 
 #### Step 4: Iterate or accept
 
 If the gate fails, spawn a new AUTHOR subagent with:
+
 - The iteration number
 - The aggregate score (e.g., "mean 75% across 2 runs")
 - NOT the per-criteria breakdown (to prevent reverse-engineering the judge)
 - The previous rewrite-log (so the author can see its own intent history)
 
 If the gate passes, optionally run with-context validation:
+
 ```bash
 npx @themoltnet/cli eval run --scenario <path> --pack <rendered-pack.md>
 ```
+
 - A positive delta (baseline → with-pack improvement ≥ 15 points) confirms
   the pack contains knowledge the scenario tests
 
 #### Step 5: Finalize
 
 When a scenario passes the gate:
+
 1. Remove `rewrite-log.md` (process artifact, not committed)
 2. Commit the scenario files
 3. Record the measured baseline + delta in a diary entry
@@ -277,6 +287,7 @@ AUTHOR (subagent):                 ORCHESTRATOR (main session):
 
 See [references/author-subagent-prompt.md](references/author-subagent-prompt.md)
 for the full template. Key constraints:
+
 - Must produce an intent declaration before writing files
 - Must NOT run eval commands or estimate scores
 - Must follow gap-test design principles from references/
@@ -286,6 +297,7 @@ for the full template. Key constraints:
 `evals/moltnet-practices/dbos-after-commit/` — scores 20% baseline.
 
 Properties that make it work:
+
 - TODOs placed inside the transaction callback (the wrong location)
 - Task never mentions "separate connections" or "DBOS"
 - 60% of score requires naming specific systems and failure modes
@@ -300,6 +312,7 @@ Study this before writing new scenarios.
 When `DIARY_ID` is available, record eval results as diary entries:
 
 **After pack evaluation (run mode):**
+
 ```
 entry_type: episodic (if delta > 20% or delta < 0)
 entry_type: semantic (if stable, expected results)
@@ -308,6 +321,7 @@ importance: 7 (surprising results) or 5 (expected results)
 ```
 
 **After scenario authoring:**
+
 ```
 entry_type: procedural
 tags: [scope:evals, eval:gap-test-design, branch:<current-branch>]

--- a/.claude/skills/legreffier-eval/references/fixture-ref-discovery.md
+++ b/.claude/skills/legreffier-eval/references/fixture-ref-discovery.md
@@ -9,31 +9,35 @@ Start from an episodic incident or semantic decision that represents
 knowledge the model wouldn't have from training data:
 
 1. Browse diary for seed entries:
+
    ```bash
    # Incidents where something broke unexpectedly
    npx @themoltnet/cli entry list --diary-id $DIARY_ID \
      --tags incident --limit 20
-   
+
    # Architectural decisions with non-obvious reasoning
    npx @themoltnet/cli entry list --diary-id $DIARY_ID \
      --tags decision --limit 20
    ```
 
 2. Follow relations from the seed entry to accountable commits:
+
    ```bash
    # Find procedural entries linked to the seed
    npx @themoltnet/cli relations list --entry-id <seed-entry-id>
-   
+
    # Search git for the commit that references the procedural entry
    git log --all --grep="MoltNet-Diary: <procedural-entry-id>" \
      --format="%H %s"
    ```
 
 3. Validate the candidate commit as a fixture.ref:
+
    ```bash
    git rev-parse --verify <candidate-hash>
    git show <candidate-hash>:<path/to/relevant/file> | head -20
    ```
+
    Verify the code state at that ref exhibits the precondition the
    scenario needs (e.g., a field that doesn't exist yet, a bug that
    hasn't been fixed).
@@ -46,18 +50,21 @@ knowledge the model wouldn't have from training data:
 ## Path B: Git-first (fallback — when you have a specific code state)
 
 1. Search git for a commit matching a condition:
+
    ```bash
    # Find commits that touched the relevant file
    git log --all --oneline -- <path/to/file> | head -20
-   
+
    # Check each candidate for the precondition
    git show <hash>:<path> | grep -c "pattern"
    ```
 
 2. Check for diary trailers on the candidate commit:
+
    ```bash
    git log -1 --format="%(trailers:key=MoltNet-Diary)" <hash>
    ```
+
    If present, fetch the diary entry for context enrichment (same as
    Path A step 4).
 

--- a/.claude/skills/legreffier-eval/references/gap-test-principles.md
+++ b/.claude/skills/legreffier-eval/references/gap-test-principles.md
@@ -40,7 +40,8 @@ from the provided code. If reading the fixtures reveals both the problem
 and the solution, you've given away the answer.
 
 **Test:** Have someone read only task.md + fixtures. If they can score
->70% without domain knowledge, the scenario leaks.
+
+> 70% without domain knowledge, the scenario leaks.
 
 ### 4. Criteria require articulation, not just correct code
 
@@ -98,7 +99,7 @@ answer. The former requires diagnosis; the latter is copy-paste.
 The `context` field in criteria.json is judge-only, but it shapes how
 the author designs criteria. If the context says "the correct timestamp
 is 1774560400011", the criteria will test for that exact value — and the
-fixture's _journal.json already shows the sequence. The scenario becomes
+fixture's \_journal.json already shows the sequence. The scenario becomes
 a lookup.
 
 ### Showing both patterns in fixtures

--- a/.claude/skills/legreffier-eval/references/scenario-format.md
+++ b/.claude/skills/legreffier-eval/references/scenario-format.md
@@ -6,12 +6,10 @@ Declares isolation mode and fixture injection.
 
 ```json
 {
-  "mode": "vitro",
   "fixture": {
-    "inject": [
-      { "from": "fixtures/some-file.ts", "to": "path/in/worktree.ts" }
-    ]
-  }
+    "inject": [{ "from": "fixtures/some-file.ts", "to": "path/in/worktree.ts" }]
+  },
+  "mode": "vitro"
 }
 ```
 
@@ -19,16 +17,17 @@ Declares isolation mode and fixture injection.
 
 ```json
 {
-  "mode": "vivo",
   "fixture": {
-    "ref": "abc123def456",
-    "exclude": ["node_modules/**", ".env*"]
-  }
+    "exclude": ["node_modules/**", ".env*"],
+    "ref": "abc123def456"
+  },
+  "mode": "vivo"
 }
 ```
 
 Vivo scenarios operate on the real repository at `fixture.ref`. The agent
 sees the full file tree (minus excluded patterns). Use vivo when:
+
 - The scenario tests multi-step workflows where step ordering matters
 - The agent needs to discover project structure (codegen chains, build deps)
 - Vitro isolation can't reproduce the failure (frontier models ace the
@@ -38,11 +37,13 @@ sees the full file tree (minus excluded patterns). Use vivo when:
 via `git rev-parse --verify` at runtime.
 
 **Modes:**
+
 - `vitro` — sparse worktree. Filesystem starts empty. Only injected
   fixtures are present. Agent receives task via prompt. Default.
 - `vivo` — real repo at a specific commit. Requires `fixture.ref`.
 
 **Choosing vitro vs vivo:**
+
 - **Vitro**: the knowledge being tested can be isolated to a few files.
   The agent receives only injected fixtures. Faster, cheaper, more
   deterministic.
@@ -64,6 +65,7 @@ What the agent under test receives. This is the entire prompt — the
 agent sees nothing else except the injected fixtures.
 
 Structure:
+
 ```markdown
 # <imperative title>
 
@@ -112,6 +114,7 @@ Weighted checklist scored by the judge. Scores must sum to 100.
 ```
 
 **The `context` field** is critical. It tells the judge:
+
 - What the scenario is actually testing
 - What the correct answer looks like
 - Why the intuitive/wrong answer fails
@@ -120,6 +123,7 @@ Weighted checklist scored by the judge. Scores must sum to 100.
 This context is visible to the judge but NOT to the agent under test.
 
 **Score distribution guidelines:**
+
 - ≥ 40% on articulation criteria (notes.md explains the WHY)
 - ≤ 60% on code-correctness criteria (code alone shouldn't pass)
 - Each criterion should be independently scorable (pass/fail)
@@ -143,18 +147,21 @@ Tracks the author's intent across iterations. Format:
 ## Iteration 1
 
 ### Intent
+
 - **Trap**: <what incorrect pattern am I tempting the model toward?>
 - **Leak closed**: <what hint did I remove vs previous iteration?>
 - **Expected failure**: <which criteria should the model fail, and why?>
 - **Knowledge required**: <what specific knowledge isn't in the fixtures?>
 
 ### Baseline result
+
 - **Score**: <measured, not estimated>
 - **Criteria passed**: [list]
 - **Criteria failed**: [list]
 - **Verdict**: PASS / MARGINAL / FAIL
 
 ### Intent vs reality
+
 - <Did the model fail where expected? If not, why?>
 ```
 
@@ -166,11 +173,11 @@ The eval runner writes results to a temp directory. Key fields:
 {
   "scenario": { "name": "...", "variant": "without-context" },
   "scores": {
-    "normalized_reward": 0.6,
     "criteria": {
-      "criterion_name_snake_case": 1,
-      "another_criterion": 0
-    }
+      "another_criterion": 0,
+      "criterion_name_snake_case": 1
+    },
+    "normalized_reward": 0.6
   },
   "usage": { "total_cost_usd": 0.128 }
 }

--- a/.claude/skills/legreffier-onboarding/SKILL.md
+++ b/.claude/skills/legreffier-onboarding/SKILL.md
@@ -78,22 +78,24 @@ context usage proportional to where the user actually is.
 ### Stage classification (from entry mix)
 
 After resolving `DIARY_ID`, fetch:
+
 ```
 entries_list({ diary_id: DIARY_ID, limit: 50 })
 ```
 
 Classify by `entryType`:
+
 - `procedural` (auto-harvested commits)
 - `semantic` NOT tagged `source:scan` (manual decisions)
 - `episodic` (manual incidents)
 - `reflection`
 
-| Condition | Stage |
-|-----------|-------|
-| total entries == 0 | Stage 2 (diary empty) |
-| only procedural + `source:scan` semantics | Stage 3 — auto-only |
-| exactly 1 manual semantic/episodic | Stage 3 — transitional |
-| >= 2 manual semantic/episodic | Stage 4 |
+| Condition                                 | Stage                  |
+| ----------------------------------------- | ---------------------- |
+| total entries == 0                        | Stage 2 (diary empty)  |
+| only procedural + `source:scan` semantics | Stage 3 — auto-only    |
+| exactly 1 manual semantic/episodic        | Stage 3 — transitional |
+| >= 2 manual semantic/episodic             | Stage 4                |
 
 ### Step continuation
 
@@ -126,6 +128,7 @@ remember to re-run the skill.
 
 For deeper context ("how does commit capture work", "full pipeline"),
 fetch on demand:
+
 ```
 https://raw.githubusercontent.com/getlarge/themoltnet/main/docs/GETTING_STARTED.md
 ```

--- a/.claude/skills/legreffier-onboarding/references/stage-3-auto-harvesting.md
+++ b/.claude/skills/legreffier-onboarding/references/stage-3-auto-harvesting.md
@@ -36,7 +36,7 @@ Classify by `entryType`:
 - total == 0 → still Stage 2
 - only procedural (+ `source:scan` semantics) → **Stage 3 — auto-only**
 - exactly 1 manual semantic/episodic → **Stage 3 — transitional**
-- > = 2 manual semantic/episodic → **Stage 4**
+- 2+ manual semantic/episodic → **Stage 4**
 
 ## Actions (in order, one at a time)
 

--- a/.claude/skills/legreffier-onboarding/references/stage-3-auto-harvesting.md
+++ b/.claude/skills/legreffier-onboarding/references/stage-3-auto-harvesting.md
@@ -3,6 +3,7 @@
 ## Signals
 
 Compute from `entries_list` response:
+
 - `LAST_ENTRY_AT` = max `createdAt`
 - `LAST_MANUAL_ENTRY_AT` = max `createdAt` filtered to non-`source:scan` semantic/episodic
 
@@ -10,6 +11,7 @@ Print: `<procedural-count> procedural entries. Last entry <N> days ago. No manua
 
 **Refinement — "auto-only stalled":** If only procedural/scan entries
 and `LAST_ENTRY_AT` > `STALE_MANUAL_DAYS`:
+
 > Commit capture is running but the last entry was `<N>` days ago.
 > If work has slowed here, that's fine; if not, check whether
 > `/legreffier` is firing on commits.
@@ -23,16 +25,18 @@ entries_list({ diary_id: DIARY_ID, limit: 50 })
 ```
 
 Classify by `entryType`:
+
 - `procedural` (auto-harvested commits)
 - `semantic` NOT tagged `source:scan` (manual decisions)
 - `episodic` (manual incidents)
 - `reflection`
 
 **Classification:**
+
 - total == 0 → still Stage 2
 - only procedural (+ `source:scan` semantics) → **Stage 3 — auto-only**
 - exactly 1 manual semantic/episodic → **Stage 3 — transitional**
-- >= 2 manual semantic/episodic → **Stage 4**
+- > = 2 manual semantic/episodic → **Stage 4**
 
 ## Actions (in order, one at a time)
 
@@ -45,10 +49,13 @@ Check `git status` for uncommitted setup files: `.claude/skills/`,
 `.agents/skills/`, `.mcp.json`, `.codex/config.toml`, `.gitignore`.
 
 If found:
+
 > You have uncommitted setup files from LeGreffier initialization:
+>
 > ```
 > <git status --short filtered to setup files>
 > ```
+>
 > Want to commit these? This will be your first accountable commit.
 
 **Commit workflow (minimal for onboarding):**
@@ -72,10 +79,12 @@ If found:
      -m "MoltNet-Diary: <entry-id>"
    ```
 4. **Push and verify signature:**
+
    ```bash
    git push origin HEAD
    git verify-commit HEAD
    ```
+
    - Signature valid → `Commit pushed and signature verified.`
    - Signature NOT valid → warn:
      > The commit was pushed but its signature is **not verified**.
@@ -92,6 +101,7 @@ entries_list({ diary_id: DIARY_ID, tags: ["system", "identity"], limit: 1 })
 ```
 
 If none:
+
 > You don't have an identity entry in this diary yet. This anchors
 > who you are for anyone reading this repo's history. Shall I create one?
 
@@ -131,6 +141,7 @@ git log --oneline -10
 ```
 
 Heuristics:
+
 - `refactor`, `migrate`, `redesign`, `rework` → semantic candidate
 - `fix`, `hotfix`, `revert`, `workaround` → episodic candidate
 - Large diffs (>200 lines) → worth capturing
@@ -140,9 +151,11 @@ Propose specifically if found. Skip silently if nothing interesting.
 ### Fallback
 
 No actions available:
+
 > Your commit capture flow is active — `<count>` procedural entries.
 > Next time something breaks, `/legreffier` captures it as episodic.
 
 Scan entries but no manual:
+
 > You ran a codebase scan (`<count>` entries). Next step: capture
 > live knowledge during real work sessions.

--- a/.claude/skills/legreffier-onboarding/references/stage-4-manual-capture.md
+++ b/.claude/skills/legreffier-onboarding/references/stage-4-manual-capture.md
@@ -2,7 +2,7 @@
 
 ## Detection
 
-> = 2 manual `semantic` or `episodic` entries exist.
+At least 2 manual `semantic` or `episodic` entries exist.
 
 ## Action
 

--- a/.claude/skills/legreffier-onboarding/references/stage-4-manual-capture.md
+++ b/.claude/skills/legreffier-onboarding/references/stage-4-manual-capture.md
@@ -2,7 +2,7 @@
 
 ## Detection
 
->= 2 manual `semantic` or `episodic` entries exist.
+> = 2 manual `semantic` or `episodic` entries exist.
 
 ## Action
 

--- a/apps/console/src/config.ts
+++ b/apps/console/src/config.ts
@@ -30,8 +30,7 @@ export function getConfig(): AppConfig {
     };
   }
 
-  const isProd =
-    import.meta.env.PROD || import.meta.env.MODE === 'production';
+  const isProd = import.meta.env.PROD || import.meta.env.MODE === 'production';
 
   if (isProd) {
     throw new Error(
@@ -40,9 +39,11 @@ export function getConfig(): AppConfig {
   }
 
   return {
-    kratosUrl: normalizeUrl(import.meta.env.VITE_KRATOS_URL) || 'http://localhost:4433',
+    kratosUrl:
+      normalizeUrl(import.meta.env.VITE_KRATOS_URL) || 'http://localhost:4433',
     apiBaseUrl:
-      normalizeUrl(import.meta.env.VITE_API_BASE_URL) || 'http://localhost:8000',
+      normalizeUrl(import.meta.env.VITE_API_BASE_URL) ||
+      'http://localhost:8000',
     consoleUrl:
       normalizeUrl(import.meta.env.VITE_CONSOLE_URL) || 'http://localhost:5174',
   };

--- a/apps/console/src/diaries/utils.ts
+++ b/apps/console/src/diaries/utils.ts
@@ -67,9 +67,7 @@ export function estimateTokenCount(content: string): number {
   return Math.max(1, Math.round(content.length / 4));
 }
 
-export function getEntryTypeQuery(
-  value: string | null,
-): EntryType | null {
+export function getEntryTypeQuery(value: string | null): EntryType | null {
   if (!value) return null;
   return ENTRY_TYPE_OPTIONS.includes(value as EntryType)
     ? (value as EntryType)

--- a/apps/landing/src/config.ts
+++ b/apps/landing/src/config.ts
@@ -19,8 +19,7 @@ export function getConfig(): AppConfig {
     };
   }
 
-  const isProd =
-    import.meta.env.PROD || import.meta.env.MODE === 'production';
+  const isProd = import.meta.env.PROD || import.meta.env.MODE === 'production';
 
   if (isProd) {
     throw new Error(

--- a/apps/rest-api/__tests__/diary-entries.test.ts
+++ b/apps/rest-api/__tests__/diary-entries.test.ts
@@ -53,6 +53,7 @@ describe('Diary entry routes', () => {
 
       expect(response.statusCode).toBe(201);
       expect(response.json().content).toBe('Test diary entry content');
+      expect(response.json().createdBy).toBe(OWNER_ID);
       expect(mocks.diaryService.createEntry).toHaveBeenCalledWith(
         {
           diaryId: DIARY_ID,
@@ -146,6 +147,7 @@ describe('Diary entry routes', () => {
       const body = response.json();
       expect(body.items).toHaveLength(2);
       expect(body.total).toBe(5);
+      expect(body.items[0].createdBy).toBe(OWNER_ID);
     });
 
     it('passes query parameters through', async () => {
@@ -462,6 +464,7 @@ describe('Diary entry routes', () => {
 
       expect(response.statusCode).toBe(200);
       expect(response.json().id).toBe(ENTRY_ID);
+      expect(response.json().createdBy).toBe(OWNER_ID);
     });
 
     it('returns 404 when not found', async () => {
@@ -535,6 +538,7 @@ describe('Diary entry routes', () => {
 
       expect(response.statusCode).toBe(200);
       expect(response.json().results).toHaveLength(1);
+      expect(response.json().results[0].createdBy).toBe(OWNER_ID);
     });
 
     it('searches without query (lists all)', async () => {

--- a/apps/rest-api/__tests__/helpers.ts
+++ b/apps/rest-api/__tests__/helpers.ts
@@ -72,6 +72,7 @@ export function createMockEntry(
   return {
     id: ENTRY_ID,
     diaryId: DIARY_ID,
+    createdBy: OWNER_ID,
     title: null,
     content: 'Test diary entry content',
     embedding: null,

--- a/apps/rest-api/e2e/helpers.ts
+++ b/apps/rest-api/e2e/helpers.ts
@@ -16,6 +16,79 @@ import { cryptoService, type KeyPair } from '@moltnet/crypto-service';
 import { agentVouchers, type Database } from '@moltnet/database';
 import type { FrontendApi } from '@ory/client-fetch';
 
+// ── Polling Helpers ───────────────────────────────────────────────────────────
+
+export interface PollOptions {
+  /** Maximum number of attempts before giving up. Default: 20. */
+  maxAttempts?: number;
+  /** Delay between attempts in milliseconds. Default: 250. */
+  intervalMs?: number;
+  /**
+   * If true (default), throw a descriptive Error on timeout.
+   * If false, resolve with the last produced value instead.
+   */
+  throwOnTimeout?: boolean;
+  /** Label used in the timeout error message. */
+  label?: string;
+}
+
+/**
+ * Poll an async producer until its result satisfies `predicate`.
+ *
+ * Returns the first value matching the predicate. On timeout, throws by default
+ * (or returns the last produced value when `throwOnTimeout: false`).
+ *
+ * Use this for any e2e readiness check that depends on async/eventually-consistent
+ * state (DBOS workflows, Keto tuple propagation, search indexing, etc.).
+ */
+export async function pollUntil<T>(
+  produce: () => Promise<T>,
+  predicate: (value: T) => boolean,
+  options: PollOptions = {},
+): Promise<T> {
+  const {
+    maxAttempts = 20,
+    intervalMs = 250,
+    throwOnTimeout = true,
+    label = 'pollUntil',
+  } = options;
+
+  let last: T | undefined;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    last = await produce();
+    if (predicate(last)) return last;
+    await new Promise<void>((r) => {
+      setTimeout(r, intervalMs);
+    });
+  }
+
+  if (throwOnTimeout) {
+    throw new Error(
+      `${label}: condition not met after ${maxAttempts} attempts (${maxAttempts * intervalMs}ms)`,
+    );
+  }
+  return last as T;
+}
+
+/**
+ * Specialization of `pollUntil` for api-client calls: polls a request until
+ * `response.status` matches `targetStatus` (or any of the provided statuses).
+ *
+ * Returns the matching `{ data, response, error }` envelope. Throws on timeout
+ * unless `throwOnTimeout: false` is passed.
+ */
+export function pollUntilStatus<R extends { response: { status: number } }>(
+  request: () => Promise<R>,
+  targetStatus: number | readonly number[],
+  options: PollOptions = {},
+): Promise<R> {
+  const targets = Array.isArray(targetStatus) ? targetStatus : [targetStatus];
+  return pollUntil(request, (r) => targets.includes(r.response.status), {
+    label: `pollUntilStatus(${targets.join('|')})`,
+    ...options,
+  });
+}
+
 export interface TestAgent {
   identityId: string;
   keyPair: KeyPair;

--- a/apps/rest-api/e2e/team-governance.e2e.test.ts
+++ b/apps/rest-api/e2e/team-governance.e2e.test.ts
@@ -18,6 +18,7 @@ import {
   createDiary,
   createTeam,
   getDiary,
+  getTeam,
   initiateTransfer,
   listPendingTransfers,
   listTeams,
@@ -25,7 +26,12 @@ import {
 } from '@moltnet/api-client';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-import { createAgent, type TestAgent } from './helpers.js';
+import {
+  createAgent,
+  pollUntil,
+  pollUntilStatus,
+  type TestAgent,
+} from './helpers.js';
 import { createTestHarness, type TestHarness } from './setup.js';
 
 // ── Team Founding ─────────────────────────────────────────────────────────────
@@ -119,6 +125,26 @@ describe('Team Governance', () => {
       });
       expect(response.status).toBe(202);
       foundingTeamId = (data as { id: string }).id;
+
+      // The team-founding workflow runs async: a single step grants Keto roles
+      // AND seeds founding-acceptance rows. Until that step commits, agentB is
+      // invisible to the team and POST /teams/:id/accept returns 404 (the
+      // route's "no existence leak" guard). Wait until Keto sees agentB as a
+      // member — by then acceptance rows also exist.
+      await pollUntilStatus(
+        () =>
+          getTeam({
+            client,
+            auth: () => agentB.accessToken,
+            path: { id: foundingTeamId },
+          }),
+        200,
+        {
+          label: 'agentB sees founding team',
+          maxAttempts: 50,
+          intervalMs: 200,
+        },
+      );
     });
 
     it('outsider probing a founding team gets 404 — no existence leak', async () => {
@@ -164,22 +190,22 @@ describe('Team Governance', () => {
 
     it('accepting twice returns 409', async () => {
       // agentB already accepted above — poll until workflow has committed accepted status
-      for (let i = 0; i < 20; i++) {
-        const { response } = await acceptTeamFounding({
-          client,
-          auth: () => agentB.accessToken,
-          path: { id: foundingTeamId },
-          body: {},
-        });
-        if (response.status === 409) {
-          expect(response.status).toBe(409);
-          return;
-        }
-        await new Promise<void>((r) => {
-          setTimeout(r, 300);
-        });
-      }
-      throw new Error('Expected 409 after repeated accept but never got it');
+      const { response } = await pollUntilStatus(
+        () =>
+          acceptTeamFounding({
+            client,
+            auth: () => agentB.accessToken,
+            path: { id: foundingTeamId },
+            body: {},
+          }),
+        409,
+        {
+          label: 'repeated accept returns 409',
+          maxAttempts: 20,
+          intervalMs: 300,
+        },
+      );
+      expect(response.status).toBe(409);
     });
 
     it('unauthenticated gets 401', async () => {
@@ -421,21 +447,21 @@ describe('Team Governance', () => {
       });
 
       it('rejecting an already-resolved transfer returns 409', async () => {
-        for (let i = 0; i < 20; i++) {
-          const { response } = await rejectTransfer({
-            client,
-            auth: () => agentB.accessToken,
-            path: { transferId },
-          });
-          if (response.status === 409) {
-            expect(response.status).toBe(409);
-            return;
-          }
-          await new Promise<void>((r) => {
-            setTimeout(r, 500);
-          });
-        }
-        throw new Error('Transfer never reached rejected status after 10s');
+        const { response } = await pollUntilStatus(
+          () =>
+            rejectTransfer({
+              client,
+              auth: () => agentB.accessToken,
+              path: { transferId },
+            }),
+          409,
+          {
+            label: 'rejecting resolved transfer returns 409',
+            maxAttempts: 20,
+            intervalMs: 500,
+          },
+        );
+        expect(response.status).toBe(409);
       });
     });
 
@@ -489,41 +515,40 @@ describe('Team Governance', () => {
       });
 
       it('diary teamId is now destTeamId after acceptance', async () => {
-        // Poll briefly — the DBOS workflow swaps teamId asynchronously
-        let teamId: string | undefined;
-        for (let attempt = 0; attempt < 10; attempt++) {
-          const { data, response } = await getDiary({
-            client,
-            auth: () => agentB.accessToken,
-            path: { id: acceptDiaryId },
-          });
-          if (response.ok && data) {
-            teamId = data.teamId;
-            if (teamId === destTeamId) break;
-          }
-          await new Promise<void>((r) => {
-            setTimeout(r, 500);
-          });
-        }
-        expect(teamId).toBe(destTeamId);
+        // The DBOS workflow swaps teamId asynchronously
+        const { data } = await pollUntil(
+          () =>
+            getDiary({
+              client,
+              auth: () => agentB.accessToken,
+              path: { id: acceptDiaryId },
+            }),
+          (r) => r.response.ok && r.data?.teamId === destTeamId,
+          {
+            label: 'diary moved to destTeam',
+            maxAttempts: 10,
+            intervalMs: 500,
+          },
+        );
+        expect(data!.teamId).toBe(destTeamId);
       });
 
       it('accepting already-accepted transfer returns 409', async () => {
-        for (let i = 0; i < 20; i++) {
-          const { response } = await acceptTransfer({
-            client,
-            auth: () => agentB.accessToken,
-            path: { transferId },
-          });
-          if (response.status === 409) {
-            expect(response.status).toBe(409);
-            return;
-          }
-          await new Promise<void>((r) => {
-            setTimeout(r, 500);
-          });
-        }
-        throw new Error('Transfer never reached accepted status after 10s');
+        const { response } = await pollUntilStatus(
+          () =>
+            acceptTransfer({
+              client,
+              auth: () => agentB.accessToken,
+              path: { transferId },
+            }),
+          409,
+          {
+            label: 'accepting accepted transfer returns 409',
+            maxAttempts: 20,
+            intervalMs: 500,
+          },
+        );
+        expect(response.status).toBe(409);
       });
     });
   });

--- a/apps/rest-api/public/openapi.json
+++ b/apps/rest-api/public/openapi.json
@@ -1101,6 +1101,10 @@
             "format": "date-time",
             "type": "string"
           },
+          "createdBy": {
+            "format": "uuid",
+            "type": "string"
+          },
           "diaryId": {
             "format": "uuid",
             "type": "string"
@@ -1187,6 +1191,7 @@
         "required": [
           "id",
           "diaryId",
+          "createdBy",
           "title",
           "content",
           "tags",
@@ -1378,6 +1383,10 @@
             "format": "date-time",
             "type": "string"
           },
+          "createdBy": {
+            "format": "uuid",
+            "type": "string"
+          },
           "diaryId": {
             "format": "uuid",
             "type": "string"
@@ -1467,6 +1476,7 @@
         "required": [
           "id",
           "diaryId",
+          "createdBy",
           "title",
           "content",
           "tags",

--- a/apps/rest-api/src/schemas/diary.ts
+++ b/apps/rest-api/src/schemas/diary.ts
@@ -15,6 +15,7 @@ export const DiaryEntrySchema = Type.Object(
   {
     id: Type.String({ format: 'uuid' }),
     diaryId: Type.String({ format: 'uuid' }),
+    createdBy: Type.String({ format: 'uuid' }),
     title: Type.Union([Type.String(), Type.Null()]),
     content: Type.String(),
     tags: Type.Union([Type.Array(Type.String()), Type.Null()]),

--- a/evals/legreffier-explore/scenario-0/eval.json
+++ b/evals/legreffier-explore/scenario-0/eval.json
@@ -1,1 +1,1 @@
-{"mode":"vitro"}
+{ "mode": "vitro" }

--- a/evals/legreffier-explore/scenario-1/eval.json
+++ b/evals/legreffier-explore/scenario-1/eval.json
@@ -1,1 +1,1 @@
-{"mode":"vitro"}
+{ "mode": "vitro" }

--- a/evals/legreffier-explore/scenario-2/eval.json
+++ b/evals/legreffier-explore/scenario-2/eval.json
@@ -1,1 +1,1 @@
-{"mode":"vitro"}
+{ "mode": "vitro" }

--- a/evals/legreffier-explore/scenario-3/eval.json
+++ b/evals/legreffier-explore/scenario-3/eval.json
@@ -1,1 +1,1 @@
-{"mode":"vitro"}
+{ "mode": "vitro" }

--- a/evals/legreffier-explore/scenario-4/eval.json
+++ b/evals/legreffier-explore/scenario-4/eval.json
@@ -1,1 +1,1 @@
-{"mode":"vitro"}
+{ "mode": "vitro" }

--- a/evals/legreffier/scenario-0/eval.json
+++ b/evals/legreffier/scenario-0/eval.json
@@ -1,1 +1,1 @@
-{"mode":"vitro"}
+{ "mode": "vitro" }

--- a/evals/legreffier/scenario-1/eval.json
+++ b/evals/legreffier/scenario-1/eval.json
@@ -1,1 +1,1 @@
-{"mode":"vitro"}
+{ "mode": "vitro" }

--- a/evals/legreffier/scenario-2/eval.json
+++ b/evals/legreffier/scenario-2/eval.json
@@ -1,1 +1,1 @@
-{"mode":"vitro"}
+{ "mode": "vitro" }

--- a/evals/legreffier/scenario-3/eval.json
+++ b/evals/legreffier/scenario-3/eval.json
@@ -1,1 +1,1 @@
-{"mode":"vitro"}
+{ "mode": "vitro" }

--- a/evals/legreffier/scenario-4/eval.json
+++ b/evals/legreffier/scenario-4/eval.json
@@ -1,1 +1,1 @@
-{"mode":"vitro"}
+{ "mode": "vitro" }

--- a/evals/moltnet-practices/auth-middleware-early-return/criteria.json
+++ b/evals/moltnet-practices/auth-middleware-early-return/criteria.json
@@ -1,36 +1,36 @@
 {
-  "type": "weighted_checklist",
-  "context": "Tests whether the agent discovers that the session cookie path in optionalAuth returns early WITHOUT calling resolveTeamContext. The task asks to add audit logging that requires teamId, but session-authenticated users will never have teamId set. A model without context will write a correct audit hook but miss that session users are systematically excluded from audit coverage. The with-context variant (given the rendered pack naming PR #667) should identify the asymmetry, add resolveTeamContext to the session path, and explain why both auth paths must produce equivalent authContext objects.",
   "checklist": [
     {
-      "name": "Notes identify session path lacks team resolution",
       "description": "notes.md explicitly states that the session cookie path in optionalAuth returns without calling resolveTeamContext, meaning session-authenticated users will never have teamId populated. Must name both the session path and the missing resolveTeamContext call specifically — generic statements like 'teamId might be undefined' without identifying the root cause fail this criterion.",
-      "max_score": 30
+      "max_score": 30,
+      "name": "Notes identify session path lacks team resolution"
     },
     {
-      "name": "Notes explain the auth path asymmetry",
       "description": "notes.md explains that bearer token authentication calls resolveTeamContext but session cookie authentication does not, creating a functional asymmetry where the same identity gets different authContext shapes depending on which auth method is used. Must contrast the two paths explicitly.",
-      "max_score": 15
+      "max_score": 15,
+      "name": "Notes explain the auth path asymmetry"
     },
     {
-      "name": "Adds resolveTeamContext to session cookie path",
       "description": "auth-plugin-updated.ts modifies the session cookie path to call resolveTeamContext before returning, so both authentication methods produce an authContext with teamId when applicable. The call must happen AFTER successful session validation and BEFORE the early return.",
-      "max_score": 25
+      "max_score": 25,
+      "name": "Adds resolveTeamContext to session cookie path"
     },
     {
-      "name": "Audit hook emits correct event shape",
       "description": "The auditLog hook checks for request.authContext, checks for teamId, emits via request.server.auditEmitter.emit with identityId, teamId, method, url, and timestamp. Logs a warning when teamId is absent.",
-      "max_score": 15
+      "max_score": 15,
+      "name": "Audit hook emits correct event shape"
     },
     {
-      "name": "Audit hook registered after optionalAuth",
       "description": "The auditLog hook is registered after optionalAuth in the addHook chain so request.authContext is populated when it runs.",
-      "max_score": 10
+      "max_score": 10,
+      "name": "Audit hook registered after optionalAuth"
     },
     {
-      "name": "Preserves early-return on auth failure",
       "description": "The session path still returns without setting authContext when session validation fails (no session or invalid session). Only the success branch is modified.",
-      "max_score": 5
+      "max_score": 5,
+      "name": "Preserves early-return on auth failure"
     }
-  ]
+  ],
+  "context": "Tests whether the agent discovers that the session cookie path in optionalAuth returns early WITHOUT calling resolveTeamContext. The task asks to add audit logging that requires teamId, but session-authenticated users will never have teamId set. A model without context will write a correct audit hook but miss that session users are systematically excluded from audit coverage. The with-context variant (given the rendered pack naming PR #667) should identify the asymmetry, add resolveTeamContext to the session path, and explain why both auth paths must produce equivalent authContext objects.",
+  "type": "weighted_checklist"
 }

--- a/evals/moltnet-practices/auth-middleware-early-return/eval.json
+++ b/evals/moltnet-practices/auth-middleware-early-return/eval.json
@@ -1,9 +1,15 @@
 {
-  "mode": "vitro",
   "fixture": {
     "inject": [
-      { "from": "fixtures/auth-plugin.ts", "to": "libs/auth/src/auth-plugin.ts" },
-      { "from": "fixtures/team-resolver.ts", "to": "libs/auth/src/team-resolver.ts" }
+      {
+        "from": "fixtures/auth-plugin.ts",
+        "to": "libs/auth/src/auth-plugin.ts"
+      },
+      {
+        "from": "fixtures/team-resolver.ts",
+        "to": "libs/auth/src/team-resolver.ts"
+      }
     ]
-  }
+  },
+  "mode": "vitro"
 }

--- a/evals/moltnet-practices/auth-middleware-early-return/fixtures/auth-plugin.ts
+++ b/evals/moltnet-practices/auth-middleware-early-return/fixtures/auth-plugin.ts
@@ -1,4 +1,5 @@
-import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+
 import { resolveTeamContext } from './team-resolver.js';
 
 interface AuthContext {
@@ -51,10 +52,12 @@ function extractSessionCookie(request: FastifyRequest): string | undefined {
 }
 
 // --- Utility: check if a session is still valid ---
-function isSessionActive(session: {
-  active?: boolean;
-  expires_at?: string;
-} | null): boolean {
+function isSessionActive(
+  session: {
+    active?: boolean;
+    expires_at?: string;
+  } | null,
+): boolean {
   if (!session?.active) return false;
   if (session.expires_at) {
     return new Date(session.expires_at).getTime() > Date.now();

--- a/evals/moltnet-practices/auth-middleware-early-return/fixtures/team-resolver.ts
+++ b/evals/moltnet-practices/auth-middleware-early-return/fixtures/team-resolver.ts
@@ -1,4 +1,4 @@
-import { FastifyRequest } from 'fastify';
+import type { FastifyRequest } from 'fastify';
 
 interface AuthContext {
   identityId: string;
@@ -37,11 +37,10 @@ export async function resolveTeamContext(
       );
     }
 
-    const isMember =
-      await request.server.permissionChecker.checkTeamMembership(
-        authContext.identityId,
-        teamHeader,
-      );
+    const isMember = await request.server.permissionChecker.checkTeamMembership(
+      authContext.identityId,
+      teamHeader,
+    );
     if (!isMember) {
       throw request.server.httpErrors.forbidden(
         'Not a member of the specified team',

--- a/evals/moltnet-practices/auth-middleware-early-return/task.md
+++ b/evals/moltnet-practices/auth-middleware-early-return/task.md
@@ -22,10 +22,10 @@ Add an `auditLog` preHandler hook to the auth plugin that:
    ```typescript
    {
      identityId: string;
-     teamId: string;      // required — compliance needs this
-     method: string;       // request.method
-     url: string;          // request.url
-     timestamp: number;    // Date.now()
+     teamId: string; // required — compliance needs this
+     method: string; // request.method
+     url: string; // request.url
+     timestamp: number; // Date.now()
    }
    ```
 3. Skips unauthenticated requests (no `authContext`)

--- a/evals/moltnet-practices/codegen-chain-go-client/criteria.json
+++ b/evals/moltnet-practices/codegen-chain-go-client/criteria.json
@@ -1,31 +1,31 @@
 {
-  "type": "weighted_checklist",
-  "context": "Tests whether the agent discovers and executes the full MoltNet codegen chain when adding a schema field. The chain is: (1) edit ContextPackSchema in apps/rest-api/src/schemas/packs.ts, (2) regenerate OpenAPI spec (pnpm run generate:openapi), (3) regenerate Go api-client (pnpm run go:generate). Most agents will do step 1 and maybe step 2, but forget step 3 because go:generate is not mentioned in the schema file, the Go build stays green with the stale client, and the failure only appears at runtime. The without-context baseline is expected to miss step 3. The with-context variant (given codegen chain documentation) should execute all three steps.",
   "checklist": [
     {
-      "name": "Schema field added correctly",
       "description": "ContextPackSchema in apps/rest-api/src/schemas/packs.ts has a new optional string field pinned_reason. The TypeScript type is correct (Type.Optional(Type.String()) or equivalent TypeBox pattern).",
-      "max_score": 15
+      "max_score": 15,
+      "name": "Schema field added correctly"
     },
     {
-      "name": "OpenAPI spec regenerated",
       "description": "The agent ran pnpm run generate:openapi (or equivalent) to regenerate the OpenAPI spec from the updated schema. Evidence: git diff shows changes in the OpenAPI spec file, or notes.md mentions running the command.",
-      "max_score": 20
+      "max_score": 20,
+      "name": "OpenAPI spec regenerated"
     },
     {
-      "name": "Go client regenerated",
       "description": "The agent ran pnpm run go:generate (or go generate ./libs/moltnet-api-client/...) to regenerate the Go api-client from the updated OpenAPI spec. Evidence: git diff shows changes in libs/moltnet-api-client/ generated files, or notes.md mentions running the command. This is the critical step most agents miss.",
-      "max_score": 30
+      "max_score": 30,
+      "name": "Go client regenerated"
     },
     {
-      "name": "Notes explain codegen dependency chain",
       "description": "notes.md explains that the schema change triggers a dependency chain: schema -> OpenAPI spec -> Go client. The agent articulates WHY the Go client must be regenerated (it is generated from the OpenAPI spec, not directly from TypeScript types) and what happens if you skip it (runtime JSON decode errors in the CLI).",
-      "max_score": 25
+      "max_score": 25,
+      "name": "Notes explain codegen dependency chain"
     },
     {
-      "name": "Build verification",
       "description": "The agent ran verification commands after the changes: at minimum pnpm run typecheck and go build or go vet on the CLI. Notes.md or workspace evidence shows verification was attempted.",
-      "max_score": 10
+      "max_score": 10,
+      "name": "Build verification"
     }
-  ]
+  ],
+  "context": "Tests whether the agent discovers and executes the full MoltNet codegen chain when adding a schema field. The chain is: (1) edit ContextPackSchema in apps/rest-api/src/schemas/packs.ts, (2) regenerate OpenAPI spec (pnpm run generate:openapi), (3) regenerate Go api-client (pnpm run go:generate). Most agents will do step 1 and maybe step 2, but forget step 3 because go:generate is not mentioned in the schema file, the Go build stays green with the stale client, and the failure only appears at runtime. The without-context baseline is expected to miss step 3. The with-context variant (given codegen chain documentation) should execute all three steps.",
+  "type": "weighted_checklist"
 }

--- a/evals/moltnet-practices/codegen-chain-go-client/eval.json
+++ b/evals/moltnet-practices/codegen-chain-go-client/eval.json
@@ -1,6 +1,6 @@
 {
-  "mode": "vivo",
   "fixture": {
     "ref": "15afdcc1d23b9a950de9723250051744ce673772"
-  }
+  },
+  "mode": "vivo"
 }

--- a/evals/moltnet-practices/codegen-chain-go-client/task.md
+++ b/evals/moltnet-practices/codegen-chain-go-client/task.md
@@ -20,6 +20,7 @@ packs should include this field in its response.
 ## Output
 
 Produce `notes.md` explaining:
+
 - What you changed and why
 - Which artifacts you regenerated and in what order
 - Any concerns about the change

--- a/evals/moltnet-practices/e2e-raw-fetch-vs-api-client/criteria.json
+++ b/evals/moltnet-practices/e2e-raw-fetch-vs-api-client/criteria.json
@@ -1,36 +1,36 @@
 {
-  "type": "weighted_checklist",
-  "context": "Tests whether the agent knows the MoltNet-specific convention: e2e tests MUST use the generated @moltnet/api-client functions (consolidateDiary, compileDiary, listDiaryPacks, getContextPackById, etc.) for any endpoint defined in the OpenAPI spec, not raw fetch(). The reference fixture (helpers.ts) uses raw fetch() for /auth/register and /oauth2/token — this is CORRECT because those are Ory proxy pass-through endpoints that are NOT part of the MoltNet OpenAPI spec. The trap: the model copies the raw fetch pattern from helpers.ts and applies it to consolidation/compile endpoints that ARE in the spec. Without context, the model sees working raw fetch code and has no reason to switch. The with-context variant should recognize that consolidate, compile, listDiaryPacks, and getContextPackById all exist in sdk.gen.ts and must be called via createClient() + the generated functions, following the { client, auth, path, body } calling convention used in the real e2e test suite.",
   "checklist": [
     {
-      "name": "Notes explain WHY helpers.ts correctly uses raw fetch",
       "description": "notes.md explicitly states that /auth/register and /oauth2/token are Ory proxy pass-through endpoints NOT part of the MoltNet OpenAPI spec, so raw fetch is the correct choice for them. Generic statements like 'helpers use fetch for setup' or 'some endpoints need fetch' fail — the notes must name the specific endpoints AND explain they are outside the spec.",
-      "max_score": 25
+      "max_score": 25,
+      "name": "Notes explain WHY helpers.ts correctly uses raw fetch"
     },
     {
-      "name": "Notes state the boundary rule for when to use each approach",
       "description": "notes.md articulates the rule: use the generated client for any endpoint defined in the OpenAPI spec; raw fetch only for endpoints that are not in the spec (auth/register, oauth2/token). Must explicitly name at least two spec endpoints (e.g., consolidateDiary, compileDiary, listDiaryPacks) as belonging to the generated client. Vague statements about 'type safety' or 'best practices' without naming the spec boundary fail.",
-      "max_score": 20
+      "max_score": 20,
+      "name": "Notes state the boundary rule for when to use each approach"
     },
     {
-      "name": "Uses generated client functions for consolidate and compile",
       "description": "The test file imports and calls consolidateDiary and compileDiary (or equivalent generated functions) from @moltnet/api-client instead of raw fetch() for the POST /diaries/:id/consolidate and POST /diaries/:id/compile endpoints. The calling convention must use { client, auth: () => token, path: { id }, body: { ... } } pattern, not a custom wrapper.",
-      "max_score": 20
+      "max_score": 20,
+      "name": "Uses generated client functions for consolidate and compile"
     },
     {
-      "name": "Uses generated client functions for pack listing and retrieval",
       "description": "The test file imports and calls listDiaryPacks and getContextPackById from @moltnet/api-client for GET /diaries/:id/packs and GET /packs/:id respectively, instead of raw fetch().",
-      "max_score": 15
+      "max_score": 15,
+      "name": "Uses generated client functions for pack listing and retrieval"
     },
     {
-      "name": "Setup uses createClient and auth callback pattern",
       "description": "The test creates a client via createClient({ baseUrl }) and passes auth as a callback (auth: () => token) to each generated function call, matching the pattern used in the real e2e test suite (diary-grants.e2e.test.ts, team-governance.e2e.test.ts). Tests that create a one-off wrapper or use a different auth mechanism fail.",
-      "max_score": 10
+      "max_score": 10,
+      "name": "Setup uses createClient and auth callback pattern"
     },
     {
-      "name": "Auth and forbidden tests still work correctly",
       "description": "The 401 (no auth) and 403 (wrong agent) tests produce correct assertions. The 401 test omits the auth callback entirely (not passing an empty string). The 403 test uses a different agent's token.",
-      "max_score": 10
+      "max_score": 10,
+      "name": "Auth and forbidden tests still work correctly"
     }
-  ]
+  ],
+  "context": "Tests whether the agent knows the MoltNet-specific convention: e2e tests MUST use the generated @moltnet/api-client functions (consolidateDiary, compileDiary, listDiaryPacks, getContextPackById, etc.) for any endpoint defined in the OpenAPI spec, not raw fetch(). The reference fixture (helpers.ts) uses raw fetch() for /auth/register and /oauth2/token — this is CORRECT because those are Ory proxy pass-through endpoints that are NOT part of the MoltNet OpenAPI spec. The trap: the model copies the raw fetch pattern from helpers.ts and applies it to consolidation/compile endpoints that ARE in the spec. Without context, the model sees working raw fetch code and has no reason to switch. The with-context variant should recognize that consolidate, compile, listDiaryPacks, and getContextPackById all exist in sdk.gen.ts and must be called via createClient() + the generated functions, following the { client, auth, path, body } calling convention used in the real e2e test suite.",
+  "type": "weighted_checklist"
 }

--- a/evals/moltnet-practices/e2e-raw-fetch-vs-api-client/eval.json
+++ b/evals/moltnet-practices/e2e-raw-fetch-vs-api-client/eval.json
@@ -1,9 +1,15 @@
 {
-  "mode": "vitro",
   "fixture": {
     "inject": [
-      { "from": "fixtures/governance.e2e.test.ts", "to": "apps/rest-api/e2e/helpers.ts" },
-      { "from": "fixtures/sdk.gen.ts", "to": "libs/api-client/src/generated/sdk.gen.ts" }
+      {
+        "from": "fixtures/governance.e2e.test.ts",
+        "to": "apps/rest-api/e2e/helpers.ts"
+      },
+      {
+        "from": "fixtures/sdk.gen.ts",
+        "to": "libs/api-client/src/generated/sdk.gen.ts"
+      }
     ]
-  }
+  },
+  "mode": "vitro"
 }

--- a/evals/moltnet-practices/e2e-raw-fetch-vs-api-client/fixtures/governance.e2e.test.ts
+++ b/evals/moltnet-practices/e2e-raw-fetch-vs-api-client/fixtures/governance.e2e.test.ts
@@ -18,8 +18,6 @@ import { randomBytes } from 'node:crypto';
 
 import { agentVouchers, type Database } from '@moltnet/database';
 
-const BASE_URL = process.env.SERVER_BASE_URL ?? 'http://localhost:8080';
-
 export interface TestAgent {
   identityId: string;
   clientId: string;
@@ -81,7 +79,9 @@ export async function createAgent(opts: {
   });
 
   if (!regRes.ok) {
-    throw new Error(`Registration failed: ${regRes.status} ${await regRes.text()}`);
+    throw new Error(
+      `Registration failed: ${regRes.status} ${await regRes.text()}`,
+    );
   }
 
   const creds = (await regRes.json()) as {
@@ -103,7 +103,9 @@ export async function createAgent(opts: {
   });
 
   if (!tokenRes.ok) {
-    throw new Error(`Token acquisition failed: ${tokenRes.status} ${await tokenRes.text()}`);
+    throw new Error(
+      `Token acquisition failed: ${tokenRes.status} ${await tokenRes.text()}`,
+    );
   }
 
   const { access_token } = (await tokenRes.json()) as { access_token: string };

--- a/evals/moltnet-practices/e2e-raw-fetch-vs-api-client/fixtures/sdk.gen.ts
+++ b/evals/moltnet-practices/e2e-raw-fetch-vs-api-client/fixtures/sdk.gen.ts
@@ -1264,15 +1264,13 @@ export const createTeam = <ThrowOnError extends boolean = false>(
 export const getTeam = <ThrowOnError extends boolean = false>(
   options: Options<GetTeamData, ThrowOnError>,
 ) =>
-  (options.client ?? client).get<
-    GetTeamResponses,
-    GetTeamErrors,
-    ThrowOnError
-  >({
-    security: [{ scheme: 'bearer', type: 'http' }],
-    url: '/teams/{id}',
-    ...options,
-  });
+  (options.client ?? client).get<GetTeamResponses, GetTeamErrors, ThrowOnError>(
+    {
+      security: [{ scheme: 'bearer', type: 'http' }],
+      url: '/teams/{id}',
+      ...options,
+    },
+  );
 
 /**
  * Delete a team.
@@ -1628,9 +1626,11 @@ export const getTrustGraph = <ThrowOnError extends boolean = false>(
 export const getNetworkInfo = <ThrowOnError extends boolean = false>(
   options?: Options<GetNetworkInfoData, ThrowOnError>,
 ) =>
-  (options?.client ?? client).get<GetNetworkInfoResponses, unknown, ThrowOnError>(
-    { url: '/network/info', ...options },
-  );
+  (options?.client ?? client).get<
+    GetNetworkInfoResponses,
+    unknown,
+    ThrowOnError
+  >({ url: '/network/info', ...options });
 
 /**
  * Get the LLMs.txt file for the API.
@@ -1731,9 +1731,7 @@ export const getLegreffierOnboardingStatus = <
 /**
  * Start the LeGreffier onboarding workflow for the authenticated agent.
  */
-export const startLegreffierOnboarding = <
-  ThrowOnError extends boolean = false,
->(
+export const startLegreffierOnboarding = <ThrowOnError extends boolean = false>(
   options: Options<StartLegreffierOnboardingData, ThrowOnError>,
 ) =>
   (options.client ?? client).post<
@@ -1753,9 +1751,7 @@ export const startLegreffierOnboarding = <
 /**
  * Request a recovery challenge for an agent that has lost its credentials.
  */
-export const requestRecoveryChallenge = <
-  ThrowOnError extends boolean = false,
->(
+export const requestRecoveryChallenge = <ThrowOnError extends boolean = false>(
   options: Options<RequestRecoveryChallengeData, ThrowOnError>,
 ) =>
   (options.client ?? client).post<
@@ -1774,9 +1770,7 @@ export const requestRecoveryChallenge = <
 /**
  * Verify a recovery challenge by submitting the signed nonce.
  */
-export const verifyRecoveryChallenge = <
-  ThrowOnError extends boolean = false,
->(
+export const verifyRecoveryChallenge = <ThrowOnError extends boolean = false>(
   options: Options<VerifyRecoveryChallengeData, ThrowOnError>,
 ) =>
   (options.client ?? client).post<

--- a/evals/moltnet-practices/go-cli-multi-status-response/criteria.json
+++ b/evals/moltnet-practices/go-cli-multi-status-response/criteria.json
@@ -1,31 +1,31 @@
 {
-  "type": "weighted_checklist",
-  "context": "Tests whether the agent recognizes that ogen generates distinct Go types per HTTP status code, and that copying the single type-assertion pattern from packs_get.go silently breaks for endpoints returning multiple success statuses. The packs get endpoint only returns 200, so a single assertion works. The compile endpoint returns either 200 (CompilePackOK, synchronous completion with the compiled Pack) or 202 (CompilePackAccepted, async job with a jobId string). A single `res.(*CompilePackOK)` assertion returns false when the server responds 202, causing `formatAPIError` to report a spurious error even though compilation was accepted. The task.md intentionally does NOT mention this, does NOT include the decoder file, and frames the work as 'follow the existing pattern'. The model must know from project context that ogen endpoints can have multiple success types and that the compile endpoint specifically returns 200 or 202.",
   "checklist": [
     {
-      "name": "Notes explain ogen per-status-code type generation",
       "description": "notes.md explicitly states that ogen generates a separate Go type for each HTTP status code (e.g. CompilePackOK for 200, CompilePackAccepted for 202), or explains that the response is a sum type / interface with multiple concrete implementations. Generic statements like 'handle errors properly' without naming the per-status-code type mapping fail this criterion.",
-      "max_score": 25
+      "max_score": 25,
+      "name": "Notes explain ogen per-status-code type generation"
     },
     {
-      "name": "Notes describe the silent failure mode of single assertion",
       "description": "notes.md explains what goes wrong if you copy the packs_get.go pattern: the type assertion `res.(*CompilePackOK)` returns false when the server responds 202, so `formatAPIError` prints a misleading error even though compilation was accepted server-side. Notes that only say 'use a type switch' without describing the failure mode fail this criterion.",
-      "max_score": 20
+      "max_score": 20,
+      "name": "Notes describe the silent failure mode of single assertion"
     },
     {
-      "name": "Handles both success types",
       "description": "The response handling uses a type switch (or equivalent multiple assertions) that treats both *CompilePackOK and *CompilePackAccepted as success cases. The 202 branch should surface the job ID or indicate async acceptance. Code that only asserts for one of the two types fails this criterion.",
-      "max_score": 30
+      "max_score": 30,
+      "name": "Handles both success types"
     },
     {
-      "name": "Async path prints job ID or acceptance message",
       "description": "The 202 path prints the job ID or a message indicating compilation was accepted for async processing. It does NOT attempt to JSON-decode a Pack struct from the 202 response. The 200 path may print the compiled pack details.",
-      "max_score": 10
+      "max_score": 10,
+      "name": "Async path prints job ID or acceptance message"
     },
     {
-      "name": "Command structure follows conventions",
       "description": "The handler uses flag.NewFlagSet, accepts --id and --api-url flags, calls newClientFromCreds, and uses formatAPIError for non-success responses — consistent with packs_get.go.",
-      "max_score": 15
+      "max_score": 15,
+      "name": "Command structure follows conventions"
     }
-  ]
+  ],
+  "context": "Tests whether the agent recognizes that ogen generates distinct Go types per HTTP status code, and that copying the single type-assertion pattern from packs_get.go silently breaks for endpoints returning multiple success statuses. The packs get endpoint only returns 200, so a single assertion works. The compile endpoint returns either 200 (CompilePackOK, synchronous completion with the compiled Pack) or 202 (CompilePackAccepted, async job with a jobId string). A single `res.(*CompilePackOK)` assertion returns false when the server responds 202, causing `formatAPIError` to report a spurious error even though compilation was accepted. The task.md intentionally does NOT mention this, does NOT include the decoder file, and frames the work as 'follow the existing pattern'. The model must know from project context that ogen endpoints can have multiple success types and that the compile endpoint specifically returns 200 or 202.",
+  "type": "weighted_checklist"
 }

--- a/evals/moltnet-practices/go-cli-multi-status-response/eval.json
+++ b/evals/moltnet-practices/go-cli-multi-status-response/eval.json
@@ -1,8 +1,8 @@
 {
-  "mode": "vitro",
   "fixture": {
     "inject": [
       { "from": "fixtures/packs_get.go", "to": "apps/moltnet-cli/packs_get.go" }
     ]
-  }
+  },
+  "mode": "vitro"
 }

--- a/evals/moltnet-practices/mcp-format-uuid-validation/eval.json
+++ b/evals/moltnet-practices/mcp-format-uuid-validation/eval.json
@@ -1,1 +1,1 @@
-{"mode":"vitro"}
+{ "mode": "vitro" }

--- a/evals/moltnet-practices/repository-tenant-scope-bypass/eval.json
+++ b/evals/moltnet-practices/repository-tenant-scope-bypass/eval.json
@@ -1,9 +1,15 @@
 {
-  "mode": "vitro",
   "fixture": {
     "inject": [
-      { "from": "fixtures/diary-entry.repository.ts", "to": "libs/database/src/repositories/diary-entry.repository.ts" },
-      { "from": "fixtures/consolidate-workflow.ts", "to": "apps/rest-api/src/workflows/consolidate-workflow.ts" }
+      {
+        "from": "fixtures/diary-entry.repository.ts",
+        "to": "libs/database/src/repositories/diary-entry.repository.ts"
+      },
+      {
+        "from": "fixtures/consolidate-workflow.ts",
+        "to": "apps/rest-api/src/workflows/consolidate-workflow.ts"
+      }
     ]
-  }
+  },
+  "mode": "vitro"
 }

--- a/evals/moltnet-practices/rest-error-boundary/criteria.json
+++ b/evals/moltnet-practices/rest-error-boundary/criteria.json
@@ -1,26 +1,26 @@
 {
-  "type": "weighted_checklist",
-  "context": "Tests whether the agent identifies that plain `throw new Error()` in REST route handlers bypasses the structured error handler and produces generic 500s. This codebase uses RFC 9457 Problem Details via createProblem() — every error thrown from a route must use the problem factory, not plain Error. The fixture file has 4 plain Error throws that each need a different problem type (conflict, not-found, forbidden, validation-failed).",
   "checklist": [
     {
-      "name": "Replaces all plain Error throws with createProblem",
       "description": "All 4 `throw new Error(...)` calls are replaced with `throw createProblem(type, message)` or equivalent structured error creation",
-      "max_score": 35
+      "max_score": 35,
+      "name": "Replaces all plain Error throws with createProblem"
     },
     {
-      "name": "Correct problem types for each case",
       "description": "Uses appropriate problem types: 'conflict' for duplicate nonce, 'not-found' for missing pack, 'forbidden' for authorization failure, 'validation-failed' for wrong status",
-      "max_score": 30
+      "max_score": 30,
+      "name": "Correct problem types for each case"
     },
     {
-      "name": "Imports createProblem",
       "description": "The fixed file imports createProblem from the problems module (../problems/index.js or equivalent)",
-      "max_score": 15
+      "max_score": 15,
+      "name": "Imports createProblem"
     },
     {
-      "name": "Notes explain RFC 9457 boundary",
       "description": "The notes explain that plain Error produces generic 500 responses while createProblem produces structured RFC 9457 Problem Details, or mentions the error handler plugin convention",
-      "max_score": 20
+      "max_score": 20,
+      "name": "Notes explain RFC 9457 boundary"
     }
-  ]
+  ],
+  "context": "Tests whether the agent identifies that plain `throw new Error()` in REST route handlers bypasses the structured error handler and produces generic 500s. This codebase uses RFC 9457 Problem Details via createProblem() — every error thrown from a route must use the problem factory, not plain Error. The fixture file has 4 plain Error throws that each need a different problem type (conflict, not-found, forbidden, validation-failed).",
+  "type": "weighted_checklist"
 }

--- a/evals/moltnet-practices/rest-error-boundary/eval.json
+++ b/evals/moltnet-practices/rest-error-boundary/eval.json
@@ -1,9 +1,15 @@
 {
-  "mode": "vitro",
   "fixture": {
     "inject": [
-      { "from": "fixtures/verification-routes.ts", "to": "apps/rest-api/src/routes/verification.ts" },
-      { "from": "fixtures/pack-routes.ts", "to": "apps/rest-api/src/routes/pack-routes.ts" }
+      {
+        "from": "fixtures/verification-routes.ts",
+        "to": "apps/rest-api/src/routes/verification.ts"
+      },
+      {
+        "from": "fixtures/pack-routes.ts",
+        "to": "apps/rest-api/src/routes/pack-routes.ts"
+      }
     ]
-  }
+  },
+  "mode": "vitro"
 }

--- a/evals/moltnet-practices/rest-error-boundary/fixtures/pack-routes.ts
+++ b/evals/moltnet-practices/rest-error-boundary/fixtures/pack-routes.ts
@@ -1,7 +1,8 @@
-import { FastifyInstance } from 'fastify';
-import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
-import { Type } from '@sinclair/typebox';
+import type { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 import { requireAuth } from '@moltnet/auth';
+import { Type } from '@sinclair/typebox';
+import type { FastifyInstance } from 'fastify';
+
 import { createProblem } from '../problems/index.js';
 
 export async function packRoutes(fastify: FastifyInstance) {
@@ -9,45 +10,53 @@ export async function packRoutes(fastify: FastifyInstance) {
 
   server.addHook('preHandler', requireAuth);
 
-  server.get('/packs/:id', {
-    schema: {
-      operationId: 'getPack',
-      tags: ['packs'],
-      params: Type.Object({
-        id: Type.String({ description: 'Pack ID (UUID).' }),
-      }),
+  server.get(
+    '/packs/:id',
+    {
+      schema: {
+        operationId: 'getPack',
+        tags: ['packs'],
+        params: Type.Object({
+          id: Type.String({ description: 'Pack ID (UUID).' }),
+        }),
+      },
     },
-  }, async (request) => {
-    const { id } = request.params;
-    const pack = await fastify.packService.getById(id);
-    if (!pack) {
-      throw createProblem('not-found', `Pack ${id} not found`);
-    }
-    const agentId = request.authContext!.identityId;
-    if (pack.diaryOwnerId !== agentId) {
-      throw createProblem('forbidden', 'Not authorized to access this pack');
-    }
-    return pack;
-  });
+    async (request) => {
+      const { id } = request.params;
+      const pack = await fastify.packService.getById(id);
+      if (!pack) {
+        throw createProblem('not-found', `Pack ${id} not found`);
+      }
+      const agentId = request.authContext!.identityId;
+      if (pack.diaryOwnerId !== agentId) {
+        throw createProblem('forbidden', 'Not authorized to access this pack');
+      }
+      return pack;
+    },
+  );
 
-  server.delete('/packs/:id', {
-    schema: {
-      operationId: 'deletePack',
-      tags: ['packs'],
-      params: Type.Object({
-        id: Type.String({ description: 'Pack ID (UUID).' }),
-      }),
+  server.delete(
+    '/packs/:id',
+    {
+      schema: {
+        operationId: 'deletePack',
+        tags: ['packs'],
+        params: Type.Object({
+          id: Type.String({ description: 'Pack ID (UUID).' }),
+        }),
+      },
     },
-  }, async (request, reply) => {
-    const { id } = request.params;
-    const pack = await fastify.packService.getById(id);
-    if (!pack) {
-      throw createProblem('not-found', `Pack ${id} not found`);
-    }
-    if (pack.pinned) {
-      throw createProblem('conflict', 'Cannot delete a pinned pack');
-    }
-    await fastify.packService.delete(id);
-    return reply.status(204).send();
-  });
+    async (request, reply) => {
+      const { id } = request.params;
+      const pack = await fastify.packService.getById(id);
+      if (!pack) {
+        throw createProblem('not-found', `Pack ${id} not found`);
+      }
+      if (pack.pinned) {
+        throw createProblem('conflict', 'Cannot delete a pinned pack');
+      }
+      await fastify.packService.delete(id);
+      return reply.status(204).send();
+    },
+  );
 }

--- a/evals/moltnet-practices/rest-error-boundary/fixtures/verification-routes.ts
+++ b/evals/moltnet-practices/rest-error-boundary/fixtures/verification-routes.ts
@@ -1,81 +1,95 @@
-import { FastifyInstance } from 'fastify';
-import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
-import { Type } from '@sinclair/typebox';
+import type { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 import { requireAuth } from '@moltnet/auth';
+import { Type } from '@sinclair/typebox';
+import type { FastifyInstance } from 'fastify';
 
 export async function verificationRoutes(fastify: FastifyInstance) {
   const server = fastify.withTypeProvider<TypeBoxTypeProvider>();
 
   server.addHook('preHandler', requireAuth);
 
-  server.post('/rendered-packs/:id/verify', {
-    schema: {
-      operationId: 'verifyRenderedPack',
-      tags: ['rendered-packs'],
-      description: 'Start a fidelity verification workflow for a rendered pack.',
-      security: [{ bearerAuth: [] }],
-      params: Type.Object({
-        id: Type.String({ description: 'Rendered pack ID (UUID).' }),
-      }),
-      body: Type.Object({
-        nonce: Type.String({ description: 'Idempotency nonce (UUID).' }),
-      }),
+  server.post(
+    '/rendered-packs/:id/verify',
+    {
+      schema: {
+        operationId: 'verifyRenderedPack',
+        tags: ['rendered-packs'],
+        description:
+          'Start a fidelity verification workflow for a rendered pack.',
+        security: [{ bearerAuth: [] }],
+        params: Type.Object({
+          id: Type.String({ description: 'Rendered pack ID (UUID).' }),
+        }),
+        body: Type.Object({
+          nonce: Type.String({ description: 'Idempotency nonce (UUID).' }),
+        }),
+      },
     },
-  }, async (request) => {
-    const agentId = request.authContext!.identityId;
-    const { id } = request.params;
-    const { nonce } = request.body;
+    async (request) => {
+      const agentId = request.authContext!.identityId;
+      const { id } = request.params;
+      const { nonce } = request.body;
 
-    const existing = await fastify.verificationService.findByNonce(nonce);
-    if (existing) {
-      throw new Error('Verification already exists for this nonce');
-    }
+      const existing = await fastify.verificationService.findByNonce(nonce);
+      if (existing) {
+        throw new Error('Verification already exists for this nonce');
+      }
 
-    const renderedPack = await fastify.renderedPackService.getById(id);
-    if (!renderedPack) {
-      throw new Error('Rendered pack not found');
-    }
+      const renderedPack = await fastify.renderedPackService.getById(id);
+      if (!renderedPack) {
+        throw new Error('Rendered pack not found');
+      }
 
-    if (renderedPack.createdBy !== agentId) {
-      throw new Error('Not authorized to verify this rendered pack');
-    }
+      if (renderedPack.createdBy !== agentId) {
+        throw new Error('Not authorized to verify this rendered pack');
+      }
 
-    const verification = await fastify.verificationService.create({
-      renderedPackId: id,
-      nonce,
-      requestedBy: agentId,
-    });
+      const verification = await fastify.verificationService.create({
+        renderedPackId: id,
+        nonce,
+        requestedBy: agentId,
+      });
 
-    return verification;
-  });
-
-  server.post('/rendered-packs/:id/verify/claim', {
-    schema: {
-      operationId: 'claimVerification',
-      tags: ['rendered-packs'],
-      description: 'Claim a verification workflow as the judge.',
-      security: [{ bearerAuth: [] }],
-      params: Type.Object({
-        id: Type.String({ description: 'Rendered pack ID (UUID).' }),
-      }),
-      body: Type.Object({
-        nonce: Type.String({ description: 'Verification nonce.' }),
-      }),
+      return verification;
     },
-  }, async (request) => {
-    const agentId = request.authContext!.identityId;
-    const { nonce } = request.body;
+  );
 
-    const verification = await fastify.verificationService.findByNonce(nonce);
-    if (!verification) {
-      throw new Error('Verification not found');
-    }
+  server.post(
+    '/rendered-packs/:id/verify/claim',
+    {
+      schema: {
+        operationId: 'claimVerification',
+        tags: ['rendered-packs'],
+        description: 'Claim a verification workflow as the judge.',
+        security: [{ bearerAuth: [] }],
+        params: Type.Object({
+          id: Type.String({ description: 'Rendered pack ID (UUID).' }),
+        }),
+        body: Type.Object({
+          nonce: Type.String({ description: 'Verification nonce.' }),
+        }),
+      },
+    },
+    async (request) => {
+      const agentId = request.authContext!.identityId;
+      const { nonce } = request.body;
 
-    if (verification.status !== 'pending') {
-      throw new Error(`Cannot claim verification in status: ${verification.status}`);
-    }
+      const verification = await fastify.verificationService.findByNonce(nonce);
+      if (!verification) {
+        throw new Error('Verification not found');
+      }
 
-    const claimed = await fastify.verificationService.claim(verification.id, agentId);
-    return claimed;
-  });
+      if (verification.status !== 'pending') {
+        throw new Error(
+          `Cannot claim verification in status: ${verification.status}`,
+        );
+      }
+
+      const claimed = await fastify.verificationService.claim(
+        verification.id,
+        agentId,
+      );
+      return claimed;
+    },
+  );
 }

--- a/evals/moltnet-practices/webhook-auth-status-code/criteria.json
+++ b/evals/moltnet-practices/webhook-auth-status-code/criteria.json
@@ -1,26 +1,26 @@
 {
-  "type": "weighted_checklist",
-  "context": "Tests whether the agent understands how Ory Kratos interprets webhook HTTP status codes. Kratos treats 5xx from webhooks as transient infrastructure errors and shows a generic 'internal error' to the user. A 4xx (specifically 403) tells Kratos the request was intentionally rejected, which produces a clearer error in the UI. The handler returns 500 for an auth failure, which misclassifies an authentication rejection as an infrastructure error.",
   "checklist": [
     {
-      "name": "Changes 500 to 403 (or 401) for auth failure",
       "description": "The webhook API key validation failure returns a 4xx status (403 Forbidden or 401 Unauthorized) instead of 500 Internal Server Error",
-      "max_score": 40
+      "max_score": 40,
+      "name": "Changes 500 to 403 (or 401) for auth failure"
     },
     {
-      "name": "Uses Ory-compatible error format",
       "description": "The error response uses the Ory error format with appropriate status code and message, not a generic error shape",
-      "max_score": 20
+      "max_score": 20,
+      "name": "Uses Ory-compatible error format"
     },
     {
-      "name": "Notes explain 5xx vs 4xx semantics for Kratos webhooks",
       "description": "The notes explain that Kratos interprets 5xx as infrastructure failure (retryable, opaque UI message) vs 4xx as intentional rejection (clearer error), or mentions the distinction between auth failure and server error",
-      "max_score": 25
+      "max_score": 25,
+      "name": "Notes explain 5xx vs 4xx semantics for Kratos webhooks"
     },
     {
-      "name": "Does not change happy path",
       "description": "The successful registration path (200 response with identity metadata) remains unchanged",
-      "max_score": 15
+      "max_score": 15,
+      "name": "Does not change happy path"
     }
-  ]
+  ],
+  "context": "Tests whether the agent understands how Ory Kratos interprets webhook HTTP status codes. Kratos treats 5xx from webhooks as transient infrastructure errors and shows a generic 'internal error' to the user. A 4xx (specifically 403) tells Kratos the request was intentionally rejected, which produces a clearer error in the UI. The handler returns 500 for an auth failure, which misclassifies an authentication rejection as an infrastructure error.",
+  "type": "weighted_checklist"
 }

--- a/evals/moltnet-practices/webhook-auth-status-code/eval.json
+++ b/evals/moltnet-practices/webhook-auth-status-code/eval.json
@@ -1,8 +1,8 @@
 {
-  "mode": "vitro",
   "fixture": {
     "inject": [
       { "from": "fixtures/hooks.ts", "to": "apps/rest-api/src/routes/hooks.ts" }
     ]
-  }
+  },
+  "mode": "vitro"
 }

--- a/evals/moltnet-practices/webhook-auth-status-code/fixtures/hooks.ts
+++ b/evals/moltnet-practices/webhook-auth-status-code/fixtures/hooks.ts
@@ -1,6 +1,6 @@
-import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
-import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
+import type { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 import { Type } from '@sinclair/typebox';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 
 /**
  * Validates the webhook API key from the X-Webhook-Api-Key header.
@@ -35,46 +35,50 @@ export async function hookRoutes(fastify: FastifyInstance) {
   const server = fastify.withTypeProvider<TypeBoxTypeProvider>();
   const webhookApiKey = fastify.config.webhookApiKey;
 
-  server.post('/hooks/after-registration', {
-    schema: {
-      operationId: 'afterRegistration',
-      tags: ['hooks'],
-      description: 'Kratos after-registration webhook handler.',
-      body: Type.Object({
-        identity: Type.Object({
-          id: Type.String(),
-          traits: Type.Object({
-            fingerprint: Type.String(),
+  server.post(
+    '/hooks/after-registration',
+    {
+      schema: {
+        operationId: 'afterRegistration',
+        tags: ['hooks'],
+        description: 'Kratos after-registration webhook handler.',
+        body: Type.Object({
+          identity: Type.Object({
+            id: Type.String(),
+            traits: Type.Object({
+              fingerprint: Type.String(),
+            }),
           }),
         }),
-      }),
+      },
     },
-  }, async (request, reply) => {
-    if (!validateWebhookApiKey(request, reply, webhookApiKey)) {
-      return;
-    }
+    async (request, reply) => {
+      if (!validateWebhookApiKey(request, reply, webhookApiKey)) {
+        return;
+      }
 
-    const { identity } = request.body;
+      const { identity } = request.body;
 
-    // Create Hydra OAuth2 client for the new agent
-    const hydraClient = await fastify.hydraAdmin.createOAuth2Client({
-      oAuth2Client: {
-        client_name: identity.traits.fingerprint,
-        grant_types: ['client_credentials'],
-        scope: 'diary:read diary:write',
-        metadata: { identity_id: identity.id },
-      },
-    });
-
-    // Grant default permissions via Keto
-    await fastify.permissionChecker.grantAgentDefaults(identity.id);
-
-    return reply.status(200).send({
-      identity: {
-        metadata_public: {
-          client_id: hydraClient.client_id,
+      // Create Hydra OAuth2 client for the new agent
+      const hydraClient = await fastify.hydraAdmin.createOAuth2Client({
+        oAuth2Client: {
+          client_name: identity.traits.fingerprint,
+          grant_types: ['client_credentials'],
+          scope: 'diary:read diary:write',
+          metadata: { identity_id: identity.id },
         },
-      },
-    });
-  });
+      });
+
+      // Grant default permissions via Keto
+      await fastify.permissionChecker.grantAgentDefaults(identity.id);
+
+      return reply.status(200).send({
+        identity: {
+          metadata_public: {
+            client_id: hydraClient.client_id,
+          },
+        },
+      });
+    },
+  );
 }

--- a/libs/api-client/src/generated/types.gen.ts
+++ b/libs/api-client/src/generated/types.gen.ts
@@ -114,6 +114,7 @@ export type DiaryCatalogList = {
 export type DiaryEntry = {
   id: string;
   diaryId: string;
+  createdBy: string;
   title: string | null;
   content: string;
   tags: Array<string> | null;
@@ -1004,6 +1005,7 @@ export type ExpandedRelations = {
 export type DiaryEntryWithRelations = {
   id: string;
   diaryId: string;
+  createdBy: string;
   title: string | null;
   content: string;
   tags: Array<string> | null;

--- a/libs/moltnet-api-client/oas_json_gen.go
+++ b/libs/moltnet-api-client/oas_json_gen.go
@@ -11664,6 +11664,10 @@ func (s *DiaryEntry) encodeFields(e *jx.Encoder) {
 		json.EncodeDateTime(e, s.CreatedAt)
 	}
 	{
+		e.FieldStart("createdBy")
+		json.EncodeUUID(e, s.CreatedBy)
+	}
+	{
 		e.FieldStart("diaryId")
 		json.EncodeUUID(e, s.DiaryId)
 	}
@@ -11709,21 +11713,22 @@ func (s *DiaryEntry) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfDiaryEntry = [14]string{
+var jsonFieldsNameOfDiaryEntry = [15]string{
 	0:  "accessCount",
 	1:  "content",
 	2:  "contentHash",
 	3:  "contentSignature",
 	4:  "createdAt",
-	5:  "diaryId",
-	6:  "entryType",
-	7:  "id",
-	8:  "importance",
-	9:  "injectionRisk",
-	10: "lastAccessedAt",
-	11: "tags",
-	12: "title",
-	13: "updatedAt",
+	5:  "createdBy",
+	6:  "diaryId",
+	7:  "entryType",
+	8:  "id",
+	9:  "importance",
+	10: "injectionRisk",
+	11: "lastAccessedAt",
+	12: "tags",
+	13: "title",
+	14: "updatedAt",
 }
 
 // Decode decodes DiaryEntry from json.
@@ -11791,8 +11796,20 @@ func (s *DiaryEntry) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"createdAt\"")
 			}
-		case "diaryId":
+		case "createdBy":
 			requiredBitSet[0] |= 1 << 5
+			if err := func() error {
+				v, err := json.DecodeUUID(d)
+				s.CreatedBy = v
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"createdBy\"")
+			}
+		case "diaryId":
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeUUID(d)
 				s.DiaryId = v
@@ -11804,7 +11821,7 @@ func (s *DiaryEntry) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"diaryId\"")
 			}
 		case "entryType":
-			requiredBitSet[0] |= 1 << 6
+			requiredBitSet[0] |= 1 << 7
 			if err := func() error {
 				if err := s.EntryType.Decode(d); err != nil {
 					return err
@@ -11814,7 +11831,7 @@ func (s *DiaryEntry) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"entryType\"")
 			}
 		case "id":
-			requiredBitSet[0] |= 1 << 7
+			requiredBitSet[1] |= 1 << 0
 			if err := func() error {
 				v, err := json.DecodeUUID(d)
 				s.ID = v
@@ -11826,7 +11843,7 @@ func (s *DiaryEntry) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"id\"")
 			}
 		case "importance":
-			requiredBitSet[1] |= 1 << 0
+			requiredBitSet[1] |= 1 << 1
 			if err := func() error {
 				v, err := d.Float64()
 				s.Importance = float64(v)
@@ -11838,7 +11855,7 @@ func (s *DiaryEntry) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"importance\"")
 			}
 		case "injectionRisk":
-			requiredBitSet[1] |= 1 << 1
+			requiredBitSet[1] |= 1 << 2
 			if err := func() error {
 				v, err := d.Bool()
 				s.InjectionRisk = bool(v)
@@ -11850,7 +11867,7 @@ func (s *DiaryEntry) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"injectionRisk\"")
 			}
 		case "lastAccessedAt":
-			requiredBitSet[1] |= 1 << 2
+			requiredBitSet[1] |= 1 << 3
 			if err := func() error {
 				if err := s.LastAccessedAt.Decode(d, json.DecodeDateTime); err != nil {
 					return err
@@ -11860,7 +11877,7 @@ func (s *DiaryEntry) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"lastAccessedAt\"")
 			}
 		case "tags":
-			requiredBitSet[1] |= 1 << 3
+			requiredBitSet[1] |= 1 << 4
 			if err := func() error {
 				switch tt := d.Next(); tt {
 				case jx.Null:
@@ -11887,7 +11904,7 @@ func (s *DiaryEntry) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"tags\"")
 			}
 		case "title":
-			requiredBitSet[1] |= 1 << 4
+			requiredBitSet[1] |= 1 << 5
 			if err := func() error {
 				if err := s.Title.Decode(d); err != nil {
 					return err
@@ -11897,7 +11914,7 @@ func (s *DiaryEntry) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "updatedAt":
-			requiredBitSet[1] |= 1 << 5
+			requiredBitSet[1] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeDateTime(d)
 				s.UpdatedAt = v
@@ -11919,7 +11936,7 @@ func (s *DiaryEntry) Decode(d *jx.Decoder) error {
 	var failures []validate.FieldError
 	for i, mask := range [2]uint8{
 		0b11111111,
-		0b00111111,
+		0b01111111,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -12437,6 +12454,10 @@ func (s *DiaryEntryWithRelations) encodeFields(e *jx.Encoder) {
 		json.EncodeDateTime(e, s.CreatedAt)
 	}
 	{
+		e.FieldStart("createdBy")
+		json.EncodeUUID(e, s.CreatedBy)
+	}
+	{
 		e.FieldStart("diaryId")
 		json.EncodeUUID(e, s.DiaryId)
 	}
@@ -12488,22 +12509,23 @@ func (s *DiaryEntryWithRelations) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfDiaryEntryWithRelations = [15]string{
+var jsonFieldsNameOfDiaryEntryWithRelations = [16]string{
 	0:  "accessCount",
 	1:  "content",
 	2:  "contentHash",
 	3:  "contentSignature",
 	4:  "createdAt",
-	5:  "diaryId",
-	6:  "entryType",
-	7:  "id",
-	8:  "importance",
-	9:  "injectionRisk",
-	10: "lastAccessedAt",
-	11: "relations",
-	12: "tags",
-	13: "title",
-	14: "updatedAt",
+	5:  "createdBy",
+	6:  "diaryId",
+	7:  "entryType",
+	8:  "id",
+	9:  "importance",
+	10: "injectionRisk",
+	11: "lastAccessedAt",
+	12: "relations",
+	13: "tags",
+	14: "title",
+	15: "updatedAt",
 }
 
 // Decode decodes DiaryEntryWithRelations from json.
@@ -12571,8 +12593,20 @@ func (s *DiaryEntryWithRelations) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"createdAt\"")
 			}
-		case "diaryId":
+		case "createdBy":
 			requiredBitSet[0] |= 1 << 5
+			if err := func() error {
+				v, err := json.DecodeUUID(d)
+				s.CreatedBy = v
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"createdBy\"")
+			}
+		case "diaryId":
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeUUID(d)
 				s.DiaryId = v
@@ -12584,7 +12618,7 @@ func (s *DiaryEntryWithRelations) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"diaryId\"")
 			}
 		case "entryType":
-			requiredBitSet[0] |= 1 << 6
+			requiredBitSet[0] |= 1 << 7
 			if err := func() error {
 				if err := s.EntryType.Decode(d); err != nil {
 					return err
@@ -12594,7 +12628,7 @@ func (s *DiaryEntryWithRelations) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"entryType\"")
 			}
 		case "id":
-			requiredBitSet[0] |= 1 << 7
+			requiredBitSet[1] |= 1 << 0
 			if err := func() error {
 				v, err := json.DecodeUUID(d)
 				s.ID = v
@@ -12606,7 +12640,7 @@ func (s *DiaryEntryWithRelations) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"id\"")
 			}
 		case "importance":
-			requiredBitSet[1] |= 1 << 0
+			requiredBitSet[1] |= 1 << 1
 			if err := func() error {
 				v, err := d.Float64()
 				s.Importance = float64(v)
@@ -12618,7 +12652,7 @@ func (s *DiaryEntryWithRelations) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"importance\"")
 			}
 		case "injectionRisk":
-			requiredBitSet[1] |= 1 << 1
+			requiredBitSet[1] |= 1 << 2
 			if err := func() error {
 				v, err := d.Bool()
 				s.InjectionRisk = bool(v)
@@ -12630,7 +12664,7 @@ func (s *DiaryEntryWithRelations) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"injectionRisk\"")
 			}
 		case "lastAccessedAt":
-			requiredBitSet[1] |= 1 << 2
+			requiredBitSet[1] |= 1 << 3
 			if err := func() error {
 				if err := s.LastAccessedAt.Decode(d, json.DecodeDateTime); err != nil {
 					return err
@@ -12650,7 +12684,7 @@ func (s *DiaryEntryWithRelations) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"relations\"")
 			}
 		case "tags":
-			requiredBitSet[1] |= 1 << 4
+			requiredBitSet[1] |= 1 << 5
 			if err := func() error {
 				switch tt := d.Next(); tt {
 				case jx.Null:
@@ -12677,7 +12711,7 @@ func (s *DiaryEntryWithRelations) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"tags\"")
 			}
 		case "title":
-			requiredBitSet[1] |= 1 << 5
+			requiredBitSet[1] |= 1 << 6
 			if err := func() error {
 				if err := s.Title.Decode(d); err != nil {
 					return err
@@ -12687,7 +12721,7 @@ func (s *DiaryEntryWithRelations) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "updatedAt":
-			requiredBitSet[1] |= 1 << 6
+			requiredBitSet[1] |= 1 << 7
 			if err := func() error {
 				v, err := json.DecodeDateTime(d)
 				s.UpdatedAt = v
@@ -12709,7 +12743,7 @@ func (s *DiaryEntryWithRelations) Decode(d *jx.Decoder) error {
 	var failures []validate.FieldError
 	for i, mask := range [2]uint8{
 		0b11111111,
-		0b01110111,
+		0b11101111,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.

--- a/libs/moltnet-api-client/oas_schemas_gen.go
+++ b/libs/moltnet-api-client/oas_schemas_gen.go
@@ -3926,6 +3926,7 @@ type DiaryEntry struct {
 	ContentHash      NilString           `json:"contentHash"`
 	ContentSignature NilString           `json:"contentSignature"`
 	CreatedAt        time.Time           `json:"createdAt"`
+	CreatedBy        uuid.UUID           `json:"createdBy"`
 	DiaryId          uuid.UUID           `json:"diaryId"`
 	EntryType        DiaryEntryEntryType `json:"entryType"`
 	ID               uuid.UUID           `json:"id"`
@@ -3960,6 +3961,11 @@ func (s *DiaryEntry) GetContentSignature() NilString {
 // GetCreatedAt returns the value of CreatedAt.
 func (s *DiaryEntry) GetCreatedAt() time.Time {
 	return s.CreatedAt
+}
+
+// GetCreatedBy returns the value of CreatedBy.
+func (s *DiaryEntry) GetCreatedBy() uuid.UUID {
+	return s.CreatedBy
 }
 
 // GetDiaryId returns the value of DiaryId.
@@ -4030,6 +4036,11 @@ func (s *DiaryEntry) SetContentSignature(val NilString) {
 // SetCreatedAt sets the value of CreatedAt.
 func (s *DiaryEntry) SetCreatedAt(val time.Time) {
 	s.CreatedAt = val
+}
+
+// SetCreatedBy sets the value of CreatedBy.
+func (s *DiaryEntry) SetCreatedBy(val uuid.UUID) {
+	s.CreatedBy = val
 }
 
 // SetDiaryId sets the value of DiaryId.
@@ -4394,6 +4405,7 @@ type DiaryEntryWithRelations struct {
 	ContentHash      NilString                        `json:"contentHash"`
 	ContentSignature NilString                        `json:"contentSignature"`
 	CreatedAt        time.Time                        `json:"createdAt"`
+	CreatedBy        uuid.UUID                        `json:"createdBy"`
 	DiaryId          uuid.UUID                        `json:"diaryId"`
 	EntryType        DiaryEntryWithRelationsEntryType `json:"entryType"`
 	ID               uuid.UUID                        `json:"id"`
@@ -4429,6 +4441,11 @@ func (s *DiaryEntryWithRelations) GetContentSignature() NilString {
 // GetCreatedAt returns the value of CreatedAt.
 func (s *DiaryEntryWithRelations) GetCreatedAt() time.Time {
 	return s.CreatedAt
+}
+
+// GetCreatedBy returns the value of CreatedBy.
+func (s *DiaryEntryWithRelations) GetCreatedBy() uuid.UUID {
+	return s.CreatedBy
 }
 
 // GetDiaryId returns the value of DiaryId.
@@ -4504,6 +4521,11 @@ func (s *DiaryEntryWithRelations) SetContentSignature(val NilString) {
 // SetCreatedAt sets the value of CreatedAt.
 func (s *DiaryEntryWithRelations) SetCreatedAt(val time.Time) {
 	s.CreatedAt = val
+}
+
+// SetCreatedBy sets the value of CreatedBy.
+func (s *DiaryEntryWithRelations) SetCreatedBy(val uuid.UUID) {
+	s.CreatedBy = val
 }
 
 // SetDiaryId sets the value of DiaryId.

--- a/libs/moltnet-api-client/openapi-normalized.json
+++ b/libs/moltnet-api-client/openapi-normalized.json
@@ -891,6 +891,10 @@
             "format": "date-time",
             "type": "string"
           },
+          "createdBy": {
+            "format": "uuid",
+            "type": "string"
+          },
           "diaryId": {
             "format": "uuid",
             "type": "string"
@@ -942,6 +946,7 @@
         "required": [
           "id",
           "diaryId",
+          "createdBy",
           "title",
           "content",
           "tags",
@@ -1068,6 +1073,10 @@
             "format": "date-time",
             "type": "string"
           },
+          "createdBy": {
+            "format": "uuid",
+            "type": "string"
+          },
           "diaryId": {
             "format": "uuid",
             "type": "string"
@@ -1122,6 +1131,7 @@
         "required": [
           "id",
           "diaryId",
+          "createdBy",
           "title",
           "content",
           "tags",

--- a/packages/cli/bin/CHANGELOG.md
+++ b/packages/cli/bin/CHANGELOG.md
@@ -1,5 +1,378 @@
 # Changelog
 
+## [1.25.0](https://github.com/getlarge/themoltnet/compare/cli-v1.24.1...cli-v1.25.0) (2026-04-14)
+
+
+### Features
+
+* **moltnet-cli, skill:** Phase 2 of team onboarding ([#797](https://github.com/getlarge/themoltnet/issues/797)) ([1318f0c](https://github.com/getlarge/themoltnet/commit/1318f0c17405d67968fad53eb4690f5434f0c8d3))
+* **moltnet-cli:** team management + diary grant commands ([#797](https://github.com/getlarge/themoltnet/issues/797)) ([9364c20](https://github.com/getlarge/themoltnet/commit/9364c208c24ab165d5eee8fe32e62831b616f9de))
+
+
+### Bug Fixes
+
+* **moltnet-cli:** address PR [#811](https://github.com/getlarge/themoltnet/issues/811) review feedback ([f65d117](https://github.com/getlarge/themoltnet/commit/f65d1175e374f433c9e3bea7a8b950206bbff274))
+
+## [1.24.1](https://github.com/getlarge/themoltnet/compare/cli-v1.24.0...cli-v1.24.1) (2026-04-14)
+
+
+### Bug Fixes
+
+* **moltnet-cli:** add missing flags to entry create, --importance to create-signed ([30d204c](https://github.com/getlarge/themoltnet/commit/30d204c4dd134bfba04de7315ffe2e8538f6c733))
+* **moltnet-cli:** flag parity on entry create + --importance on create-signed ([2f8b49f](https://github.com/getlarge/themoltnet/commit/2f8b49f9d287df309c9689d971609b45d19924c0))
+* **moltnet-cli:** require --type on create-signed, validate up-front ([43b24fd](https://github.com/getlarge/themoltnet/commit/43b24fd34fe9509f836bb0f3c7543a137290f3ea))
+
+## [1.24.0](https://github.com/getlarge/themoltnet/compare/cli-v1.23.0...cli-v1.24.0) (2026-04-13)
+
+
+### Features
+
+* **cli,skill:** add env-driven commit authorship modes ([5e5cb11](https://github.com/getlarge/themoltnet/commit/5e5cb11f5b9509f2fc4eb3be349a9a478ec58614))
+* **cli,skill:** add env-driven commit authorship modes ([#786](https://github.com/getlarge/themoltnet/issues/786)) ([61b643e](https://github.com/getlarge/themoltnet/commit/61b643e53e9c42fd4a5e9531ed80fe201dd09a8b))
+* **eval:** dispatch VitroSignature vs VivoSignature based on mode ([b429cf6](https://github.com/getlarge/themoltnet/commit/b429cf62acbc2b47eb2dbd36554ece7cf83a4954)), closes [#734](https://github.com/getlarge/themoltnet/issues/734)
+* **eval:** pass repo_ref to solver for vivo runs ([029f384](https://github.com/getlarge/themoltnet/commit/029f3847d5e95ce04005740ce774adade9957e79)), closes [#734](https://github.com/getlarge/themoltnet/issues/734)
+* **eval:** thread mode and fixtureRef through solverInput ([359dc78](https://github.com/getlarge/themoltnet/commit/359dc785dc9fe653e096fbb8d0672ff60814a36e)), closes [#734](https://github.com/getlarge/themoltnet/issues/734)
+* **eval:** vivo mode + CoT signature dispatch ([20da98d](https://github.com/getlarge/themoltnet/commit/20da98dacea02c15fc369a4b61e668ffea2dc3ab))
+
+
+### Bug Fixes
+
+* **cli,skill:** address PR [#792](https://github.com/getlarge/themoltnet/issues/792) review feedback ([4c4970c](https://github.com/getlarge/themoltnet/commit/4c4970ce6d3de622c27aee255ed06fc28e0f5f63))
+* **evals:** address PR [#785](https://github.com/getlarge/themoltnet/issues/785) review feedback ([cee3c62](https://github.com/getlarge/themoltnet/commit/cee3c62de1abd2fad162acee5a04c47f8f8b909f))
+* **evals:** lightweight workspace snapshot for vivo mode ([54851b3](https://github.com/getlarge/themoltnet/commit/54851b3a9984371fb830b549ff419b0fe93c9ad2))
+
+## [1.23.0](https://github.com/getlarge/themoltnet/compare/cli-v1.22.0...cli-v1.23.0) (2026-04-12)
+
+
+### Features
+
+* **cli,mcp-server:** regen clients + wire expand/depth params ([#740](https://github.com/getlarge/themoltnet/issues/740)) ([b6549ef](https://github.com/getlarge/themoltnet/commit/b6549ef9a03cd193af3225b53e618bdba150f26f))
+* expand entry relations inline with depth traversal ([#740](https://github.com/getlarge/themoltnet/issues/740)) ([147c5d4](https://github.com/getlarge/themoltnet/commit/147c5d4221e9c133a7bc10f6a2d37e30a3470eaa))
+* Kratos cookie auth + OpenAPI declarations + self-service UI ([38bec91](https://github.com/getlarge/themoltnet/commit/38bec9165480b9d5203e751a381c81ac1678ce3a))
+
+
+### Bug Fixes
+
+* **cli,rest-api:** update Go tests for DiaryEntryWithRelations response type ([91d8993](https://github.com/getlarge/themoltnet/commit/91d89937fc30ae34b1113df43b028f6b6b910c13))
+* **release:** recover cli v1.23.0 release cycle ([9a95371](https://github.com/getlarge/themoltnet/commit/9a953713269eac53be8dffa9f8b35c1b14d40e43))
+* **release:** recover cli v1.23.0 release cycle ([a3e09e0](https://github.com/getlarge/themoltnet/commit/a3e09e00850edfdbed537913fc747bb5d06fe20a))
+* **release:** recover cli v1.23.0 release cycle ([0193be1](https://github.com/getlarge/themoltnet/commit/0193be1957b4a3306644f00a61fbbd2c2e7b5b83))
+* **release:** recover cli v1.23.0 release cycle ([5cc1559](https://github.com/getlarge/themoltnet/commit/5cc1559954aafeb080a0c0dadff3c300bd4dcd1d))
+
+## [1.22.0](https://github.com/getlarge/themoltnet/compare/cli-v1.21.1...cli-v1.22.0) (2026-04-11)
+
+
+### Features
+
+* add rendered pack update endpoint across the stack ([7394985](https://github.com/getlarge/themoltnet/commit/73949853c76fe04623b6529e53b7681225d387c3))
+* **cli,sdk:** add team management commands ([f9b7bf9](https://github.com/getlarge/themoltnet/commit/f9b7bf9a6e96f7deb4391c2a10edfd97885ee184))
+* **cli:** add teams command group — list, get, members, create, join, invite ([5af3ab8](https://github.com/getlarge/themoltnet/commit/5af3ab8b593b5a7b129f31e9fdd60062ae6ac57c))
+* **rest-api,mcp,cli,sdk:** add rendered pack update endpoint ([098363b](https://github.com/getlarge/themoltnet/commit/098363b6843eb79501706efc8c6bdd4b379aaece)), closes [#752](https://github.com/getlarge/themoltnet/issues/752)
+
+
+### Bug Fixes
+
+* address PR review feedback ([cfcbbe5](https://github.com/getlarge/themoltnet/commit/cfcbbe5f3eb80cec36df81351c0a2a36e5b993e7))
+* **cli:** address PR [#742](https://github.com/getlarge/themoltnet/issues/742) review — path validation, dotenv quoting, npx --yes ([6c1cb8a](https://github.com/getlarge/themoltnet/commit/6c1cb8ac46bb2a91e0e43d6b181c8e561f700a04))
+* **cli:** address PR [#742](https://github.com/getlarge/themoltnet/issues/742) review feedback ([0ebb2f8](https://github.com/getlarge/themoltnet/commit/0ebb2f865f60164c606a27480944762b9b10fda5))
+* **release:** recover cli v1.22.0 release cycle ([#763](https://github.com/getlarge/themoltnet/issues/763)) ([a1ee949](https://github.com/getlarge/themoltnet/commit/a1ee949004989a8e6b400a6c9f454f175c6e2af3))
+
+## [1.21.1](https://github.com/getlarge/themoltnet/compare/cli-v1.21.0...cli-v1.21.1) (2026-04-10)
+
+
+### Bug Fixes
+
+* **cli:** config portability — agent name and git identity export/import ([4bfad3e](https://github.com/getlarge/themoltnet/commit/4bfad3e02e302cd9e9b68db8ae20e74ebdd51594))
+* **cli:** config portability — agent name, git identity, docs ([1cb997b](https://github.com/getlarge/themoltnet/commit/1cb997b9999ddc10c2ab8426b4aef8f990ddc834))
+* **moltnet-cli:** isolate config tests from ambient MOLTNET_* env vars ([53ff938](https://github.com/getlarge/themoltnet/commit/53ff9384ef8e4e31fb1749f5f410413109ecc5a9))
+
+## [1.21.0](https://github.com/getlarge/themoltnet/compare/cli-v1.20.0...cli-v1.21.0) (2026-04-10)
+
+
+### Features
+
+* **cli:** add `moltnet config export-env` — inverse of init-from-env ([70a6dc3](https://github.com/getlarge/themoltnet/commit/70a6dc350670d18a6f680b8e4712fa6fea4f0ba2))
+* **cli:** add config init-from-env, export-env, and SessionStart hook ([56deec2](https://github.com/getlarge/themoltnet/commit/56deec2b16479cb8fafd8d2fa3cae924b058c45c))
+* **eval:** add fixture.inject for scenario-local file injection ([301d681](https://github.com/getlarge/themoltnet/commit/301d681b15490fd02973336c913878b2dc6dc501))
+* **eval:** scenario-local fixture injection ([a6282fe](https://github.com/getlarge/themoltnet/commit/a6282fe5cc158365c709bc7e47bf13f3ae87e4f6))
+
+
+### Bug Fixes
+
+* **cli:** fix export-env stdout capture, init-from-env idempotency, and env file AppID ([78332f3](https://github.com/getlarge/themoltnet/commit/78332f36075470b497398ea3358f09f49c7017bf))
+* **eval:** harden fixture.inject path validation ([e46c038](https://github.com/getlarge/themoltnet/commit/e46c0381291bb4d4604a8303b61e0be1810e8cb1))
+* **eval:** preserve os.Stat error and use IsRegular for inject source ([2ed88b8](https://github.com/getlarge/themoltnet/commit/2ed88b8d454cb91cdf18eff4196eb36319e6725f))
+
+## [1.20.0](https://github.com/getlarge/themoltnet/compare/cli-v1.19.0...cli-v1.20.0) (2026-04-09)
+
+
+### Features
+
+* **eval:** add solver field to eval.json manifest ([e6ae772](https://github.com/getlarge/themoltnet/commit/e6ae772538dfcef18b567b636e06ae9b16b70330))
+
+## [1.19.0](https://github.com/getlarge/themoltnet/compare/cli-v1.18.0...cli-v1.19.0) (2026-04-09)
+
+
+### Features
+
+* **eval:** add --mode and --fixture-ref CLI flags ([46cd2c6](https://github.com/getlarge/themoltnet/commit/46cd2c6f6e49d89492185c110697229f7f3f3e21))
+* **eval:** add evalManifest struct and loadEvalManifest ([7c52f11](https://github.com/getlarge/themoltnet/commit/7c52f1119fb8c37edd7e057ed5d881899e9335ac))
+* **eval:** add sparsePassDSPYEvalWorktree and branch createDSPYEvalWorktree on vitro/vivo mode ([883eba8](https://github.com/getlarge/themoltnet/commit/883eba8d0d2dbf85a56982667057e45482c41c1e))
+* **eval:** add validateScenario with strict criteria.json + eval.json validation ([e71d22b](https://github.com/getlarge/themoltnet/commit/e71d22b23e8fa613503f964853f506c4ec50b697))
+* **eval:** drive solver via dspy-go ChainOfThought module ([371a133](https://github.com/getlarge/themoltnet/commit/371a133322ec1c318232f7f824ef8f6732793788))
+* **eval:** drive solver via dspy-go module with --solver flag ([e8b146a](https://github.com/getlarge/themoltnet/commit/e8b146a734a4b3bae1dacf024bd4066ce4ebf824)), closes [#714](https://github.com/getlarge/themoltnet/issues/714)
+* **eval:** DSPy engine migration — progress bar, canary scripts, cutover ([9d51c4d](https://github.com/getlarge/themoltnet/commit/9d51c4d5910e1f82dc1d90fd2de93c8e155de1e2))
+* **eval:** pin JSON batch config support with test and json struct tags ([34f34d9](https://github.com/getlarge/themoltnet/commit/34f34d98cc6cd80b1d2e4744c04eb1b1eb000b7b))
+* **eval:** smarter DSPy judge — pack on disk, hardened scores_json, incident-derived scenarios ([643753e](https://github.com/getlarge/themoltnet/commit/643753ee52f809cb3bc0695f3d958ae5e99d8bfc))
+* **eval:** vitro/vivo isolation modes for DSPy eval runner ([bd6f144](https://github.com/getlarge/themoltnet/commit/bd6f1442be104fac8a4b0c6cb7fd832cc9c3d764))
+* **eval:** wire validateScenario into resolveEvalRun, add manifest to evalRunInput ([43be425](https://github.com/getlarge/themoltnet/commit/43be425ce4f47d0cb73dba3376e1ca09425b644e))
+* **eval:** write context pack to disk for DSPy judge parity ([36510c5](https://github.com/getlarge/themoltnet/commit/36510c5288a0b9cf2ec4beae7b167b277154a22d))
+* **legreffier:** support GitHub org account in manifest flow ([fdb9621](https://github.com/getlarge/themoltnet/commit/fdb9621a90d5fa4fab1cde1862d33d19695990e8))
+* **legreffier:** support GitHub org account in onboarding ([d2194d5](https://github.com/getlarge/themoltnet/commit/d2194d555e14aa119b08a3c3d73300e438199a63))
+
+
+### Bug Fixes
+
+* **dspy-adapters,eval:** address PR [#717](https://github.com/getlarge/themoltnet/issues/717) review — capture all trajectories, gate context_pack ([25e1b37](https://github.com/getlarge/themoltnet/commit/25e1b370212c6fc3e42b08a3d9c533a5107f2a40))
+* **eval:** address Copilot review comments ([95189d0](https://github.com/getlarge/themoltnet/commit/95189d06af6fd104077b73a2cc8f99449602dd20))
+* **eval:** address Copilot review on [#719](https://github.com/getlarge/themoltnet/issues/719) — vitro correctness, .git preservation ([37b0fd6](https://github.com/getlarge/themoltnet/commit/37b0fd64c67c91b060ba3d9ce6bb444ca61bad62))
+* **eval:** address Copilot review on [#719](https://github.com/getlarge/themoltnet/issues/719) — vitro correctness, .git preservation, validation strictness ([61e27a8](https://github.com/getlarge/themoltnet/commit/61e27a827768835a144d21eeaea3d520cb537262))
+* **eval:** address Task 1 review — guard test writes, clarify loadEvalManifest godoc ([80a1ed0](https://github.com/getlarge/themoltnet/commit/80a1ed0557a068e10f559cbb3260e5caf7d6baa0))
+* **eval:** progress bar layout and mpb corruption under concurrent runs ([5646d6e](https://github.com/getlarge/themoltnet/commit/5646d6e0041d68e5c368a90e1fc6be92e3dd1ca4))
+* **release:** recover cli v1.19.0 release cycle ([c2a6f27](https://github.com/getlarge/themoltnet/commit/c2a6f2784eadc19ff076a88875934ec993b17a99))
+* **release:** recover cli v1.19.0 release cycle ([2fcb830](https://github.com/getlarge/themoltnet/commit/2fcb8305e18bc5bed22df119a4b0ab916781a665))
+
+## [1.18.0](https://github.com/getlarge/themoltnet/compare/cli-v1.17.0...cli-v1.18.0) (2026-04-07)
+
+
+### Features
+
+* **cli:** add --env-file and --override flags to config init-from-env ([86a2324](https://github.com/getlarge/themoltnet/commit/86a2324084e60575d6986a893d0ae62fba361088))
+* **cli:** add `moltnet config init-from-env` and SessionStart hook ([93e4daa](https://github.com/getlarge/themoltnet/commit/93e4daa4a5726f58d8a2b71e15183cf0975294f5))
+* **cli:** add lightweight dspy eval engine ([7a3bada](https://github.com/getlarge/themoltnet/commit/7a3badab82c407f1d9c3cf7172724d64ed4593ac))
+* **cli:** add pack list/get and rendered-packs get commands ([2889ed0](https://github.com/getlarge/themoltnet/commit/2889ed0f8bac872b6975a74af5ce43607dc0087f))
+* **cli:** add rendered-packs list command ([65b44f7](https://github.com/getlarge/themoltnet/commit/65b44f724995d0978b1d899de24bed95365498bd))
+* **dspy-adapters:** harden DSPy judge runtime defaults ([c448e67](https://github.com/getlarge/themoltnet/commit/c448e679208b9ab448bd2aa89ee4f2d078b37103))
+* **eval:** add --config batch mode support for DSPy engine ([9559adf](https://github.com/getlarge/themoltnet/commit/9559adf1741a15225ee626dde7dc6b5b6b38f0d3))
+* **eval:** add Codex agent and judge support for DSPy engine ([7694cf0](https://github.com/getlarge/themoltnet/commit/7694cf01b5c69c2e47de41b12e8fde0193c86652))
+* **eval:** add Codex agent and judge support for DSPy engine ([641319c](https://github.com/getlarge/themoltnet/commit/641319cae0a53547e98d692a8f5f7feabe28d9af))
+* **eval:** add per-criterion evidence in DSPy judge terminal output ([f02c524](https://github.com/getlarge/themoltnet/commit/f02c5241064701db7847ecbede26717c79def451))
+* **eval:** add retry.js and wire withRetry into both judge scripts ([3cbac43](https://github.com/getlarge/themoltnet/commit/3cbac434159db8506e38602cc4fcafb3bc1bbe7b))
+* **eval:** add retry.py and wire with_retry into Python agent adapters ([d096207](https://github.com/getlarge/themoltnet/commit/d09620775d6e24af50f7ed3a7e4760f3e7b2cdbb))
+* **eval:** DSPy engine phase 2 — concurrency, artifacts, batch mode ([dafcc44](https://github.com/getlarge/themoltnet/commit/dafcc441827047dbf4575220515d4989c3571e6c))
+* **eval:** embed retry.py, add JUDGE_MAX_RETRIES to task.toml, add test ([2744fe3](https://github.com/getlarge/themoltnet/commit/2744fe3e398dafb26445c7c2f6aaac113e3f49bf))
+* **eval:** enable concurrent without/with-context variants for DSPy engine ([59b32ba](https://github.com/getlarge/themoltnet/commit/59b32bac4efb64470b35b67e610288118c6b7e4e))
+* **eval:** extract token usage and session metrics from agent JSONL ([75bf4df](https://github.com/getlarge/themoltnet/commit/75bf4df50fd32fafe662fb34fce8699a324ded5c))
+* **eval:** normalize all artifacts to Phase 0 contract schema ([5d050cb](https://github.com/getlarge/themoltnet/commit/5d050cb32a7ea8318c9ffc21ff19ebe017ca0e7a))
+* **eval:** switch DSPy runner to stream-json and emit normalized artifacts ([1d61bb4](https://github.com/getlarge/themoltnet/commit/1d61bb4102c223ee6a5298baf41e2f083eab4e6f))
+* fidelity judge verification workflow + routes ([92095c7](https://github.com/getlarge/themoltnet/commit/92095c752f4e8e0cd5d716eabf2a76564f7eccfb))
+* local judge mode, Codex adapter, CLI isolation ([22bb1c7](https://github.com/getlarge/themoltnet/commit/22bb1c79c94a65a4fb1939a335d6bbd7e3588ddd))
+* **moltnet-cli:** add local judge mode and fix claude-code adapter envelope parsing ([9e1e3d7](https://github.com/getlarge/themoltnet/commit/9e1e3d7c9719393c86b8c1d72d03852cffad6fa6))
+
+
+### Bug Fixes
+
+* **ci,go:** remove release-cli co-release block, reset manifest, bump go.mod ([8007e32](https://github.com/getlarge/themoltnet/commit/8007e3274f7972084f4ebc32f03fe5a672310d81))
+* **ci,go:** remove release-cli co-release block, reset manifest, bump go.mod ([d6e547f](https://github.com/getlarge/themoltnet/commit/d6e547fddcdfd4a12d0eb15d25927b9e59f77c80))
+* **ci:** sync CLI go.mod after proxy tags are pushed, before goreleaser ([e52ca66](https://github.com/getlarge/themoltnet/commit/e52ca667220c855adb9ff9e96439d2b059153268))
+* **ci:** sync CLI go.mod to manifest versions on release PR branch ([e2695dc](https://github.com/getlarge/themoltnet/commit/e2695dcabccdcb93517ce638ddba6bcbe15a1a97))
+* **ci:** sync CLI go.mod to release PR branch on manifest bump ([c6ec152](https://github.com/getlarge/themoltnet/commit/c6ec152fd05fccd81cdffb4b865ff6c5c5727740))
+* **cli:** fix init-from-env env file bugs and test parallelism ([b8367b3](https://github.com/getlarge/themoltnet/commit/b8367b3ab86abdea7dec038e8c4f026d4054d68b))
+* **cli:** freeze dspy source ref and disable auto memory ([65575cd](https://github.com/getlarge/themoltnet/commit/65575cdd68d6f8cd844bc9cd2b183937b9e1c4fd))
+* **cli:** use godotenv.Read instead of Load to avoid env var leakage ([6a633e0](https://github.com/getlarge/themoltnet/commit/6a633e01f1cef9402c4b931b82b41938edf0c895))
+* **cli:** use valid 32-byte Ed25519 test keys in init-from-env tests ([b150c1d](https://github.com/getlarge/themoltnet/commit/b150c1def0d5c1a0b8c238ce0914de2798d0cc19))
+* **dspy-adapters,cli:** fidelity judge empty scores + relations 201 handling ([b7623a2](https://github.com/getlarge/themoltnet/commit/b7623a2d39877f52273d0e0809dd5edde350b3b5))
+* **dspy-adapters:** address copilot review feedback ([84c7b52](https://github.com/getlarge/themoltnet/commit/84c7b52feeeee76748250de23add59d156af8d97))
+* **dspy-adapters:** default codex model to gpt-5.3-codex ([c424543](https://github.com/getlarge/themoltnet/commit/c424543fd47eba5bc235fcca70a1f440e8b6642c))
+* **dspy-adapters:** structured error handling, per-provider model defaults, project isolation ([6695d7a](https://github.com/getlarge/themoltnet/commit/6695d7a6d64c4152ac950905bb715f330878eb7a))
+* **eval:** add retry/backoff to Harbor agent and judge adapters ([101c8ae](https://github.com/getlarge/themoltnet/commit/101c8aee992a09f114c860856d2a5e2811cd4ed7))
+* **eval:** address claude[bot] review findings from PR [#673](https://github.com/getlarge/themoltnet/issues/673) ([e7766f0](https://github.com/getlarge/themoltnet/commit/e7766f00a02b45fc842d1b0cdaae421bcc827c3b))
+* **eval:** address copilot review findings ([51ccea2](https://github.com/getlarge/themoltnet/commit/51ccea2b223c0195ed0c12263e18a731c62397bc))
+* **eval:** address Copilot review findings ([428c5aa](https://github.com/getlarge/themoltnet/commit/428c5aa27c58a408313f35127a650c068f99a8e6))
+* **eval:** address Copilot review findings ([1fb87cb](https://github.com/getlarge/themoltnet/commit/1fb87cb0ae34612c94a04de73ee6972cfb3d643e))
+* **eval:** address review findings from DSPy Codex adapter PR ([62caab9](https://github.com/getlarge/themoltnet/commit/62caab952e36c7d752302bbfa013e21ddbb495f8))
+* **eval:** always preserve runner artifacts ([fcc3769](https://github.com/getlarge/themoltnet/commit/fcc37692619a4818f1b25c14cab0666ca995e329))
+* **eval:** always preserve runner artifacts ([32d0009](https://github.com/getlarge/themoltnet/commit/32d000971413a01454ad4100635648b3b378f52f))
+* **eval:** bridge Codex auth credentials into isolated CODEX_HOME ([c2aad57](https://github.com/getlarge/themoltnet/commit/c2aad57b762cdd2876388e09c63832e334a35ae2))
+* **eval:** broaden _is_retryable to match NonZeroAgentExitCodeError ([609d2aa](https://github.com/getlarge/themoltnet/commit/609d2aa9caef4b034d6521e0e428a2ce671463ed))
+* **eval:** embed and scaffold retry.js into judge environment dir ([460ba6e](https://github.com/getlarge/themoltnet/commit/460ba6ee4566e7b54f3a6f768f7462d230c25843))
+* **eval:** isolate Codex agent from user/project MCP config ([6a9182d](https://github.com/getlarge/themoltnet/commit/6a9182d6128fb0538c91b877eee0f615bfceb40a))
+* **eval:** per-variant judge LLM and resolved agent/model in artifacts ([4c300ea](https://github.com/getlarge/themoltnet/commit/4c300ea7bd9584f3ec71a8a3cfb8eab0504f3c24))
+* **eval:** use --full-auto for Codex eval agent ([e5268e9](https://github.com/getlarge/themoltnet/commit/e5268e98056190e44a586b263b14c182357ecab8))
+* **eval:** use workspace-write sandbox mode for Codex agent ([6ab4cbb](https://github.com/getlarge/themoltnet/commit/6ab4cbbccf192c837f515ae596ae161ca55044ef))
+* **moltnet-cli:** handle HTTP 201 response in relations create ([8e8fa09](https://github.com/getlarge/themoltnet/commit/8e8fa09d66e89d338439820d6777929d0cb3ea49))
+* **release:** auto-sync CLI go.mod to released api-client/dspy versions ([b98a759](https://github.com/getlarge/themoltnet/commit/b98a759c87b6db1c8d2e94256f79772ff5fcfa75))
+* **release:** decouple cli from go lib releases ([d0b35d2](https://github.com/getlarge/themoltnet/commit/d0b35d21c3e202af1df749b5420272e0eee72214))
+
+## [1.18.0](https://github.com/getlarge/themoltnet/compare/cli-v1.17.0...cli-v1.18.0) (2026-04-06)
+
+
+### Features
+
+* **cli:** add --env-file and --override flags to config init-from-env ([86a2324](https://github.com/getlarge/themoltnet/commit/86a2324084e60575d6986a893d0ae62fba361088))
+* **cli:** add `moltnet config init-from-env` and SessionStart hook ([93e4daa](https://github.com/getlarge/themoltnet/commit/93e4daa4a5726f58d8a2b71e15183cf0975294f5))
+* **cli:** add lightweight dspy eval engine ([7a3bada](https://github.com/getlarge/themoltnet/commit/7a3badab82c407f1d9c3cf7172724d64ed4593ac))
+* **cli:** add pack list/get and rendered-packs get commands ([2889ed0](https://github.com/getlarge/themoltnet/commit/2889ed0f8bac872b6975a74af5ce43607dc0087f))
+* **cli:** add rendered-packs list command ([65b44f7](https://github.com/getlarge/themoltnet/commit/65b44f724995d0978b1d899de24bed95365498bd))
+* **dspy-adapters:** harden DSPy judge runtime defaults ([c448e67](https://github.com/getlarge/themoltnet/commit/c448e679208b9ab448bd2aa89ee4f2d078b37103))
+* **eval:** add --config batch mode support for DSPy engine ([9559adf](https://github.com/getlarge/themoltnet/commit/9559adf1741a15225ee626dde7dc6b5b6b38f0d3))
+* **eval:** add Codex agent and judge support for DSPy engine ([7694cf0](https://github.com/getlarge/themoltnet/commit/7694cf01b5c69c2e47de41b12e8fde0193c86652))
+* **eval:** add Codex agent and judge support for DSPy engine ([641319c](https://github.com/getlarge/themoltnet/commit/641319cae0a53547e98d692a8f5f7feabe28d9af))
+* **eval:** add per-criterion evidence in DSPy judge terminal output ([f02c524](https://github.com/getlarge/themoltnet/commit/f02c5241064701db7847ecbede26717c79def451))
+* **eval:** add retry.js and wire withRetry into both judge scripts ([3cbac43](https://github.com/getlarge/themoltnet/commit/3cbac434159db8506e38602cc4fcafb3bc1bbe7b))
+* **eval:** add retry.py and wire with_retry into Python agent adapters ([d096207](https://github.com/getlarge/themoltnet/commit/d09620775d6e24af50f7ed3a7e4760f3e7b2cdbb))
+* **eval:** DSPy engine phase 2 — concurrency, artifacts, batch mode ([dafcc44](https://github.com/getlarge/themoltnet/commit/dafcc441827047dbf4575220515d4989c3571e6c))
+* **eval:** embed retry.py, add JUDGE_MAX_RETRIES to task.toml, add test ([2744fe3](https://github.com/getlarge/themoltnet/commit/2744fe3e398dafb26445c7c2f6aaac113e3f49bf))
+* **eval:** enable concurrent without/with-context variants for DSPy engine ([59b32ba](https://github.com/getlarge/themoltnet/commit/59b32bac4efb64470b35b67e610288118c6b7e4e))
+* **eval:** extract token usage and session metrics from agent JSONL ([75bf4df](https://github.com/getlarge/themoltnet/commit/75bf4df50fd32fafe662fb34fce8699a324ded5c))
+* **eval:** normalize all artifacts to Phase 0 contract schema ([5d050cb](https://github.com/getlarge/themoltnet/commit/5d050cb32a7ea8318c9ffc21ff19ebe017ca0e7a))
+* **eval:** switch DSPy runner to stream-json and emit normalized artifacts ([1d61bb4](https://github.com/getlarge/themoltnet/commit/1d61bb4102c223ee6a5298baf41e2f083eab4e6f))
+* fidelity judge verification workflow + routes ([92095c7](https://github.com/getlarge/themoltnet/commit/92095c752f4e8e0cd5d716eabf2a76564f7eccfb))
+* local judge mode, Codex adapter, CLI isolation ([22bb1c7](https://github.com/getlarge/themoltnet/commit/22bb1c79c94a65a4fb1939a335d6bbd7e3588ddd))
+* **moltnet-cli:** add local judge mode and fix claude-code adapter envelope parsing ([9e1e3d7](https://github.com/getlarge/themoltnet/commit/9e1e3d7c9719393c86b8c1d72d03852cffad6fa6))
+
+
+### Bug Fixes
+
+* **ci:** sync CLI go.mod after proxy tags are pushed, before goreleaser ([e52ca66](https://github.com/getlarge/themoltnet/commit/e52ca667220c855adb9ff9e96439d2b059153268))
+* **ci:** sync CLI go.mod to manifest versions on release PR branch ([e2695dc](https://github.com/getlarge/themoltnet/commit/e2695dcabccdcb93517ce638ddba6bcbe15a1a97))
+* **ci:** sync CLI go.mod to release PR branch on manifest bump ([c6ec152](https://github.com/getlarge/themoltnet/commit/c6ec152fd05fccd81cdffb4b865ff6c5c5727740))
+* **cli:** fix init-from-env env file bugs and test parallelism ([b8367b3](https://github.com/getlarge/themoltnet/commit/b8367b3ab86abdea7dec038e8c4f026d4054d68b))
+* **cli:** freeze dspy source ref and disable auto memory ([65575cd](https://github.com/getlarge/themoltnet/commit/65575cdd68d6f8cd844bc9cd2b183937b9e1c4fd))
+* **cli:** use godotenv.Read instead of Load to avoid env var leakage ([6a633e0](https://github.com/getlarge/themoltnet/commit/6a633e01f1cef9402c4b931b82b41938edf0c895))
+* **cli:** use valid 32-byte Ed25519 test keys in init-from-env tests ([b150c1d](https://github.com/getlarge/themoltnet/commit/b150c1def0d5c1a0b8c238ce0914de2798d0cc19))
+* **dspy-adapters,cli:** fidelity judge empty scores + relations 201 handling ([b7623a2](https://github.com/getlarge/themoltnet/commit/b7623a2d39877f52273d0e0809dd5edde350b3b5))
+* **dspy-adapters:** address copilot review feedback ([84c7b52](https://github.com/getlarge/themoltnet/commit/84c7b52feeeee76748250de23add59d156af8d97))
+* **dspy-adapters:** default codex model to gpt-5.3-codex ([c424543](https://github.com/getlarge/themoltnet/commit/c424543fd47eba5bc235fcca70a1f440e8b6642c))
+* **dspy-adapters:** structured error handling, per-provider model defaults, project isolation ([6695d7a](https://github.com/getlarge/themoltnet/commit/6695d7a6d64c4152ac950905bb715f330878eb7a))
+* **eval:** add retry/backoff to Harbor agent and judge adapters ([101c8ae](https://github.com/getlarge/themoltnet/commit/101c8aee992a09f114c860856d2a5e2811cd4ed7))
+* **eval:** address claude[bot] review findings from PR [#673](https://github.com/getlarge/themoltnet/issues/673) ([e7766f0](https://github.com/getlarge/themoltnet/commit/e7766f00a02b45fc842d1b0cdaae421bcc827c3b))
+* **eval:** address copilot review findings ([51ccea2](https://github.com/getlarge/themoltnet/commit/51ccea2b223c0195ed0c12263e18a731c62397bc))
+* **eval:** address Copilot review findings ([428c5aa](https://github.com/getlarge/themoltnet/commit/428c5aa27c58a408313f35127a650c068f99a8e6))
+* **eval:** address Copilot review findings ([1fb87cb](https://github.com/getlarge/themoltnet/commit/1fb87cb0ae34612c94a04de73ee6972cfb3d643e))
+* **eval:** address review findings from DSPy Codex adapter PR ([62caab9](https://github.com/getlarge/themoltnet/commit/62caab952e36c7d752302bbfa013e21ddbb495f8))
+* **eval:** always preserve runner artifacts ([fcc3769](https://github.com/getlarge/themoltnet/commit/fcc37692619a4818f1b25c14cab0666ca995e329))
+* **eval:** always preserve runner artifacts ([32d0009](https://github.com/getlarge/themoltnet/commit/32d000971413a01454ad4100635648b3b378f52f))
+* **eval:** bridge Codex auth credentials into isolated CODEX_HOME ([c2aad57](https://github.com/getlarge/themoltnet/commit/c2aad57b762cdd2876388e09c63832e334a35ae2))
+* **eval:** broaden _is_retryable to match NonZeroAgentExitCodeError ([609d2aa](https://github.com/getlarge/themoltnet/commit/609d2aa9caef4b034d6521e0e428a2ce671463ed))
+* **eval:** embed and scaffold retry.js into judge environment dir ([460ba6e](https://github.com/getlarge/themoltnet/commit/460ba6ee4566e7b54f3a6f768f7462d230c25843))
+* **eval:** isolate Codex agent from user/project MCP config ([6a9182d](https://github.com/getlarge/themoltnet/commit/6a9182d6128fb0538c91b877eee0f615bfceb40a))
+* **eval:** per-variant judge LLM and resolved agent/model in artifacts ([4c300ea](https://github.com/getlarge/themoltnet/commit/4c300ea7bd9584f3ec71a8a3cfb8eab0504f3c24))
+* **eval:** use --full-auto for Codex eval agent ([e5268e9](https://github.com/getlarge/themoltnet/commit/e5268e98056190e44a586b263b14c182357ecab8))
+* **eval:** use workspace-write sandbox mode for Codex agent ([6ab4cbb](https://github.com/getlarge/themoltnet/commit/6ab4cbbccf192c837f515ae596ae161ca55044ef))
+* **moltnet-cli:** handle HTTP 201 response in relations create ([8e8fa09](https://github.com/getlarge/themoltnet/commit/8e8fa09d66e89d338439820d6777929d0cb3ea49))
+* **release:** auto-sync CLI go.mod to released api-client/dspy versions ([b98a759](https://github.com/getlarge/themoltnet/commit/b98a759c87b6db1c8d2e94256f79772ff5fcfa75))
+* **release:** decouple cli from go lib releases ([d0b35d2](https://github.com/getlarge/themoltnet/commit/d0b35d21c3e202af1df749b5420272e0eee72214))
+
+## [1.17.0](https://github.com/getlarge/themoltnet/compare/cli-v1.16.0...cli-v1.17.0) (2026-04-06)
+
+
+### Features
+
+* **cli:** add --env-file and --override flags to config init-from-env ([86a2324](https://github.com/getlarge/themoltnet/commit/86a2324084e60575d6986a893d0ae62fba361088))
+* **cli:** add `moltnet config init-from-env` and SessionStart hook ([93e4daa](https://github.com/getlarge/themoltnet/commit/93e4daa4a5726f58d8a2b71e15183cf0975294f5))
+* **cli:** add lightweight dspy eval engine ([7a3bada](https://github.com/getlarge/themoltnet/commit/7a3badab82c407f1d9c3cf7172724d64ed4593ac))
+* **cli:** add pack list/get and rendered-packs get commands ([2889ed0](https://github.com/getlarge/themoltnet/commit/2889ed0f8bac872b6975a74af5ce43607dc0087f))
+* **cli:** add rendered-packs list command ([65b44f7](https://github.com/getlarge/themoltnet/commit/65b44f724995d0978b1d899de24bed95365498bd))
+* **dspy-adapters:** harden DSPy judge runtime defaults ([c448e67](https://github.com/getlarge/themoltnet/commit/c448e679208b9ab448bd2aa89ee4f2d078b37103))
+* **eval:** add --config batch mode support for DSPy engine ([9559adf](https://github.com/getlarge/themoltnet/commit/9559adf1741a15225ee626dde7dc6b5b6b38f0d3))
+* **eval:** add Codex agent and judge support for DSPy engine ([7694cf0](https://github.com/getlarge/themoltnet/commit/7694cf01b5c69c2e47de41b12e8fde0193c86652))
+* **eval:** add Codex agent and judge support for DSPy engine ([641319c](https://github.com/getlarge/themoltnet/commit/641319cae0a53547e98d692a8f5f7feabe28d9af))
+* **eval:** add per-criterion evidence in DSPy judge terminal output ([f02c524](https://github.com/getlarge/themoltnet/commit/f02c5241064701db7847ecbede26717c79def451))
+* **eval:** add retry.js and wire withRetry into both judge scripts ([3cbac43](https://github.com/getlarge/themoltnet/commit/3cbac434159db8506e38602cc4fcafb3bc1bbe7b))
+* **eval:** add retry.py and wire with_retry into Python agent adapters ([d096207](https://github.com/getlarge/themoltnet/commit/d09620775d6e24af50f7ed3a7e4760f3e7b2cdbb))
+* **eval:** DSPy engine phase 2 — concurrency, artifacts, batch mode ([dafcc44](https://github.com/getlarge/themoltnet/commit/dafcc441827047dbf4575220515d4989c3571e6c))
+* **eval:** embed retry.py, add JUDGE_MAX_RETRIES to task.toml, add test ([2744fe3](https://github.com/getlarge/themoltnet/commit/2744fe3e398dafb26445c7c2f6aaac113e3f49bf))
+* **eval:** enable concurrent without/with-context variants for DSPy engine ([59b32ba](https://github.com/getlarge/themoltnet/commit/59b32bac4efb64470b35b67e610288118c6b7e4e))
+* **eval:** extract token usage and session metrics from agent JSONL ([75bf4df](https://github.com/getlarge/themoltnet/commit/75bf4df50fd32fafe662fb34fce8699a324ded5c))
+* **eval:** normalize all artifacts to Phase 0 contract schema ([5d050cb](https://github.com/getlarge/themoltnet/commit/5d050cb32a7ea8318c9ffc21ff19ebe017ca0e7a))
+* **eval:** switch DSPy runner to stream-json and emit normalized artifacts ([1d61bb4](https://github.com/getlarge/themoltnet/commit/1d61bb4102c223ee6a5298baf41e2f083eab4e6f))
+* fidelity judge verification workflow + routes ([92095c7](https://github.com/getlarge/themoltnet/commit/92095c752f4e8e0cd5d716eabf2a76564f7eccfb))
+* local judge mode, Codex adapter, CLI isolation ([22bb1c7](https://github.com/getlarge/themoltnet/commit/22bb1c79c94a65a4fb1939a335d6bbd7e3588ddd))
+* **moltnet-cli:** add local judge mode and fix claude-code adapter envelope parsing ([9e1e3d7](https://github.com/getlarge/themoltnet/commit/9e1e3d7c9719393c86b8c1d72d03852cffad6fa6))
+
+
+### Bug Fixes
+
+* **ci:** sync CLI go.mod after proxy tags are pushed, before goreleaser ([e52ca66](https://github.com/getlarge/themoltnet/commit/e52ca667220c855adb9ff9e96439d2b059153268))
+* **ci:** sync CLI go.mod to manifest versions on release PR branch ([e2695dc](https://github.com/getlarge/themoltnet/commit/e2695dcabccdcb93517ce638ddba6bcbe15a1a97))
+* **ci:** sync CLI go.mod to release PR branch on manifest bump ([c6ec152](https://github.com/getlarge/themoltnet/commit/c6ec152fd05fccd81cdffb4b865ff6c5c5727740))
+* **cli:** fix init-from-env env file bugs and test parallelism ([b8367b3](https://github.com/getlarge/themoltnet/commit/b8367b3ab86abdea7dec038e8c4f026d4054d68b))
+* **cli:** freeze dspy source ref and disable auto memory ([65575cd](https://github.com/getlarge/themoltnet/commit/65575cdd68d6f8cd844bc9cd2b183937b9e1c4fd))
+* **cli:** use godotenv.Read instead of Load to avoid env var leakage ([6a633e0](https://github.com/getlarge/themoltnet/commit/6a633e01f1cef9402c4b931b82b41938edf0c895))
+* **cli:** use valid 32-byte Ed25519 test keys in init-from-env tests ([b150c1d](https://github.com/getlarge/themoltnet/commit/b150c1def0d5c1a0b8c238ce0914de2798d0cc19))
+* **dspy-adapters,cli:** fidelity judge empty scores + relations 201 handling ([b7623a2](https://github.com/getlarge/themoltnet/commit/b7623a2d39877f52273d0e0809dd5edde350b3b5))
+* **dspy-adapters:** address copilot review feedback ([84c7b52](https://github.com/getlarge/themoltnet/commit/84c7b52feeeee76748250de23add59d156af8d97))
+* **dspy-adapters:** default codex model to gpt-5.3-codex ([c424543](https://github.com/getlarge/themoltnet/commit/c424543fd47eba5bc235fcca70a1f440e8b6642c))
+* **dspy-adapters:** structured error handling, per-provider model defaults, project isolation ([6695d7a](https://github.com/getlarge/themoltnet/commit/6695d7a6d64c4152ac950905bb715f330878eb7a))
+* **eval:** add retry/backoff to Harbor agent and judge adapters ([101c8ae](https://github.com/getlarge/themoltnet/commit/101c8aee992a09f114c860856d2a5e2811cd4ed7))
+* **eval:** address claude[bot] review findings from PR [#673](https://github.com/getlarge/themoltnet/issues/673) ([e7766f0](https://github.com/getlarge/themoltnet/commit/e7766f00a02b45fc842d1b0cdaae421bcc827c3b))
+* **eval:** address copilot review findings ([51ccea2](https://github.com/getlarge/themoltnet/commit/51ccea2b223c0195ed0c12263e18a731c62397bc))
+* **eval:** address Copilot review findings ([428c5aa](https://github.com/getlarge/themoltnet/commit/428c5aa27c58a408313f35127a650c068f99a8e6))
+* **eval:** address Copilot review findings ([1fb87cb](https://github.com/getlarge/themoltnet/commit/1fb87cb0ae34612c94a04de73ee6972cfb3d643e))
+* **eval:** address review findings from DSPy Codex adapter PR ([62caab9](https://github.com/getlarge/themoltnet/commit/62caab952e36c7d752302bbfa013e21ddbb495f8))
+* **eval:** always preserve runner artifacts ([fcc3769](https://github.com/getlarge/themoltnet/commit/fcc37692619a4818f1b25c14cab0666ca995e329))
+* **eval:** always preserve runner artifacts ([32d0009](https://github.com/getlarge/themoltnet/commit/32d000971413a01454ad4100635648b3b378f52f))
+* **eval:** bridge Codex auth credentials into isolated CODEX_HOME ([c2aad57](https://github.com/getlarge/themoltnet/commit/c2aad57b762cdd2876388e09c63832e334a35ae2))
+* **eval:** broaden _is_retryable to match NonZeroAgentExitCodeError ([609d2aa](https://github.com/getlarge/themoltnet/commit/609d2aa9caef4b034d6521e0e428a2ce671463ed))
+* **eval:** embed and scaffold retry.js into judge environment dir ([460ba6e](https://github.com/getlarge/themoltnet/commit/460ba6ee4566e7b54f3a6f768f7462d230c25843))
+* **eval:** isolate Codex agent from user/project MCP config ([6a9182d](https://github.com/getlarge/themoltnet/commit/6a9182d6128fb0538c91b877eee0f615bfceb40a))
+* **eval:** per-variant judge LLM and resolved agent/model in artifacts ([4c300ea](https://github.com/getlarge/themoltnet/commit/4c300ea7bd9584f3ec71a8a3cfb8eab0504f3c24))
+* **eval:** use --full-auto for Codex eval agent ([e5268e9](https://github.com/getlarge/themoltnet/commit/e5268e98056190e44a586b263b14c182357ecab8))
+* **eval:** use workspace-write sandbox mode for Codex agent ([6ab4cbb](https://github.com/getlarge/themoltnet/commit/6ab4cbbccf192c837f515ae596ae161ca55044ef))
+* **moltnet-cli:** handle HTTP 201 response in relations create ([8e8fa09](https://github.com/getlarge/themoltnet/commit/8e8fa09d66e89d338439820d6777929d0cb3ea49))
+* **release:** auto-sync CLI go.mod to released api-client/dspy versions ([b98a759](https://github.com/getlarge/themoltnet/commit/b98a759c87b6db1c8d2e94256f79772ff5fcfa75))
+* **release:** decouple cli from go lib releases ([d0b35d2](https://github.com/getlarge/themoltnet/commit/d0b35d21c3e202af1df749b5420272e0eee72214))
+
+## [1.16.0](https://github.com/getlarge/themoltnet/compare/cli-v1.15.0...cli-v1.16.0) (2026-04-05)
+
+
+### Features
+
+* **eval:** DSPy engine phase 2 — concurrency, artifacts, batch mode ([dafcc44](https://github.com/getlarge/themoltnet/commit/dafcc441827047dbf4575220515d4989c3571e6c))
+* **eval:** normalize all artifacts to Phase 0 contract schema ([5d050cb](https://github.com/getlarge/themoltnet/commit/5d050cb32a7ea8318c9ffc21ff19ebe017ca0e7a))
+
+
+### Bug Fixes
+
+* **eval:** address Copilot review findings ([1fb87cb](https://github.com/getlarge/themoltnet/commit/1fb87cb0ae34612c94a04de73ee6972cfb3d643e))
+
+## [1.15.0](https://github.com/getlarge/themoltnet/compare/cli-v1.14.0...cli-v1.15.0) (2026-04-04)
+
+
+### Features
+
+* **cli:** add lightweight dspy eval engine ([7a3bada](https://github.com/getlarge/themoltnet/commit/7a3badab82c407f1d9c3cf7172724d64ed4593ac))
+* **cli:** add pack list/get and rendered-packs get commands ([2889ed0](https://github.com/getlarge/themoltnet/commit/2889ed0f8bac872b6975a74af5ce43607dc0087f))
+* **cli:** add rendered-packs list command ([65b44f7](https://github.com/getlarge/themoltnet/commit/65b44f724995d0978b1d899de24bed95365498bd))
+* **dspy-adapters:** harden DSPy judge runtime defaults ([c448e67](https://github.com/getlarge/themoltnet/commit/c448e679208b9ab448bd2aa89ee4f2d078b37103))
+* **eval:** add retry.js and wire withRetry into both judge scripts ([3cbac43](https://github.com/getlarge/themoltnet/commit/3cbac434159db8506e38602cc4fcafb3bc1bbe7b))
+* **eval:** add retry.py and wire with_retry into Python agent adapters ([d096207](https://github.com/getlarge/themoltnet/commit/d09620775d6e24af50f7ed3a7e4760f3e7b2cdbb))
+* **eval:** embed retry.py, add JUDGE_MAX_RETRIES to task.toml, add test ([2744fe3](https://github.com/getlarge/themoltnet/commit/2744fe3e398dafb26445c7c2f6aaac113e3f49bf))
+* fidelity judge verification workflow + routes ([92095c7](https://github.com/getlarge/themoltnet/commit/92095c752f4e8e0cd5d716eabf2a76564f7eccfb))
+* local judge mode, Codex adapter, CLI isolation ([22bb1c7](https://github.com/getlarge/themoltnet/commit/22bb1c79c94a65a4fb1939a335d6bbd7e3588ddd))
+* **moltnet-cli:** add local judge mode and fix claude-code adapter envelope parsing ([9e1e3d7](https://github.com/getlarge/themoltnet/commit/9e1e3d7c9719393c86b8c1d72d03852cffad6fa6))
+
+
+### Bug Fixes
+
+* **ci:** sync CLI go.mod after proxy tags are pushed, before goreleaser ([e52ca66](https://github.com/getlarge/themoltnet/commit/e52ca667220c855adb9ff9e96439d2b059153268))
+* **ci:** sync CLI go.mod to manifest versions on release PR branch ([e2695dc](https://github.com/getlarge/themoltnet/commit/e2695dcabccdcb93517ce638ddba6bcbe15a1a97))
+* **ci:** sync CLI go.mod to release PR branch on manifest bump ([c6ec152](https://github.com/getlarge/themoltnet/commit/c6ec152fd05fccd81cdffb4b865ff6c5c5727740))
+* **cli:** freeze dspy source ref and disable auto memory ([65575cd](https://github.com/getlarge/themoltnet/commit/65575cdd68d6f8cd844bc9cd2b183937b9e1c4fd))
+* **dspy-adapters,cli:** fidelity judge empty scores + relations 201 handling ([b7623a2](https://github.com/getlarge/themoltnet/commit/b7623a2d39877f52273d0e0809dd5edde350b3b5))
+* **dspy-adapters:** address copilot review feedback ([84c7b52](https://github.com/getlarge/themoltnet/commit/84c7b52feeeee76748250de23add59d156af8d97))
+* **dspy-adapters:** default codex model to gpt-5.3-codex ([c424543](https://github.com/getlarge/themoltnet/commit/c424543fd47eba5bc235fcca70a1f440e8b6642c))
+* **dspy-adapters:** structured error handling, per-provider model defaults, project isolation ([6695d7a](https://github.com/getlarge/themoltnet/commit/6695d7a6d64c4152ac950905bb715f330878eb7a))
+* **eval:** add retry/backoff to Harbor agent and judge adapters ([101c8ae](https://github.com/getlarge/themoltnet/commit/101c8aee992a09f114c860856d2a5e2811cd4ed7))
+* **eval:** address copilot review findings ([51ccea2](https://github.com/getlarge/themoltnet/commit/51ccea2b223c0195ed0c12263e18a731c62397bc))
+* **eval:** always preserve runner artifacts ([fcc3769](https://github.com/getlarge/themoltnet/commit/fcc37692619a4818f1b25c14cab0666ca995e329))
+* **eval:** always preserve runner artifacts ([32d0009](https://github.com/getlarge/themoltnet/commit/32d000971413a01454ad4100635648b3b378f52f))
+* **eval:** broaden _is_retryable to match NonZeroAgentExitCodeError ([609d2aa](https://github.com/getlarge/themoltnet/commit/609d2aa9caef4b034d6521e0e428a2ce671463ed))
+* **eval:** embed and scaffold retry.js into judge environment dir ([460ba6e](https://github.com/getlarge/themoltnet/commit/460ba6ee4566e7b54f3a6f768f7462d230c25843))
+* **moltnet-cli:** handle HTTP 201 response in relations create ([8e8fa09](https://github.com/getlarge/themoltnet/commit/8e8fa09d66e89d338439820d6777929d0cb3ea49))
+* **release:** auto-sync CLI go.mod to released api-client/dspy versions ([b98a759](https://github.com/getlarge/themoltnet/commit/b98a759c87b6db1c8d2e94256f79772ff5fcfa75))
+
 ## [1.14.0](https://github.com/getlarge/themoltnet/compare/cli-v1.13.0...cli-v1.14.0) (2026-04-04)
 
 

--- a/tools/eval-canary/README.md
+++ b/tools/eval-canary/README.md
@@ -26,17 +26,18 @@ Run both Harbor and DSPy eval engines on the same scenario set and compare resul
 
 Override via environment variables:
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `CANARY_MAX_SCORE_DRIFT` | `0.10` | Max absolute per-scenario reward difference |
-| `CANARY_MIN_COMPLETION_RATE` | `0.90` | DSPy must achieve at least this |
-| `CANARY_MAX_INFRA_FAILURE_RATE` | `0.05` | DSPy infra failures must be below this |
+| Variable                        | Default | Description                                 |
+| ------------------------------- | ------- | ------------------------------------------- |
+| `CANARY_MAX_SCORE_DRIFT`        | `0.10`  | Max absolute per-scenario reward difference |
+| `CANARY_MIN_COMPLETION_RATE`    | `0.90`  | DSPy must achieve at least this             |
+| `CANARY_MAX_INFRA_FAILURE_RATE` | `0.05`  | DSPy infra failures must be below this      |
 
 ## Verdict
 
 Exit code 0 = PASS (all criteria met), exit code 1 = FAIL.
 
 Pass criteria:
+
 - DSPy completion rate >= threshold
 - DSPy completion rate >= Harbor completion rate
 - DSPy infra-failure rate <= threshold

--- a/tools/src/process.ts
+++ b/tools/src/process.ts
@@ -9,9 +9,7 @@ export interface CommandResult {
   output: string;
 }
 
-function isExecException(
-  error: unknown,
-): error is ExecException & {
+function isExecException(error: unknown): error is ExecException & {
   stdout?: string | Buffer;
   stderr?: string | Buffer;
 } {


### PR DESCRIPTION
## Summary

  - Add createdBy to REST DiaryEntrySchema so it is serialized in private diary entry responses.
  - Update REST diary-entry test fixtures/assertions for create/list/get/search routes.
  - Regenerate OpenAPI plus API clients (TypeScript and Go) from the updated schema.

  ## Why

  diary_entries.created_by is persisted in DB and present in service-layer objects, but it was missing from DiaryEntrySchema. Fastify response
  serialization therefore dropped it from API responses.

  ## Changes

  - Added createdBy: uuid field to private DiaryEntry response schema.
  - Kept public feed behavior unchanged (createdBy is still not exposed there).
  - Updated generated artifacts to keep API contracts and clients aligned:
      - apps/rest-api/public/openapi.json
      - libs/api-client/src/generated/types.gen.ts
      - libs/moltnet-api-client/openapi-normalized.json
      - libs/moltnet-api-client/oas_schemas_gen.go
      - libs/moltnet-api-client/oas_json_gen.go

  ## Validation

  - Ran targeted regression tests:
      - pnpm --filter @moltnet/rest-api exec vitest run __tests__/diary-entries.test.ts __tests__/public.test.ts
  - Result: 76/76 tests passed.

  ## Notes

  - This is a response-shape fix only. No DB migration required.
  - Existing private diary entry endpoints now consistently include createdBy.