### PR TITLE
feat(cli): platform-specific npm packages for binary distribution

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -9,6 +9,11 @@ fi
 
 cd "$CLAUDE_PROJECT_DIR"
 
+# Ensure openssh-client is available (needed for git SSH commit signing)
+if ! command -v ssh-keygen &>/dev/null; then
+  apt-get update -qq && apt-get install -y -qq openssh-client >/dev/null 2>&1 || true
+fi
+
 # Install Node.js dependencies (idempotent, cached between sessions)
 if [ ! -d "node_modules" ]; then
   pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -400,6 +400,47 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
 
+      - name: Download release binaries
+        run: |
+          TAG="${{ needs.resolve-publish.outputs.cli-tag }}"
+          SEMVER="${TAG#cli-v}"
+          mkdir -p /tmp/cli-binaries
+          cd /tmp/cli-binaries
+          gh release download "$TAG" \
+            --pattern "moltnet_${SEMVER}_*.tar.gz" \
+            --pattern "moltnet_${SEMVER}_*.zip"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish platform-specific packages
+        run: |
+          TAG="${{ needs.resolve-publish.outputs.cli-tag }}"
+          SEMVER="${TAG#cli-v}"
+
+          publish_platform() {
+            local npm_dir="$1" archive="$2" binary="$3"
+            local pkg_dir="packages/cli/npm/${npm_dir}"
+
+            mkdir -p "${pkg_dir}/bin"
+            if [[ "$archive" == *.zip ]]; then
+              unzip -o "/tmp/cli-binaries/${archive}" "${binary}" -d "${pkg_dir}/bin/"
+            else
+              tar xzf "/tmp/cli-binaries/${archive}" -C "${pkg_dir}/bin/" "${binary}"
+            fi
+            chmod +x "${pkg_dir}/bin/${binary}" 2>/dev/null || true
+
+            cd "${pkg_dir}"
+            npm publish --access public --provenance
+            cd "$GITHUB_WORKSPACE"
+          }
+
+          publish_platform "linux-x64"     "moltnet_${SEMVER}_linux_amd64.tar.gz"   "moltnet"
+          publish_platform "linux-arm64"    "moltnet_${SEMVER}_linux_arm64.tar.gz"   "moltnet"
+          publish_platform "darwin-x64"     "moltnet_${SEMVER}_darwin_amd64.tar.gz"  "moltnet"
+          publish_platform "darwin-arm64"   "moltnet_${SEMVER}_darwin_arm64.tar.gz"  "moltnet"
+          publish_platform "win32-x64"      "moltnet_${SEMVER}_windows_amd64.zip"   "moltnet.exe"
+          publish_platform "win32-arm64"    "moltnet_${SEMVER}_windows_arm64.zip"    "moltnet.exe"
+
       - name: Publish @themoltnet/cli
         working-directory: packages/cli
         run: npm publish --access public --provenance

--- a/.gitignore
+++ b/.gitignore
@@ -186,6 +186,8 @@ cmd/moltnet/moltnet
 packages/cli/bin/moltnet
 packages/cli/bin/moltnet.exe
 packages/cli/.tmp/
