### PR TITLE
[codex] Fix CLI postinstall fallback in workspace installs

### DIFF
--- a/packages/cli/install.js
+++ b/packages/cli/install.js
@@ -1,13 +1,14 @@
 #!/usr/bin/env node
 'use strict';
 
-const https = require('https');
 const fs = require('fs');
 const path = require('path');
 const zlib = require('zlib');
 const { execFileSync } = require('child_process');
 
 const VERSION = require('./package.json').version;
+const WORKSPACE_PLATFORM_ROOT = path.resolve(__dirname, 'npm');
+const FETCH_TIMEOUT_MS = 15_000;
 
 function getBinaryName() {
   return process.platform === 'win32' ? 'moltnet.exe' : 'moltnet';
@@ -17,20 +18,47 @@ function getPlatformPackageName() {
   return `@themoltnet/cli-${process.platform}-${process.arch}`;
 }
 
+function resolvePlatformPackage() {
+  const pkgName = getPlatformPackageName();
+  try {
+    const pkgDir = path.dirname(require.resolve(`${pkgName}/package.json`));
+    return {
+      binaryPath: path.join(pkgDir, 'bin', getBinaryName()),
+      isWorkspacePackage:
+        pkgDir === WORKSPACE_PLATFORM_ROOT ||
+        pkgDir.startsWith(`${WORKSPACE_PLATFORM_ROOT}${path.sep}`),
+      pkgDir,
+    };
+  } catch {
+    return null;
+  }
+}
+
 // Case 1 (happy path): the platform package was installed via
 // optionalDependencies. bin/moltnet.js resolves the binary in place at
 // runtime, so install.js has nothing to do.
 function tryPlatformPackage() {
-  const pkgName = getPlatformPackageName();
-  try {
-    const pkgDir = path.dirname(require.resolve(`${pkgName}/package.json`));
-    const binaryPath = path.join(pkgDir, 'bin', getBinaryName());
-    if (fs.existsSync(binaryPath)) {
-      return binaryPath;
-    }
-  } catch {
+  const resolvedPackage = resolvePlatformPackage();
+  if (!resolvedPackage) {
     // Platform package not installed (e.g. --no-optional, yarn v1 optional bug)
+    return null;
   }
+
+  if (fs.existsSync(resolvedPackage.binaryPath)) {
+    return resolvedPackage.binaryPath;
+  }
+
+  // In this monorepo, workspace platform packages resolve during `pnpm install`
+  // before their release artifacts exist in the checkout. That should not
+  // trigger a registry fetch; the fallback is only for published installs.
+  if (resolvedPackage.isWorkspacePackage) {
+    console.log(
+      `Skipping moltnet binary download for workspace package ${getPlatformPackageName()} ` +
+        `(${resolvedPackage.pkgDir})`
+    );
+    return resolvedPackage.binaryPath;
+  }
+
   return null;
 }
 
@@ -39,24 +67,30 @@ function fetch(url, maxRedirects = 5) {
     if (maxRedirects <= 0) {
       return reject(new Error('Too many redirects'));
     }
-    https
-      .get(url, { headers: { 'User-Agent': 'themoltnet-cli' } }, (res) => {
-        if (
-          res.statusCode >= 300 &&
-          res.statusCode < 400 &&
-          res.headers.location
-        ) {
-          return resolve(fetch(res.headers.location, maxRedirects - 1));
-        }
-        if (res.statusCode !== 200) {
-          return reject(new Error(`HTTP ${res.statusCode} fetching ${url}`));
-        }
-        const chunks = [];
-        res.on('data', (chunk) => chunks.push(chunk));
-        res.on('end', () => resolve(Buffer.concat(chunks)));
-        res.on('error', reject);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    globalThis
+      .fetch(url, {
+        headers: { 'User-Agent': 'themoltnet-cli' },
+        redirect: 'follow',
+        signal: controller.signal,
       })
-      .on('error', reject);
+      .then(async (response) => {
+        clearTimeout(timeout);
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status} fetching ${url}`);
+        }
+        return Buffer.from(await response.arrayBuffer());
+      })
+      .then(resolve)
+      .catch((err) => {
+        clearTimeout(timeout);
+        if (err.name === 'AbortError') {
+          reject(new Error(`Request timed out after ${FETCH_TIMEOUT_MS}ms`));
+          return;
+        }
+        reject(err);
+      });
   });
 }
 


### PR DESCRIPTION
## What changed

This updates `packages/cli/install.js` to harden the npm fallback path used by
`@themoltnet/cli` postinstall.

- skip the npm tarball download when the resolved platform package is the local
  workspace copy under `packages/cli/npm/*`
- replace the custom `https.get` helper with native `fetch`
- add an `AbortController` timeout so stalled registry requests fail fast
  instead of holding `pnpm install`

## Why

The CI failure was caused by the wrapper package falling back to npm during a
workspace install even though the local platform package had already resolved.
In the monorepo, the workspace package exists before its release artifact is
present in the checkout, so the previous logic treated that as a missing package
and attempted to fetch `@themoltnet/cli-linux-x64@1.29.0` from npm.

That produced two bad behaviors:

- false fallback to the registry in local/workspace installs
- slow or hanging `pnpm install` while waiting on the registry response, because
  the request had no timeout

## Impact

- local and CI workspace installs no longer hit the npm registry for this case
- published installs still keep the npm fallback path
- registry stalls now time out instead of appearing stuck in
  `packages/cli postinstall`

## Validation

- `node --check packages/cli/install.js`
