### PR TITLE
fix(mcp-server): prevent cross-tenant identity leak in moltnet_whoami (#889)

### DIFF
--- a/apps/mcp-server/__tests__/profile-utils.test.ts
+++ b/apps/mcp-server/__tests__/profile-utils.test.ts
@@ -3,13 +3,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { findProfileEntries, findSystemEntry } from '../src/profile-utils.js';
 
 vi.mock('@moltnet/api-client', () => ({
+  listDiaries: vi.fn(),
   searchDiary: vi.fn(),
 }));
 
 import type { Client } from '@moltnet/api-client';
-import { searchDiary } from '@moltnet/api-client';
+import { listDiaries, searchDiary } from '@moltnet/api-client';
 
 import { sdkErr, sdkOk } from './helpers.js';
+
+const DIARY_ID = '550e8400-e29b-41d4-a716-446655440001';
 
 describe('profile-utils', () => {
   const client = {} as Client;
@@ -17,6 +20,9 @@ describe('profile-utils', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(listDiaries).mockResolvedValue(
+      sdkOk({ items: [{ id: DIARY_ID }] }) as never,
+    );
   });
 
   describe('findSystemEntry', () => {
@@ -37,9 +43,13 @@ describe('profile-utils', () => {
 
       const result = await findSystemEntry(client, token, 'identity');
 
+      expect(listDiaries).toHaveBeenCalledWith(
+        expect.objectContaining({ client, auth: expect.any(Function) }),
+      );
       expect(searchDiary).toHaveBeenCalledWith(
         expect.objectContaining({
           body: {
+            diaryId: DIARY_ID,
             entryTypes: ['identity'],
             tags: ['system'],
             limit: 1,
@@ -71,12 +81,62 @@ describe('profile-utils', () => {
       expect(result).toBeNull();
     });
 
-    it('handles entries with null tags', async () => {
-      vi.mocked(searchDiary).mockResolvedValue(sdkOk({ results: [] }) as never);
+    it('returns null when listDiaries returns empty', async () => {
+      vi.mocked(listDiaries).mockResolvedValue(sdkOk({ items: [] }) as never);
 
       const result = await findSystemEntry(client, token, 'identity');
 
+      expect(searchDiary).not.toHaveBeenCalled();
       expect(result).toBeNull();
+    });
+
+    it('returns null when listDiaries errors', async () => {
+      vi.mocked(listDiaries).mockResolvedValue(
+        sdkErr({ error: 'fail', message: 'fail', statusCode: 500 }) as never,
+      );
+
+      const result = await findSystemEntry(client, token, 'identity');
+
+      expect(searchDiary).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
+    it('searches across multiple own diaries and returns first match', async () => {
+      const DIARY_ID_2 = '550e8400-e29b-41d4-a716-446655440002';
+      vi.mocked(listDiaries).mockResolvedValue(
+        sdkOk({ items: [{ id: DIARY_ID }, { id: DIARY_ID_2 }] }) as never,
+      );
+      vi.mocked(searchDiary)
+        .mockResolvedValueOnce(sdkOk({ results: [] }) as never)
+        .mockResolvedValueOnce(
+          sdkOk({
+            results: [
+              {
+                id: 'entry-in-second-diary',
+                content: 'Found in second diary',
+                tags: ['system', 'identity'],
+                entryType: 'identity',
+              },
+            ],
+          }) as never,
+        );
+
+      const result = await findSystemEntry(client, token, 'identity');
+
+      expect(searchDiary).toHaveBeenCalledTimes(2);
+      expect(searchDiary).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          body: expect.objectContaining({ diaryId: DIARY_ID }),
+        }),
+      );
+      expect(searchDiary).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          body: expect.objectContaining({ diaryId: DIARY_ID_2 }),
+        }),
+      );
+      expect(result?.id).toBe('entry-in-second-diary');
     });
   });
 
@@ -155,21 +215,44 @@ describe('profile-utils', () => {
       expect(result.soul).toBeNull();
     });
 
-    it('makes only one search API call for both entries', async () => {
+    it('returns nulls when listDiaries returns empty', async () => {
+      vi.mocked(listDiaries).mockResolvedValue(sdkOk({ items: [] }) as never);
+
+      const result = await findProfileEntries(client, token);
+
+      expect(searchDiary).not.toHaveBeenCalled();
+      expect(result.whoami).toBeNull();
+      expect(result.soul).toBeNull();
+    });
+
+    it('scopes each search call to the own diary id', async () => {
       vi.mocked(searchDiary).mockResolvedValue(sdkOk({ results: [] }) as never);
 
       await findProfileEntries(client, token);
 
-      expect(searchDiary).toHaveBeenCalledTimes(1);
       expect(searchDiary).toHaveBeenCalledWith(
         expect.objectContaining({
-          body: {
+          body: expect.objectContaining({
+            diaryId: DIARY_ID,
             entryTypes: ['identity', 'soul'],
             tags: ['system'],
             limit: 10,
-          },
+          }),
         }),
       );
+    });
+
+    it('never searches without a diary id (prevents cross-tenant leak)', async () => {
+      vi.mocked(searchDiary).mockResolvedValue(sdkOk({ results: [] }) as never);
+
+      await findProfileEntries(client, token);
+
+      const calls = vi.mocked(searchDiary).mock.calls;
+      for (const [opts] of calls) {
+        expect(
+          (opts as { body?: { diaryId?: string } }).body?.diaryId,
+        ).toBeDefined();
+      }
     });
   });
 });

--- a/apps/mcp-server/__tests__/resources.test.ts
+++ b/apps/mcp-server/__tests__/resources.test.ts
@@ -22,6 +22,7 @@ import {
 vi.mock('@moltnet/api-client', () => ({
   getWhoami: vi.fn(),
   getDiary: vi.fn(),
+  listDiaries: vi.fn(),
   searchDiary: vi.fn(),
   getDiaryEntryById: vi.fn(),
   getAgentProfile: vi.fn(),
@@ -32,6 +33,7 @@ import {
   getDiary,
   getDiaryEntryById,
   getWhoami,
+  listDiaries,
   searchDiary,
 } from '@moltnet/api-client';
 
@@ -43,6 +45,9 @@ describe('MCP Resources', () => {
     vi.clearAllMocks();
     deps = createMockDeps();
     context = createMockContext();
+    vi.mocked(listDiaries).mockResolvedValue(
+      sdkOk({ items: [{ id: DIARY_ID }] }) as never,
+    );
   });
 
   describe('moltnet://identity', () => {
@@ -274,7 +279,12 @@ describe('MCP Resources', () => {
 
       expect(searchDiary).toHaveBeenCalledWith(
         expect.objectContaining({
-          body: { entryTypes: ['identity'], tags: ['system'], limit: 1 },
+          body: {
+            diaryId: DIARY_ID,
+            entryTypes: ['identity'],
+            tags: ['system'],
+            limit: 1,
+          },
         }),
       );
     });
@@ -331,7 +341,12 @@ describe('MCP Resources', () => {
 
       expect(searchDiary).toHaveBeenCalledWith(
         expect.objectContaining({
-          body: { entryTypes: ['soul'], tags: ['system'], limit: 1 },
+          body: {
+            diaryId: DIARY_ID,
+            entryTypes: ['soul'],
+            tags: ['system'],
+            limit: 1,
+          },
         }),
       );
     });

--- a/apps/mcp-server/e2e/whoami-cross-tenant.e2e.test.ts
+++ b/apps/mcp-server/e2e/whoami-cross-tenant.e2e.test.ts
@@ -1,0 +1,226 @@
+/**
+ * E2E: moltnet_whoami cross-tenant isolation (regression for issue #889)
+ *
+ * Two independent agents are bootstrapped. Agent B creates identity/soul entries
+ * with moltnet visibility. Agent A's whoami must return its own profile (null if
+ * no entries) — never Agent B's entries.
+ */
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { createMcpTestHarness, type McpTestHarness } from './setup.js';
+
+describe('moltnet_whoami cross-tenant isolation (issue #889)', () => {
+  let harness: McpTestHarness;
+  let clientA: Client;
+  let setupError: Error | undefined;
+
+  // Agent B's identity content — must never appear in Agent A's whoami
+  const AGENT_B_WHOAMI_CONTENT =
+    'I am Agent B, a completely separate agent. Fingerprint: AGENT-B-MARKER.';
+  const AGENT_B_SOUL_CONTENT =
+    'Agent B soul: I value isolation and keeping data to myself.';
+
+  beforeAll(async () => {
+    harness = await createMcpTestHarness();
+
+    try {
+      // Connect Agent A (the harness default agent — has no identity entries yet)
+      const transportA = new StreamableHTTPClientTransport(
+        new URL(`${harness.mcpBaseUrl}/mcp`),
+        {
+          requestInit: {
+            headers: {
+              'X-Client-Id': harness.agent.clientId,
+              'X-Client-Secret': harness.agent.clientSecret,
+            },
+          },
+        },
+      );
+      clientA = new Client({
+        name: 'e2e-cross-tenant-client-a',
+        version: '1.0.0',
+      });
+      await clientA.connect(transportA);
+
+      // Bootstrap Agent B with moltnet-visible identity entries via direct REST API
+      const agentBHarness = await harness.createAgent(
+        'e2e-cross-tenant-agent-b',
+      );
+      const agentB = agentBHarness.agent;
+
+      // Create Agent B's identity entry with moltnet visibility
+      // (moltnet visibility is the default — readable by any authenticated agent)
+      const whoamiResp = await fetch(
+        `${harness.restApiUrl}/diaries/${agentBHarness.privateDiaryId}/entries`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${agentB.accessToken}`,
+          },
+          body: JSON.stringify({
+            content: AGENT_B_WHOAMI_CONTENT,
+            title: 'I am Agent B',
+            tags: ['system', 'identity'],
+            entry_type: 'identity',
+            visibility: 'moltnet',
+          }),
+        },
+      );
+      if (!whoamiResp.ok) {
+        throw new Error(
+          `Agent B identity create failed: ${whoamiResp.status} ${await whoamiResp.text()}`,
+        );
+      }
+
+      // Create Agent B's soul entry with moltnet visibility
+      const soulResp = await fetch(
+        `${harness.restApiUrl}/diaries/${agentBHarness.privateDiaryId}/entries`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${agentB.accessToken}`,
+          },
+          body: JSON.stringify({
+            content: AGENT_B_SOUL_CONTENT,
+            title: 'Agent B soul',
+            tags: ['system', 'soul'],
+            entry_type: 'soul',
+            visibility: 'moltnet',
+          }),
+        },
+      );
+      if (!soulResp.ok) {
+        throw new Error(
+          `Agent B soul create failed: ${soulResp.status} ${await soulResp.text()}`,
+        );
+      }
+    } catch (err) {
+      setupError = err instanceof Error ? err : new Error(String(err));
+    }
+  });
+
+  afterAll(async () => {
+    await clientA?.close();
+    await harness?.teardown();
+  });
+
+  function requireSetup(): void {
+    if (setupError) {
+      throw new Error(
+        `E2E setup failed — cannot continue: ${setupError.message}`,
+      );
+    }
+  }
+
+  it('Agent A whoami returns null profile when Agent A has no entries (not Agent B entries)', async () => {
+    requireSetup();
+
+    const result = await clientA.callTool({
+      name: 'moltnet_whoami',
+      arguments: {},
+    });
+
+    const content = result.content as Array<{ type: string; text: string }>;
+    expect(result.isError, `whoami error: ${content[0].text}`).toBeUndefined();
+
+    const parsed = result.structuredContent as {
+      authenticated: boolean;
+      identity: { identityId: string; fingerprint: string };
+      profile: {
+        whoami: { id: string; content: string } | null;
+        soul: { id: string; content: string } | null;
+      };
+    };
+
+    expect(parsed.authenticated).toBe(true);
+    // Agent A's auth identity must be Agent A's own identity
+    expect(parsed.identity.fingerprint).toBe(harness.agent.keyPair.fingerprint);
+
+    // Profile must be null — Agent A has no entries, and Agent B's entries
+    // must not bleed through even though they have moltnet visibility
+    expect(
+      parsed.profile.whoami,
+      'Agent B whoami leaked into Agent A profile (issue #889)',
+    ).toBeNull();
+    expect(
+      parsed.profile.soul,
+      'Agent B soul leaked into Agent A profile (issue #889)',
+    ).toBeNull();
+  });
+
+  it('Agent A whoami returns own entries after Agent A creates them (not Agent B entries)', async () => {
+    requireSetup();
+
+    const AGENT_A_CONTENT = 'I am Agent A. My unique content: AGENT-A-MARKER.';
+
+    // Create Agent A's identity entry
+    const createResult = await clientA.callTool({
+      name: 'entries_create',
+      arguments: {
+        diary_id: harness.privateDiaryId,
+        content: AGENT_A_CONTENT,
+        title: 'I am Agent A',
+        tags: ['system', 'identity'],
+        entry_type: 'identity',
+      },
+    });
+    const createContent = createResult.content as Array<{
+      type: string;
+      text: string;
+    }>;
+    expect(
+      createResult.isError,
+      `Agent A identity create error: ${createContent[0].text}`,
+    ).toBeUndefined();
+
+    // Now whoami must return Agent A's own content
+    const result = await clientA.callTool({
+      name: 'moltnet_whoami',
+      arguments: {},
+    });
+
+    const parsed = result.structuredContent as {
+      authenticated: boolean;
+      profile: {
+        whoami: { id: string; content: string } | null;
+        soul: { id: string; content: string } | null;
+      };
+    };
+
+    expect(parsed.profile.whoami).not.toBeNull();
+    expect(
+      parsed.profile.whoami?.content,
+      'Agent A whoami should contain Agent A content',
+    ).toContain('AGENT-A-MARKER');
+    expect(
+      parsed.profile.whoami?.content,
+      'Agent A whoami must not contain Agent B content',
+    ).not.toContain('AGENT-B-MARKER');
+  });
+
+  it('self resource moltnet://self/whoami returns exists:false for Agent A before bootstrap', async () => {
+    // This verifies the resource handler (findSystemEntry) also scopes correctly.
+    // Note: this test order depends on the first test running before Agent A creates entries.
+    // The full bootstrap test above creates entries, so this test is order-sensitive.
+    // We verify the resource after the bootstrap test has run — it should now return exists:true
+    // with Agent A's content, not Agent B's.
+    requireSetup();
+
+    const result = await clientA.readResource({
+      uri: 'moltnet://self/whoami',
+    });
+    const data = JSON.parse((result.contents[0] as { text: string }).text);
+
+    // After the previous test created Agent A's identity entry, this must return it
+    if (data.exists) {
+      expect(data.content).toContain('AGENT-A-MARKER');
+      expect(data.content).not.toContain('AGENT-B-MARKER');
+    }
+    // If exists is false, the scoping worked (no bleed-through from Agent B)
+  });
+});

--- a/apps/mcp-server/src/profile-utils.ts
+++ b/apps/mcp-server/src/profile-utils.ts
@@ -4,18 +4,27 @@
  * Helpers for finding system diary entries (identity/soul)
  * that store an agent's self-concept.
  *
- * Uses the search endpoint with entryTypes filter — searches across
- * all owned diaries (no diary_id scoping).
+ * Searches are scoped to the caller's own diaries to prevent
+ * cross-tenant data leaks from moltnet-visibility entries.
  */
 
 import type { Client } from '@moltnet/api-client';
-import { searchDiary } from '@moltnet/api-client';
+import { listDiaries, searchDiary } from '@moltnet/api-client';
 
 export interface SystemEntry {
   id: string;
   title: string | null;
   content: string;
   tags: string[] | null;
+}
+
+async function getOwnDiaryIds(
+  client: Client,
+  token: string,
+): Promise<string[]> {
+  const { data, error } = await listDiaries({ client, auth: () => token });
+  if (error || !data?.items?.length) return [];
+  return data.items.map((d) => d.id);
 }
 
 /**
@@ -27,25 +36,33 @@ export async function findSystemEntry(
   token: string,
   entryType: 'identity' | 'soul',
 ): Promise<SystemEntry | null> {
-  const { data, error } = await searchDiary({
-    client,
-    auth: () => token,
-    body: {
-      entryTypes: [entryType],
-      tags: ['system'],
-      limit: 1,
-    },
-  });
+  const diaryIds = await getOwnDiaryIds(client, token);
+  if (!diaryIds.length) return null;
 
-  if (error || !data?.results?.length) return null;
+  for (const diaryId of diaryIds) {
+    const { data, error } = await searchDiary({
+      client,
+      auth: () => token,
+      body: {
+        diaryId,
+        entryTypes: [entryType],
+        tags: ['system'],
+        limit: 1,
+      },
+    });
 
-  const entry = data.results[0] as SystemEntryCandidate;
-  return {
-    id: entry.id,
-    title: entry.title ?? null,
-    content: entry.content,
-    tags: entry.tags ?? null,
-  };
+    if (error || !data?.results?.length) continue;
+
+    const entry = data.results[0] as SystemEntryCandidate;
+    return {
+      id: entry.id,
+      title: entry.title ?? null,
+      content: entry.content,
+      tags: entry.tags ?? null,
+    };
+  }
+
+  return null;
 }
 
 /**
@@ -55,39 +72,47 @@ export async function findProfileEntries(
   client: Client,
   token: string,
 ): Promise<{ whoami: SystemEntry | null; soul: SystemEntry | null }> {
-  const { data, error } = await searchDiary({
-    client,
-    auth: () => token,
-    body: {
-      entryTypes: ['identity', 'soul'],
-      tags: ['system'],
-      limit: 10,
-    },
-  });
-
-  if (error || !data?.results) return { whoami: null, soul: null };
+  const diaryIds = await getOwnDiaryIds(client, token);
+  if (!diaryIds.length) return { whoami: null, soul: null };
 
   let whoami: SystemEntry | null = null;
   let soul: SystemEntry | null = null;
 
-  for (const raw of data.results as SystemEntryCandidate[]) {
-    if (raw.entryType === 'identity' && !whoami) {
-      whoami = {
-        id: raw.id,
-        title: raw.title ?? null,
-        content: raw.content,
-        tags: raw.tags ?? null,
-      };
-    }
-    if (raw.entryType === 'soul' && !soul) {
-      soul = {
-        id: raw.id,
-        title: raw.title ?? null,
-        content: raw.content,
-        tags: raw.tags ?? null,
-      };
-    }
+  for (const diaryId of diaryIds) {
     if (whoami && soul) break;
+
+    const { data, error } = await searchDiary({
+      client,
+      auth: () => token,
+      body: {
+        diaryId,
+        entryTypes: ['identity', 'soul'],
+        tags: ['system'],
+        limit: 10,
+      },
+    });
+
+    if (error || !data?.results) continue;
+
+    for (const raw of data.results as SystemEntryCandidate[]) {
+      if (raw.entryType === 'identity' && !whoami) {
+        whoami = {
+          id: raw.id,
+          title: raw.title ?? null,
+          content: raw.content,
+          tags: raw.tags ?? null,
+        };
+      }
+      if (raw.entryType === 'soul' && !soul) {
+        soul = {
+          id: raw.id,
+          title: raw.title ?? null,
+          content: raw.content,
+          tags: raw.tags ?? null,
+        };
+      }
+      if (whoami && soul) break;
+    }
   }
 
   return { whoami, soul };


### PR DESCRIPTION
## Summary

- `findSystemEntry` and `findProfileEntries` now call `listDiaries` first and scope every `searchDiary` call with the caller's own `diaryId`, preventing other agents' `moltnet`-visibility identity entries from surfacing in `moltnet_whoami`
- Unit tests updated to assert `diaryId` is always passed to `searchDiary` (new invariant: no unsoped search ever happens)
- New e2e regression test (`whoami-cross-tenant.e2e.test.ts`) bootstraps two agents, creates moltnet-visible identity entries for agent B, and verifies agent A's `moltnet_whoami` never returns agent B's data

Fixes #889.

## Root cause

`searchDiary` without `diaryId` searches all entries readable by the caller, including `moltnet`-visibility entries from other agents. Relevance ranking surfaced another agent's `identity` entry first, returning the wrong `profile.whoami`. Auth identity was unaffected.

## Fix

Pre-flight `listDiaries` call (already auth-scoped to the caller) → pass each diary's ID into `searchDiary`. The `diaryId` filter is server-enforced and was already supported by the API.

## Test plan

- [ ] Unit tests pass: `pnpm --filter @moltnet/mcp-server exec vitest run __tests__/profile-utils.test.ts __tests__/resources.test.ts __tests__/prompts.test.ts __tests__/identity-tools.test.ts`
- [ ] E2E regression: `pnpm --filter @moltnet/mcp-server run test:e2e` (requires e2e stack running) — `whoami-cross-tenant.e2e.test.ts` must pass
- [ ] `moltnet_whoami` called as `legreffier` returns `legreffier`'s own profile, not `moltnet-bot`'s