+# Platform-specific CLI packages (binaries injected at publish time)
+packages/cli/npm/*/bin/
 
 # Scratch/draft documents
 .scratch/

--- a/packages/cli/bin/moltnet.js
+++ b/packages/cli/bin/moltnet.js
@@ -6,11 +6,32 @@ const fs = require('fs');
 const { execFileSync } = require('child_process');
 
 const binaryName = process.platform === 'win32' ? 'moltnet.exe' : 'moltnet';
-const binaryPath = path.join(__dirname, binaryName);
 
-if (!fs.existsSync(binaryPath)) {
+function findBinary() {
+  const localPath = path.join(__dirname, binaryName);
+  if (fs.existsSync(localPath)) {
+    return localPath;
+  }
+
+  const pkgName = `@themoltnet/cli-${process.platform}-${process.arch}`;
+  try {
+    const pkgDir = path.dirname(require.resolve(`${pkgName}/package.json`));
+    const pkgPath = path.join(pkgDir, 'bin', binaryName);
+    if (fs.existsSync(pkgPath)) {
+      return pkgPath;
+    }
+  } catch {
+    // Platform package not installed
+  }
+
+  return null;
+}
+
+const binaryPath = findBinary();
+
+if (!binaryPath) {
   console.error(
-    `moltnet binary not found at ${binaryPath}\n` +
+    `moltnet binary not found for ${process.platform}-${process.arch}\n` +
       'Run "node install.js" in the package directory, or download manually from:\n' +
       '  https://github.com/getlarge/themoltnet/releases'
   );

--- a/packages/cli/install.js
+++ b/packages/cli/install.js
@@ -5,7 +5,6 @@ const https = require('https');
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
-const zlib = require('zlib');
 const { execFileSync } = require('child_process');
 
 const VERSION = require('./package.json').version;
@@ -30,6 +29,24 @@ function getBinaryName() {
 
 function getBinaryPath() {
   return path.join(__dirname, 'bin', getBinaryName());
+}
+
+function getPlatformPackageName() {
+  return `@themoltnet/cli-${process.platform}-${process.arch}`;
+}
+
+function tryPlatformPackage() {
+  const pkgName = getPlatformPackageName();
+  try {
+    const pkgDir = path.dirname(require.resolve(`${pkgName}/package.json`));
+    const binaryPath = path.join(pkgDir, 'bin', getBinaryName());
+    if (fs.existsSync(binaryPath)) {
+      return binaryPath;
+    }
+  } catch {
+    // Platform package not installed — expected when os/cpu filters exclude it
+  }
+  return null;
 }
 
 function getArchiveName() {
@@ -132,6 +149,19 @@ async function main() {
 
   if (fs.existsSync(binaryPath)) {
     console.log(`moltnet binary already exists at ${binaryPath}, skipping download.`);
+    return;
+  }
+
+  const platformBinary = tryPlatformPackage();
+  if (platformBinary) {
+    console.log(`Found moltnet binary via platform package: ${platformBinary}`);
+    const binDir = path.join(__dirname, 'bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.copyFileSync(platformBinary, binaryPath);
+    if (process.platform !== 'win32') {
+      fs.chmodSync(binaryPath, 0o755);
+    }
+    console.log(`Installed moltnet ${VERSION} to ${binaryPath}`);
     return;
   }
 

--- a/packages/cli/npm/darwin-arm64/package.json
+++ b/packages/cli/npm/darwin-arm64/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@themoltnet/cli-darwin-arm64",
+  "version": "1.21.1",
+  "description": "MoltNet CLI binary for macOS ARM64",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/getlarge/themoltnet.git",
+    "directory": "packages/cli/npm/darwin-arm64"
+  },
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "files": [
+    "bin/moltnet"
+  ]
+}

--- a/packages/cli/npm/darwin-x64/package.json
+++ b/packages/cli/npm/darwin-x64/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@themoltnet/cli-darwin-x64",
+  "version": "1.21.1",
+  "description": "MoltNet CLI binary for macOS x64",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/getlarge/themoltnet.git",
+    "directory": "packages/cli/npm/darwin-x64"
+  },
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "bin/moltnet"
+  ]
+}

--- a/packages/cli/npm/linux-arm64/package.json
+++ b/packages/cli/npm/linux-arm64/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@themoltnet/cli-linux-arm64",
+  "version": "1.21.1",
+  "description": "MoltNet CLI binary for Linux ARM64",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/getlarge/themoltnet.git",
+    "directory": "packages/cli/npm/linux-arm64"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "files": [
+    "bin/moltnet"
+  ]
+}

--- a/packages/cli/npm/linux-x64/package.json
+++ b/packages/cli/npm/linux-x64/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@themoltnet/cli-linux-x64",
+  "version": "1.21.1",
+  "description": "MoltNet CLI binary for Linux x64",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/getlarge/themoltnet.git",
+    "directory": "packages/cli/npm/linux-x64"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "bin/moltnet"
+  ]
+}

--- a/packages/cli/npm/win32-arm64/package.json
+++ b/packages/cli/npm/win32-arm64/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@themoltnet/cli-win32-arm64",
+  "version": "1.21.1",
+  "description": "MoltNet CLI binary for Windows ARM64",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/getlarge/themoltnet.git",
+    "directory": "packages/cli/npm/win32-arm64"
+  },
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "files": [
+    "bin/moltnet.exe"
+  ]
+}

--- a/packages/cli/npm/win32-x64/package.json
+++ b/packages/cli/npm/win32-x64/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@themoltnet/cli-win32-x64",
+  "version": "1.21.1",
+  "description": "MoltNet CLI binary for Windows x64",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/getlarge/themoltnet.git",
+    "directory": "packages/cli/npm/win32-x64"
+  },
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "bin/moltnet.exe"
+  ]
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,6 +19,14 @@
     "bin/moltnet.js",
     "install.js"
   ],
+  "optionalDependencies": {
+    "@themoltnet/cli-linux-x64": "1.21.1",
+    "@themoltnet/cli-linux-arm64": "1.21.1",
+    "@themoltnet/cli-darwin-x64": "1.21.1",
+    "@themoltnet/cli-darwin-arm64": "1.21.1",
+    "@themoltnet/cli-win32-x64": "1.21.1",
+    "@themoltnet/cli-win32-arm64": "1.21.1"
+  },
   "engines": {
     "node": ">=18"
   }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,6 +13,66 @@
           "jsonpath": "$.version",
           "path": "/packages/cli/package.json",
           "type": "json"
+        },
+        {
+          "jsonpath": "$.optionalDependencies['@themoltnet/cli-linux-x64']",
+          "path": "/packages/cli/package.json",
+          "type": "json"
+        },
+        {
+          "jsonpath": "$.optionalDependencies['@themoltnet/cli-linux-arm64']",
+          "path": "/packages/cli/package.json",
+          "type": "json"
+        },
+        {
+          "jsonpath": "$.optionalDependencies['@themoltnet/cli-darwin-x64']",
+          "path": "/packages/cli/package.json",
+          "type": "json"
+        },
+        {
+          "jsonpath": "$.optionalDependencies['@themoltnet/cli-darwin-arm64']",
+          "path": "/packages/cli/package.json",
+          "type": "json"
+        },
+        {
+          "jsonpath": "$.optionalDependencies['@themoltnet/cli-win32-x64']",
+          "path": "/packages/cli/package.json",
+          "type": "json"
+        },
+        {
+          "jsonpath": "$.optionalDependencies['@themoltnet/cli-win32-arm64']",
+          "path": "/packages/cli/package.json",
+          "type": "json"
+        },
+        {
+          "jsonpath": "$.version",
+          "path": "/packages/cli/npm/linux-x64/package.json",
+          "type": "json"
+        },
+        {
+          "jsonpath": "$.version",
+          "path": "/packages/cli/npm/linux-arm64/package.json",
+          "type": "json"
+        },
+        {
+          "jsonpath": "$.version",
+          "path": "/packages/cli/npm/darwin-x64/package.json",
+          "type": "json"
+        },
+        {
+          "jsonpath": "$.version",
+          "path": "/packages/cli/npm/darwin-arm64/package.json",
+          "type": "json"
+        },
+        {
+          "jsonpath": "$.version",
+          "path": "/packages/cli/npm/win32-x64/package.json",
+          "type": "json"
+        },
+        {
+          "jsonpath": "$.version",
+          "path": "/packages/cli/npm/win32-arm64/package.json",
+          "type": "json"
         }
       ],
       "release-type": "go"


### PR DESCRIPTION
## Summary

- Add 6 platform-specific npm packages (`@themoltnet/cli-{linux,darwin,win32}-{x64,arm64}`) following the esbuild/turbo pattern, so npm/pnpm installs the CLI binary from the registry instead of downloading from GitHub releases at postinstall
- Update `install.js` and `bin/moltnet.js` to resolve the binary from platform packages first, falling back to the existing GitHub releases download
- Update the release workflow to publish platform packages before the main `@themoltnet/cli` wrapper (using OIDC provenance, no stored tokens)
- Update `release-please-config.json` to keep versions in sync across all 7 package.json files
- Add `openssh-client` install to the session-start hook for git SSH signing in web sessions

### Why

The current `install.js` downloads the Go binary from `github.com` releases via raw HTTPS. In sandboxed environments (e.g. Claude Code web), DNS resolution for `github.com` fails (`EAI_AGAIN`) — the npm registry is reachable but GitHub is not. This silently breaks `npx @themoltnet/cli` for any project using the CLI.

### First-time setup required

The 6 new platform packages need an initial manual `npm publish --access public` before CI automation kicks in. After that, releases are fully automated.

## Test plan

- [ ] Verify `install.js` resolves binary from platform package when available (mock `require.resolve`)
- [ ] Verify `bin/moltnet.js` falls back to platform package when local binary is missing
- [ ] Verify release workflow publishes platform packages before the main wrapper
- [ ] Verify `release-please-config.json` syncs versions to all platform package.json files
- [ ] Manual first publish of each `@themoltnet/cli-*` package after merge
- [ ] Test `npx @themoltnet/cli version` in a sandboxed environment after first publish

https://claude.ai/code/session_01FFmukSuFGv7a3vFSu2LqNs