### PR TITLE
Localize sandbox status copy

### DIFF
--- a/libs/pi-extension/src/commands/sandbox.ts
+++ b/libs/pi-extension/src/commands/sandbox.ts
@@ -1,3 +1,4 @@
+import { t } from '../i18n.js';
 import type { CommandRegistrar } from './types.js';
 
 const GUEST_WORKSPACE = '/workspace';
@@ -7,7 +8,7 @@ export const registerSandboxCommand: CommandRegistrar = (pi, state) => {
     description: 'Show sandbox status and egress policy',
     handler: async (_args, ctx) => {
       if (!state.vm) {
-        ctx.ui.notify('Sandbox is not running', 'warning');
+        ctx.ui.notify(t('sandbox.notRunning', 'Sandbox is not running'), 'warning');
         return;
       }
       const r = await state.vm.exec(
@@ -15,9 +16,14 @@ export const registerSandboxCommand: CommandRegistrar = (pi, state) => {
       );
       ctx.ui.notify(
         [
-          'Sandbox: running',
-          `Workspace: ${state.worktreePath ?? state.localCwd} → ${GUEST_WORKSPACE}`,
-          `MoltNet diary: ${state.diaryId ?? 'not configured'}`,
+          t('sandbox.running', 'Sandbox: running'),
+          t('sandbox.workspace', 'Workspace: {host} → {guest}', {
+            host: state.worktreePath ?? state.localCwd,
+            guest: GUEST_WORKSPACE,
+          }),
+          t('sandbox.diary', 'MoltNet diary: {diary}', {
+            diary: state.diaryId ?? t('sandbox.notConfigured', 'not configured'),
+          }),
           r.stdout?.trimEnd() ?? '',
         ].join('\n'),
         'info',

--- a/libs/pi-extension/src/i18n.ts
+++ b/libs/pi-extension/src/i18n.ts
@@ -1,0 +1,57 @@
+import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+
+type Locale = 'en' | 'es' | 'fr' | 'pt-BR';
+type Params = Record<string, string | number>;
+
+const translations: Record<Exclude<Locale, 'en'>, Record<string, string>> = {
+  es: {
+    'sandbox.notRunning': 'El sandbox no está en ejecución',
+    'sandbox.running': 'Sandbox: en ejecución',
+    'sandbox.workspace': 'Espacio de trabajo: {host} → {guest}',
+    'sandbox.diary': 'Diario de MoltNet: {diary}',
+    'sandbox.notConfigured': 'no configurado',
+  },
+  fr: {
+    'sandbox.notRunning': 'Le sandbox n’est pas en cours d’exécution',
+    'sandbox.running': 'Sandbox : en cours d’exécution',
+    'sandbox.workspace': 'Espace de travail : {host} → {guest}',
+    'sandbox.diary': 'Journal MoltNet : {diary}',
+    'sandbox.notConfigured': 'non configuré',
+  },
+  'pt-BR': {
+    'sandbox.notRunning': 'O sandbox não está em execução',
+    'sandbox.running': 'Sandbox: em execução',
+    'sandbox.workspace': 'Workspace: {host} → {guest}',
+    'sandbox.diary': 'Diário MoltNet: {diary}',
+    'sandbox.notConfigured': 'não configurado',
+  },
+};
+
+let currentLocale: Locale = 'en';
+
+export function initI18n(pi: ExtensionAPI): void {
+  pi.events?.emit?.('pi-core/i18n/registerBundle', {
+    namespace: 'themoltnet-pi-extension',
+    defaultLocale: 'en',
+    locales: translations,
+  });
+
+  pi.events?.emit?.('pi-core/i18n/requestApi', {
+    onReady: (api: { getLocale?: () => string; onLocaleChange?: (cb: (locale: string) => void) => void }) => {
+      const next = api.getLocale?.();
+      if (isLocale(next)) currentLocale = next;
+      api.onLocaleChange?.((locale) => {
+        if (isLocale(locale)) currentLocale = locale;
+      });
+    },
+  });
+}
+
+export function t(key: string, fallback: string, params: Params = {}): string {
+  const template = currentLocale === 'en' ? fallback : translations[currentLocale]?.[key] ?? fallback;
+  return template.replace(/\{(\w+)\}/g, (_, name) => String(params[name] ?? `{${name}}`));
+}
+
+function isLocale(locale: string | undefined): locale is Locale {
+  return locale === 'en' || locale === 'es' || locale === 'fr' || locale === 'pt-BR';
+}

--- a/libs/pi-extension/src/index.ts
+++ b/libs/pi-extension/src/index.ts
@@ -41,6 +41,7 @@ import {
   createGondolinReadOps,
   createGondolinWriteOps,
 } from './tool-operations.js';
+import { initI18n } from './i18n.js';
 import { activateAgentEnv, findMainWorktree, resumeVm } from './vm-manager.js';
 
 export {
@@ -53,6 +54,8 @@ export { createPiOtelExtension, type PiOtelOptions } from './otel/index.js';
 const GUEST_WORKSPACE = '/workspace';
 
 export default function moltnetExtension(pi: ExtensionAPI) {
+  initI18n(pi);
+
   // -- Flags ------------------------------------------------------------------
 
   pi.registerFlag('agent', {


### PR DESCRIPTION
The `/sandbox` command is the point where a Pi user checks whether execution is actually isolated, which host path is mounted into `/workspace`, and whether a MoltNet diary is configured. Those labels affect trust in the sandbox boundary, so I kept this PR focused on that status path only.

What changed:
- added a tiny optional i18n bridge for the Pi extension
- registered `es`, `fr`, and `pt-BR` strings for `/sandbox` status copy
- wrapped only the sandbox running/not-running/workspace/diary labels

What did not change:
- no required dependency
- English fallback strings stay in the call sites
- no behavior change without a Pi i18n provider
- no generated files, package metadata, tool descriptions, or docs changed
- easy to revert by deleting `src/i18n.ts` and the small wrappers in `sandbox.ts`/`index.ts`

Validation:
- `corepack pnpm --filter @themoltnet/pi-extension run test` passed: 9 files / 80 tests
- `corepack pnpm --filter @themoltnet/pi-extension run build` emitted the existing workspace declaration warnings/errors about unbuilt referenced packages, but still produced `dist/index.js`; also noted local Node 20 vs repo engine Node 22 warnings

If useful later, I’m happy to handle broader localization in small follow-up PRs using whatever locale set you prefer.
