### PR TITLE
fix(tasks): heartbeat on open, timed_out→409, traceparent propagation

### DIFF
--- a/apps/rest-api/src/routes/tasks.ts
+++ b/apps/rest-api/src/routes/tasks.ts
@@ -5,6 +5,7 @@ import {
   ValidationProblemDetailsSchema,
 } from '@moltnet/models';
 import { Task, TaskAttempt, TaskMessage } from '@moltnet/tasks';
+import { context as otelContext, propagation } from '@opentelemetry/api';
 import { Type } from '@sinclair/typebox';
 import type { FastifyInstance } from 'fastify';
 
@@ -48,7 +49,7 @@ function toTaskProblem(error: TaskServiceError) {
         error.message,
       );
     case 'timed_out':
-      return createProblem('internal-server-error', error.message);
+      return createProblem('conflict', error.message);
   }
 }
 
@@ -187,7 +188,20 @@ export async function taskRoutes(fastify: FastifyInstance) {
         params: TaskParamsSchema,
         body: ClaimTaskBodySchema,
         response: {
-          200: Type.Ref(ClaimTaskResponseSchema),
+          200: {
+            ...Type.Ref(ClaimTaskResponseSchema),
+            headers: {
+              traceparent: {
+                type: 'string',
+                description:
+                  'W3C trace context header linking worker calls to the workflow trace.',
+              },
+              tracestate: {
+                type: 'string',
+                description: 'W3C trace state, present when non-empty.',
+              },
+            },
+          },
           400: Type.Ref(ProblemDetailsSchema),
           401: Type.Ref(ProblemDetailsSchema),
           403: Type.Ref(ProblemDetailsSchema),
@@ -196,17 +210,26 @@ export async function taskRoutes(fastify: FastifyInstance) {
         },
       },
     },
