### PR TITLE
docs(db): clarify production baseline switch

### DIFF
--- a/docs/recipes/fly-mpg-backup-restore.md
+++ b/docs/recipes/fly-mpg-backup-restore.md
@@ -157,6 +157,10 @@ docker exec themoltnet-pg17-restore-test \
   -c "select count(*) as diary_entries from public.diary_entries;"
 ```
 
+Treat the row counts as sanity checks, not fixed values. Production keeps
+changing, so the useful signal is that the tables exist and return plausible,
+non-zero results.
+
 ## 6. Start the app against the restored database
 
 After the restore succeeds, you can boot `rest-api` against the restored
@@ -185,6 +189,38 @@ Teardown:
 ```bash
 COMPOSE_DISABLE_ENV_FILE=true docker compose -f docker-compose.e2e.yaml -f docker-compose.restore-test.yaml stop rest-api-restore
 ```
+
+## 7. If the goal is a production baseline switch
+
+Do the rehearsal above first. Then, on production itself:
+
+1. Take a fresh backup immediately before touching the migration ledger.
+2. Compute the SHA-256 hashes of `libs/database/drizzle/0000_init.sql` and
+   `libs/database/drizzle/0001_baseline_runtime.sql`.
+3. Replace `drizzle.__drizzle_migrations` with those 2 rows.
+4. Verify the live table now contains exactly 2 rows with the expected hashes.
+5. Only then run the migrator that Fly release will run.
+
+Use direct `psql -c` statements for the ledger swap, not a heredoc-wrapped
+shell pipeline. The direct form is easier to audit and verify line by line:
+
+```bash
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 \
+  -c "begin;" \
+  -c "delete from drizzle.__drizzle_migrations;" \
+  -c "insert into drizzle.__drizzle_migrations (hash, created_at) values ('<hash_from_0000_init>', <when_from_meta_journal_0000>), ('<hash_from_0001_baseline_runtime>', <when_from_meta_journal_0001>);" \
+  -c "commit;" \
+  -c "select id, hash, created_at from drizzle.__drizzle_migrations order by created_at;"
+```
+
+Hard gate before the migrator:
+
+- `select count(*) from drizzle.__drizzle_migrations;` must return `2`
+- the 2 stored hashes must match the files being deployed
+
+If this gate fails, stop there. Do not run the migrator against prod with the
+old ledger still present, or Drizzle will try to replay `0000_init.sql` over
+the live schema.
 
 ## Known caveats
 

--- a/libs/database/drizzle/README.md
+++ b/libs/database/drizzle/README.md
@@ -100,6 +100,21 @@ already applied without executing them again.
 Important: Drizzle uses the `drizzle` schema, not `public`, for its migration
 tracking table.
 
+For production, the safe order is:
+
+1. Take a fresh backup first.
+2. Compute the SHA-256 hashes of the baseline SQL files you are about to
+   deploy.
+3. Replace the existing contents of `drizzle.__drizzle_migrations` with the
+   new baseline rows.
+4. Verify the live table contains exactly those 2 rows.
+5. Only then run the migrator.
+
+Do not merge or deploy the release that contains the new baseline before the
+production ledger has been updated. Fly release runs `node dist/migrate.js`
+before switching traffic, so an old ledger plus the new two-file baseline will
+make Drizzle try to replay `0000_init.sql` over the live schema.
+
 ```sql
 CREATE SCHEMA IF NOT EXISTS drizzle;
 
@@ -119,6 +134,26 @@ Compute the hashes with:
 ```bash
 node -e "const c=require('crypto'),f=require('fs'); for (const p of process.argv.slice(1)) console.log(p + ': ' + c.createHash('sha256').update(f.readFileSync(p, 'utf-8')).digest('hex'))" libs/database/drizzle/*.sql
 ```
+
+On production, prefer plain `psql -c` statements over heredoc-wrapped shell
+pipelines so each step is visible and easy to verify:
+
+```bash
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 \
+  -c "begin;" \
+  -c "delete from drizzle.__drizzle_migrations;" \
+  -c "insert into drizzle.__drizzle_migrations (hash, created_at) values ('<hash_from_0000_init>', <when_from_meta_journal_0000>), ('<hash_from_0001_baseline_runtime>', <when_from_meta_journal_0001>);" \
+  -c "commit;" \
+  -c "select id, hash, created_at from drizzle.__drizzle_migrations order by created_at;"
+```
+
+Before running the migrator, confirm both of these:
+
+- `select count(*) from drizzle.__drizzle_migrations;` returns `2`
+- the stored hashes match the exact files being deployed
+
+After the migrator runs, verify status with `pnpm db:status` or the equivalent
+runtime entrypoint. Expect `2/2 applied`, not a replay of the baseline SQL.
 
 ## Docker and rollback
 


### PR DESCRIPTION
## Summary
- clarify the production-safe Drizzle baseline switch order in the migration README
- document the verified gate before rerunning the migrator on prod
- note in the Fly MPG recipe that restore row counts are sanity checks, not fixed expected values

## Why
This follows the live production ledger transition. The existing docs explained baselining conceptually, but they did not encode the exact execution pattern we ended up needing in prod:
- take a fresh backup first
- use direct  statements for the ledger swap
- verify the live table contains exactly 2 baseline rows with the expected hashes
- only then rerun the migrator

## Testing
- docs only
- based on the completed production baseline transition and follow-up verification
