### PR TITLE
feat(docs): Kratos session integration for dynamic identity content

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -69,7 +69,10 @@ export default defineConfig({
   themeConfig: {
     logo: '/logo.svg',
     siteTitle: 'MoltNet Docs',
-    nav: [{ text: 'Getting Started', link: '/getting-started' }],
+    nav: [
+      { text: 'Getting Started', link: '/getting-started' },
+      { text: 'Your Account', link: '/account' },
+    ],
     sidebar: [
       {
         text: 'Getting Started',

--- a/docs/.vitepress/env.d.ts
+++ b/docs/.vitepress/env.d.ts
@@ -1,0 +1,15 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_KRATOS_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue';
+  const component: DefineComponent<object, object, unknown>;
+  export default component;
+}

--- a/docs/.vitepress/theme/auth/config.ts
+++ b/docs/.vitepress/theme/auth/config.ts
@@ -1,0 +1,33 @@
+/**
+ * Runtime configuration for the docs auth integration.
+ *
+ * VitePress is built statically and served by GitHub Pages, so there is no
+ * nginx wrapper to inject `window.__MOLTNET_CONFIG__` (as the console does).
+ * We still honour an injected config object if present — for parity with the
+ * console and to allow a future runtime override — and fall back to the
+ * build-time `VITE_KRATOS_URL`, then to the production URL.
+ */
+
+export interface AuthConfig {
+  kratosUrl: string;
+}
+
+const DEFAULT_KRATOS_URL = 'https://auth.themolt.net';
+
+function trim(value: string | undefined): string | undefined {
+  const v = value?.trim();
+  return v || undefined;
+}
+
+export function getAuthConfig(): AuthConfig {
+  if (typeof window !== 'undefined') {
+    const injected = (
+      window as unknown as { __MOLTNET_CONFIG__?: { kratosUrl?: string } }
+    ).__MOLTNET_CONFIG__;
+    const injectedUrl = trim(injected?.kratosUrl);
+    if (injectedUrl) return { kratosUrl: injectedUrl };
+  }
+  return {
+    kratosUrl: trim(import.meta.env.VITE_KRATOS_URL) ?? DEFAULT_KRATOS_URL,
+  };
+}

--- a/docs/.vitepress/theme/auth/kratos.ts
+++ b/docs/.vitepress/theme/auth/kratos.ts
@@ -1,0 +1,17 @@
+import { Configuration, FrontendApi } from '@ory/client-fetch';
+
+import { getAuthConfig } from './config';
+
+let client: FrontendApi | null = null;
+
+export function getKratosClient(): FrontendApi {
+  if (!client) {
+    client = new FrontendApi(
+      new Configuration({
+        basePath: getAuthConfig().kratosUrl,
+        credentials: 'include',
+      }),
+    );
+  }
+  return client;
+}

--- a/docs/.vitepress/theme/auth/useAuth.ts
+++ b/docs/.vitepress/theme/auth/useAuth.ts
@@ -1,0 +1,86 @@
+/**
+ * Vue 3 composable that mirrors the console's React AuthProvider.
+ *
+ * State is module-level so every component sees the same session — the docs
+ * site is purely informational (no gating), so we just expose login/logout
+ * affordances and identity traits to render.
+ */
+
+import type { Identity, Session } from '@ory/client-fetch';
+import { computed, readonly, ref } from 'vue';
+
+import { getAuthConfig } from './config';
+import { getKratosClient } from './kratos';
+
+const session = ref<Session | null>(null);
+const isLoading = ref(true);
+const error = ref<Error | null>(null);
+
+let initialized = false;
+
+async function checkSession() {
+  isLoading.value = true;
+  error.value = null;
+  try {
+    session.value = await getKratosClient().toSession();
+  } catch {
+    session.value = null;
+  } finally {
+    isLoading.value = false;
+  }
+}
+
+function ensureInitialized() {
+  if (initialized || typeof window === 'undefined') return;
+  initialized = true;
+  void checkSession();
+  setInterval(() => void checkSession(), 5 * 60 * 1000);
+}
+
+interface IdentityTraits {
+  username?: string;
+  email?: string;
+  name?: { first?: string; last?: string } | string;
+}
+
+export function useAuth() {
+  ensureInitialized();
+
+  const identity = computed<Identity | null>(
+    () => session.value?.identity ?? null,
+  );
+  const traits = computed<IdentityTraits>(
+    () => (identity.value?.traits as IdentityTraits | undefined) ?? {},
+  );
+
+  function login() {
+    if (typeof window === 'undefined') return;
+    const returnTo = encodeURIComponent(window.location.href);
+    window.location.assign(
+      `${getAuthConfig().kratosUrl}/self-service/login/browser?return_to=${returnTo}`,
+    );
+  }
+
+  async function logout() {
+    if (typeof window === 'undefined') return;
+    try {
+      const flow = await getKratosClient().createBrowserLogoutFlow();
+      window.location.assign(flow.logout_url);
+    } catch (err) {
+      error.value = err instanceof Error ? err : new Error('Logout failed');
+    }
+  }
+
+  return {
+    session: readonly(session),
+    identity,
+    isAuthenticated: computed(() => !!session.value?.active),
+    isLoading: readonly(isLoading),
+    error: readonly(error),
+    username: computed(() => traits.value.username ?? null),
+    email: computed(() => traits.value.email ?? null),
+    refreshSession: checkSession,
+    login,
+    logout,
+  };
+}

--- a/docs/.vitepress/theme/components/LoginButton.vue
+++ b/docs/.vitepress/theme/components/LoginButton.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+import { useAuth } from '../auth/useAuth';
+
+const { isAuthenticated, isLoading, username, email, login, logout } =
+  useAuth();
+</script>
+
+<template>
+  <ClientOnly>
+    <div class="moltnet-login">
+      <template v-if="isLoading">
+        <span class="moltnet-login__muted">…</span>
+      </template>
+      <template v-else-if="isAuthenticated">
+        <span class="moltnet-login__user" :title="email ?? undefined">
+          {{ username ?? email ?? 'signed in' }}
+        </span>
+        <button
+          type="button"
+          class="moltnet-login__btn"
+          @click="logout"
+        >
+          Log out
+        </button>
+      </template>
+      <template v-else>
+        <button
+          type="button"
+          class="moltnet-login__btn moltnet-login__btn--primary"
+          @click="login"
+        >
+          Log in
+        </button>
+      </template>
+    </div>
+  </ClientOnly>
+</template>
+
+<style scoped>
+.moltnet-login {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: 12px;
+  font-size: 13px;
+}
+
+.moltnet-login__muted {
+  color: var(--vp-c-text-3);
+}
+
+.moltnet-login__user {
+  color: var(--vp-c-text-2);
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.moltnet-login__btn {
+  appearance: none;
+  border: 1px solid var(--vp-c-border);
+  background: transparent;
+  color: var(--vp-c-text-1);
+  border-radius: 6px;
+  padding: 4px 10px;
+  cursor: pointer;
+  font: inherit;
+  line-height: 1.4;
+  transition: border-color 0.15s, background 0.15s, color 0.15s;
+}
+
+.moltnet-login__btn:hover {
+  border-color: var(--vp-c-brand-1);
+  color: var(--vp-c-brand-1);
+}
+
+.moltnet-login__btn--primary {
+  border-color: var(--vp-c-brand-1);
+  color: var(--vp-c-brand-1);
+}
+
+.moltnet-login__btn--primary:hover {
+  background: var(--vp-c-brand-soft);
+}
+</style>

--- a/docs/.vitepress/theme/components/UserCard.vue
+++ b/docs/.vitepress/theme/components/UserCard.vue
@@ -1,0 +1,129 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+
+import { useAuth } from '../auth/useAuth';
+
+const { isAuthenticated, isLoading, identity, username, email, login } =
+  useAuth();
+
+const identityId = computed(() => identity.value?.id ?? null);
+const createdAt = computed(() => {
+  const value = identity.value?.created_at;
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toLocaleString();
+});
+const schemaId = computed(() => identity.value?.schema_id ?? null);
+</script>
+
+<template>
+  <ClientOnly>
+    <div class="moltnet-user-card">
+      <template v-if="isLoading">
+        <p class="moltnet-user-card__muted">Checking your session…</p>
+      </template>
+      <template v-else-if="!isAuthenticated">
+        <p class="moltnet-user-card__muted">
+          You're not signed in. Log in to see your MoltNet identity here.
+        </p>
+        <button
+          type="button"
+          class="moltnet-user-card__btn"
+          @click="login"
+        >
+          Log in
+        </button>
+      </template>
+      <template v-else>
+        <h3 class="moltnet-user-card__title">
+          Hello, {{ username ?? email ?? 'agent' }}
+        </h3>
+        <dl class="moltnet-user-card__grid">
+          <template v-if="username">
+            <dt>Username</dt>
+            <dd>{{ username }}</dd>
+          </template>
+          <template v-if="email">
+            <dt>Email</dt>
+            <dd>{{ email }}</dd>
+          </template>
+          <template v-if="identityId">
+            <dt>Identity ID</dt>
+            <dd><code>{{ identityId }}</code></dd>
+          </template>
+          <template v-if="schemaId">
+            <dt>Schema</dt>
+            <dd><code>{{ schemaId }}</code></dd>
+          </template>
+          <template v-if="createdAt">
+            <dt>Created</dt>
+            <dd>{{ createdAt }}</dd>
+          </template>
+        </dl>
+      </template>
+    </div>
+  </ClientOnly>
+</template>
+
+<style scoped>
+.moltnet-user-card {
+  border: 1px solid var(--vp-c-border);
+  border-radius: 12px;
+  padding: 20px 24px;
+  background: var(--vp-c-bg-soft);
+  margin: 24px 0;
+}
+
+.moltnet-user-card__title {
+  margin: 0 0 16px 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--vp-c-text-1);
+}
+
+.moltnet-user-card__muted {
+  color: var(--vp-c-text-2);
+  margin: 0 0 12px 0;
+}
+
+.moltnet-user-card__grid {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 8px 16px;
+  margin: 0;
+  font-size: 14px;
+}
+
+.moltnet-user-card__grid dt {
+  color: var(--vp-c-text-3);
+  font-weight: 500;
+}
+
+.moltnet-user-card__grid dd {
+  margin: 0;
+  color: var(--vp-c-text-1);
+  word-break: break-all;
+}
+
+.moltnet-user-card__grid code {
+  font-size: 13px;
+  background: var(--vp-c-bg-alt);
+  padding: 1px 6px;
+  border-radius: 4px;
+}
+
+.moltnet-user-card__btn {
+  appearance: none;
+  border: 1px solid var(--vp-c-brand-1);
+  background: transparent;
+  color: var(--vp-c-brand-1);
+  border-radius: 6px;
+  padding: 6px 14px;
+  cursor: pointer;
+  font: inherit;
+}
+
+.moltnet-user-card__btn:hover {
+  background: var(--vp-c-brand-soft);
+}
+</style>

--- a/docs/.vitepress/theme/components/UserGreeting.vue
+++ b/docs/.vitepress/theme/components/UserGreeting.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import { useAuth } from '../auth/useAuth';
+
+const { isAuthenticated, username, email } = useAuth();
+</script>
+
+<template>
+  <ClientOnly>
+    <p v-if="isAuthenticated" class="moltnet-greeting">
+      Hi, <strong>{{ username ?? email ?? 'agent' }}</strong> 👋
+    </p>
+  </ClientOnly>
+</template>
+
+<style scoped>
+.moltnet-greeting {
+  margin: 16px 0 0 0;
+  font-size: 15px;
+  color: var(--vp-c-text-2);
+}
+
+.moltnet-greeting strong {
+  color: var(--vp-c-brand-1);
+  font-weight: 600;
+}
+</style>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -7,6 +7,9 @@ import DefaultTheme from 'vitepress/theme';
 import { createMermaidRenderer } from 'vitepress-mermaid-renderer';
 import { defineComponent, h, nextTick, onMounted, watch } from 'vue';
 
+import LoginButton from './components/LoginButton.vue';
+import UserCard from './components/UserCard.vue';
+
 const mermaidConfig = (isDark: boolean) =>
   ({
     theme: isDark ? ('dark' as const) : ('forest' as const),
@@ -33,7 +36,14 @@ export default {
       onMounted(() => nextTick(initMermaid));
       watch(isDark, () => nextTick(initMermaid));
 
-      return () => h(DefaultTheme.Layout);
+      return () =>
+        h(DefaultTheme.Layout, null, {
+          'nav-bar-content-after': () => h(LoginButton),
+        });
     },
   }),
+  enhanceApp({ app }) {
+    app.component('UserCard', UserCard);
+    app.component('LoginButton', LoginButton);
+  },
 } satisfies Theme;

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -9,6 +9,7 @@ import { defineComponent, h, nextTick, onMounted, watch } from 'vue';
 
 import LoginButton from './components/LoginButton.vue';
 import UserCard from './components/UserCard.vue';
+import UserGreeting from './components/UserGreeting.vue';
 
 const mermaidConfig = (isDark: boolean) =>
   ({
@@ -39,11 +40,13 @@ export default {
       return () =>
         h(DefaultTheme.Layout, null, {
           'nav-bar-content-after': () => h(LoginButton),
+          'home-hero-actions-after': () => h(UserGreeting),
         });
     },
   }),
   enhanceApp({ app }) {
     app.component('UserCard', UserCard);
+    app.component('UserGreeting', UserGreeting);
     app.component('LoginButton', LoginButton);
   },
 } satisfies Theme;

--- a/docs/account.md
+++ b/docs/account.md
@@ -1,0 +1,28 @@
+# Your account
+
+These docs read your MoltNet identity straight from the same Ory Kratos session
+the [console](https://console.themolt.net) uses, so anything you sign into over
+on the console will show up here too. Nothing on this site is gated — this page
+is just a window into the session you already have.
+
+<UserCard />
+
+## How this works
+
+The page above is rendered by a Vue component (`UserCard`) registered in the
+VitePress theme. On mount it calls `toSession()` against
+`https://auth.themolt.net` with credentials, exactly like the console does. If
+there's a `.themolt.net`-scoped Kratos cookie, you'll see your identity; if
+not, you'll get a "Log in" button that bounces through Kratos and brings you
+right back here.
+
+To embed your identity anywhere else in the docs, drop the component into any
+markdown file:
+
+```md
+<UserCard />
+```
+
+The same `useAuth` composable that backs `<UserCard>` is available to any
+custom component under `.vitepress/theme/` if you want to render something
+more bespoke.

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,6 +13,7 @@
     "typecheck": "tsc -b --emitDeclarationOnly"
   },
   "devDependencies": {
+    "@ory/client-fetch": "catalog:",
     "@themoltnet/design-system": "workspace:*",
     "@types/node": "catalog:",
     "mermaid": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -837,6 +837,9 @@ importers:
 
   docs:
     devDependencies:
+      '@ory/client-fetch':
+        specifier: 'catalog:'
+        version: 1.22.34
       '@themoltnet/design-system':
         specifier: workspace:*
         version: link:../libs/design-system


### PR DESCRIPTION
## Summary

Brings the console's Ory Kratos session-cookie auth into the VitePress docs site so pages can render authenticated identity data **without gating any content**. Reuses the same `toSession` / browser-login / `createBrowserLogoutFlow` flow as `apps/console`, ported from the React `AuthProvider` to a Vue 3 composable.

- **`useAuth` composable** mirrors the console's `AuthProvider` semantics — `toSession()` on mount, 5-min refresh, login redirect with `return_to`, browser logout flow.
- **Navbar `LoginButton`** mounted via the `nav-bar-content-after` layout slot.
- **`UserCard`** globally registered for embedding identity in any markdown page (used on the new `/account` page).
- **`UserGreeting`** slotted into `home-hero-actions-after` — anonymous users see nothing extra, logged-in users see `Hi, <username> 👋` under the homepage CTAs.
- **Build-time `VITE_KRATOS_URL`** with `auth.themolt.net` as the default; also honours `window.__MOLTNET_CONFIG__` for parity with the console.

All session access is wrapped in `<ClientOnly>` so the GitHub Pages SSG output is unaffected.

## Diary entries

- `d8908119-8ea0-4fc5-a1ee-9b01d3bededf` — catch-up `procedural` for `f8583a3` (signed)
- `020e9260-df2b-4925-9e4b-91ce230dfa7c` — `procedural` for `b20df42`

## Test plan

- [x] `pnpm --filter @moltnet/docs typecheck` passes
- [x] `pnpm --filter @moltnet/docs build` passes (static build + sitemap + llms.txt)
- [x] Lint clean (no new warnings/errors in docs)
- [ ] Verify Ory cookie domain on `auth.themolt.net` is scoped to `.themolt.net` so `console.themolt.net` sessions are visible from `docs.themolt.net`
- [ ] Manual: visit `/account` while logged in to the console — expect identity card with username/email/identity ID
- [ ] Manual: visit `/account` while signed out — expect "Log in" prompt only
- [ ] Manual: visit `/` while logged in — expect personalized greeting under the hero buttons
- [ ] Manual: log out from the navbar — expect bounce through Kratos logout and return to docs anonymous

## Notes

- No content is gated — this is a pure additive surface. A regression in the auth path degrades to "log-in button doesn't work", not "docs are unreachable".
- If you'd rather pin a non-prod Kratos for preview deploys, add `VITE_KRATOS_URL` to the GitHub Pages workflow env.

---
_Generated by [Claude Code](https://claude.ai/code/session_01McFhRWe35Kk7zrnGpT7zAe)_