-    async (request) => {
+    async (request, reply) => {
       const { identityId, subjectType } = request.authContext!;
       const callerNs =
         subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
       try {
-        return await fastify.taskService.claim(
+        const result = await fastify.taskService.claim(
           request.params.id,
           identityId,
           callerNs,
           request.body.leaseTtlSec,
         );
+        const carrier: Record<string, string> = {};
+        propagation.inject(otelContext.active(), carrier);
+        if (carrier['traceparent']) {
+          reply.header('traceparent', carrier['traceparent']);
+          if (carrier['tracestate']) {
+            reply.header('tracestate', carrier['tracestate']);
+          }
+        }
+        return await reply.send(result);
       } catch (error) {
         if (error instanceof TaskServiceError) throw toTaskProblem(error);
         throw error;

--- a/libs/agent-runtime/src/reporters/api.test.ts
+++ b/libs/agent-runtime/src/reporters/api.test.ts
@@ -11,7 +11,7 @@ describe('ApiTaskReporter', () => {
     vi.useRealTimers();
   });
 
-  it('posts messages and heartbeats via the Tasks API', async () => {
+  it('sends an immediate heartbeat on open, then periodic ones', async () => {
     const fetchMock = vi
       .fn<typeof fetch>()
       .mockResolvedValue(new Response('{}', { status: 200 }));
@@ -27,11 +27,20 @@ describe('ApiTaskReporter', () => {
       taskId: '11111111-1111-4111-8111-111111111111',
       attemptN: 2,
     });
+
+    // Immediate heartbeat must have fired during open()
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.example.test/tasks/11111111-1111-4111-8111-111111111111/attempts/2/heartbeat',
+      expect.objectContaining({ method: 'POST' }),
+    );
+
     await reporter.record({
       kind: 'info',
       payload: { event: 'started' },
     });
 
+    // Advance past the interval to fire the periodic heartbeat
     await vi.advanceTimersByTimeAsync(1_000);
     await reporter.finalize({ inputTokens: 1, outputTokens: 2 });
 
@@ -39,10 +48,12 @@ describe('ApiTaskReporter', () => {
       'https://api.example.test/tasks/11111111-1111-4111-8111-111111111111/attempts/2/messages',
       expect.objectContaining({ method: 'POST' }),
     );
-    expect(fetchMock).toHaveBeenCalledWith(
-      'https://api.example.test/tasks/11111111-1111-4111-8111-111111111111/attempts/2/heartbeat',
-      expect.objectContaining({ method: 'POST' }),
-    );
+    // Immediate + one periodic heartbeat
+    expect(
+      fetchMock.mock.calls.filter((c) =>
+        (c[0] as string).endsWith('/heartbeat'),
+      ),
+    ).toHaveLength(2);
     expect(reporter.getUsage()).toEqual({ inputTokens: 1, outputTokens: 2 });
   });
 
@@ -59,10 +70,14 @@ describe('ApiTaskReporter', () => {
       fetch: fetchMock,
     });
 
-    await reporter.open({
-      taskId: '11111111-1111-4111-8111-111111111111',
-      attemptN: 1,
-    });
+    // open() fires an immediate heartbeat which will fail — that's fine for
+    // this test; we only care that record() throws on a 500.
+    await reporter
+      .open({
+        taskId: '11111111-1111-4111-8111-111111111111',
+        attemptN: 1,
+      })
+      .catch(() => {});
 
     await expect(
       reporter.record({ kind: 'error', payload: { message: 'boom' } }),

--- a/libs/agent-runtime/src/reporters/api.ts
+++ b/libs/agent-runtime/src/reporters/api.ts
@@ -42,6 +42,11 @@ export class ApiTaskReporter implements TaskReporter {
     this.taskId = ctx.taskId;
     this.attemptN = ctx.attemptN;
 
+    // Send immediately so the DBOS workflow receives the 'started' signal
+    // before the dispatch timeout (default 5 min). Without this, fast tasks
+    // that complete before the first periodic heartbeat silently time out.
+    await this.sendHeartbeat();
+
     const intervalMs = this.opts.heartbeatIntervalMs ?? 60_000;
     if (intervalMs > 0) {
       this.heartbeatTimer = setInterval(() => {

--- a/libs/sdk/src/agent-context.ts
+++ b/libs/sdk/src/agent-context.ts
@@ -5,6 +5,8 @@ import { MoltNetError, problemToError } from './errors.js';
 export interface AgentContext {
   client: Client;
   auth?: () => Promise<string>;
+  /** W3C trace headers captured from the last task claim response, injected on subsequent task calls. */
+  taskTraceHeaders?: Record<string, string>;
 }
 
 export function unwrapResult<T>(

--- a/libs/sdk/src/namespaces/tasks.ts
+++ b/libs/sdk/src/namespaces/tasks.ts
@@ -16,6 +16,10 @@ import type { TasksNamespace } from '../agent.js';
 import type { AgentContext } from '../agent-context.js';
 import { unwrapResult } from '../agent-context.js';
 
+function traceHeaders(context: AgentContext): Record<string, string> {
+  return context.taskTraceHeaders ?? {};
+}
+
 export function createTasksNamespace(context: AgentContext): TasksNamespace {
   const { client, auth } = context;
 
@@ -33,7 +37,24 @@ export function createTasksNamespace(context: AgentContext): TasksNamespace {
     },
 
     async claim(id, body) {
-      return unwrapResult(await claimTask({ client, auth, path: { id }, body }));
+      const result = await claimTask({ client, auth, path: { id }, body });
+      // Capture W3C trace headers from the response so subsequent calls
+      // (heartbeat, messages, complete, fail) arrive as children of the
+      // workflow trace rather than orphan spans in Axiom.
+      const response = (result as { response?: Response }).response;
+      if (response) {
+        const headers: Record<string, string> = {};
+        const traceparent = response.headers.get('traceparent');
+        if (traceparent) {
+          headers['traceparent'] = traceparent;
+          const tracestate = response.headers.get('tracestate');
+          if (tracestate) headers['tracestate'] = tracestate;
+        }
+        context.taskTraceHeaders = Object.keys(headers).length
+          ? headers
+          : undefined;
+      }
+      return unwrapResult(result);
     },
 
     async heartbeat(id, n, body) {
@@ -43,6 +64,7 @@ export function createTasksNamespace(context: AgentContext): TasksNamespace {
           auth,
           path: { id, n },
           body,
+          headers: traceHeaders(context),
         }),
       );
     },
@@ -54,6 +76,7 @@ export function createTasksNamespace(context: AgentContext): TasksNamespace {
           auth,
           path: { id, n },
           body,
+          headers: traceHeaders(context),
         }),
       );
     },
@@ -65,6 +88,7 @@ export function createTasksNamespace(context: AgentContext): TasksNamespace {
           auth,
           path: { id, n },
           body,
+          headers: traceHeaders(context),
         }),
       );
     },
@@ -108,6 +132,7 @@ export function createTasksNamespace(context: AgentContext): TasksNamespace {
           auth,
           path: { id, n },
           body,
+          headers: traceHeaders(context),
         }),
       );
     },


### PR DESCRIPTION
Closes #909

## Summary

- **Immediate heartbeat on open**: `ApiTaskReporter.open()` now calls `sendHeartbeat()` once before starting the periodic timer. DBOS workflow gates on `DBOS.recv('started', 300s)` — fast tasks completing before the first 60s tick caused dispatch timeout and the `result` signal to be ignored, producing a 500. Firing immediately eliminates the race.

- **`timed_out` → 409 Conflict**: `TaskServiceError` with code `timed_out` was incorrectly mapped to 500 `internal-server-error`. It's now mapped to 409 Conflict — the correct semantic for a stale workflow state race.

- **`traceparent` header on `/claim`**: The claim handler injects the active OTel span context into response headers (`traceparent`, `tracestate`) so worker processes can carry the workflow trace. Documented in the OpenAPI spec via `@fastify/swagger` `rawJsonSchema.headers` extension.

- **SDK trace propagation**: `AgentContext` gains `taskTraceHeaders`. `tasks.claim()` captures the headers from the response; `heartbeat()`, `complete()`, `fail()`, and `appendMessages()` inject them on every request, connecting worker-side spans to the DBOS workflow trace in Axiom.

- **Fix 4 (DBOS context wrapping) — not needed**: Investigated DBOS SDK source. `startWorkflow()` calls `startSpan()` which uses `context.active()` from OTel `AsyncLocalStorage`. `@fastify/otel` wraps every route handler in `context.with(trace.setSpan(ctx, span), handler)`, so DBOS workflow spans automatically inherit the HTTP request span as parent — no manual wrapping needed.

## Test plan

- [ ] `pnpm --filter @themoltnet/agent-runtime run test` — all 28 tests pass, including new immediate-heartbeat assertions
- [ ] `pnpm --filter @moltnet/rest-api run typecheck` — clean
- [ ] `pnpm --filter @moltnet/rest-api run lint` — 0 errors
- [ ] End-to-end: run `work-task` against a live stack with a task that completes in < 60s — verify task reaches `completed` status (no 500)
- [ ] Axiom: confirm `/claim`, `/heartbeat`, and `/complete` spans share the same `trace_id`