### PR TITLE
fix(legreffier): anchor relative GIT_CONFIG_GLOBAL and dedup snippet

### DIFF
--- a/.claude/rules/legreffier-gh.md
+++ b/.claude/rules/legreffier-gh.md
@@ -19,8 +19,12 @@
 ## The only correct form
 
 ```bash
-# 1. Resolve credentials to an ABSOLUTE path (never trust $GIT_CONFIG_GLOBAL as-is).
-CREDS="$(cd "$(dirname "$GIT_CONFIG_GLOBAL")" 2>/dev/null && pwd)/moltnet.json"
+# 1. Resolve credentials to an ABSOLUTE path. GIT_CONFIG_GLOBAL is typically
+#    relative (e.g. .moltnet/<agent>/gitconfig). Anchor it against the repo
+#    root so this works from any subdirectory or worktree, not just the root.
+CFG="$GIT_CONFIG_GLOBAL"
+case "$CFG" in /*) ;; *) CFG="$(git rev-parse --show-toplevel)/$CFG" ;; esac
+CREDS="$(dirname "$CFG")/moltnet.json"
 
 # 2. Refuse to proceed if the file does not exist at that absolute path.
 [ -f "$CREDS" ] || { echo "FATAL: moltnet.json not found at $CREDS" >&2; exit 1; }
@@ -42,18 +46,22 @@ so repeated calls are fast after the first API hit.
 
 ## Why absolute paths are mandatory
 
-`GIT_CONFIG_GLOBAL` is almost always a **relative path** (e.g. `.moltnet/<agent>/gitconfig`).
-Every git worktree has a different CWD from the main worktree root, so
-`$(dirname "$GIT_CONFIG_GLOBAL")` resolves differently depending on where you are.
-When it resolves to a non-existent directory:
+`GIT_CONFIG_GLOBAL` is almost always a **relative path** (e.g. `.moltnet/<agent>/gitconfig`),
+interpreted by git relative to the repo root — not the shell's CWD. So a bare
+`$(dirname "$GIT_CONFIG_GLOBAL")` resolves to a non-existent directory whenever
+you run `gh` from a subdirectory (e.g. `packages/api`) or from a worktree whose
+CWD differs from the main worktree root. When that happens:
 
 - `moltnet github token` (or `npx @themoltnet/cli github token`) prints `no credentials found` to stderr,
 - the command substitution yields an empty `GH_TOKEN`,
 - `gh` silently falls back to your personal token,
 - the resulting API call is attributed to the **human**, not the agent.
 
-This failure is invisible in normal output. The `cd ... && pwd` dance in step 1
-is the only reliable way to get an absolute path that works across worktrees.
+This failure is invisible in normal output. The `git rev-parse --show-toplevel`
+anchoring in step 1 is the only reliable way to get an absolute path that works
+from any CWD inside the repo (and any worktree). If the snippet is run outside
+a git repo, `git rev-parse` exits non-zero and the whole pipeline fails loudly
+instead of silently producing the wrong path.
 
 ## Forbidden patterns
 

--- a/.claude/skills/legreffier/SKILL.md
+++ b/.claude/skills/legreffier/SKILL.md
@@ -363,17 +363,12 @@ Applies only when the agent has a GitHub App configured — i.e. `moltnet.json` 
   `gh issue view`, etc.), for `git push`, and for content API calls
   (`gh api repos/{owner}/{repo}/contents/...`). The human must have `gh auth login` configured.
 
-When using the agent token:
-
-```bash
-CREDS="$(cd "$(dirname "$GIT_CONFIG_GLOBAL")" && pwd)/moltnet.json"
-GH_TOKEN=$($MOLTNET_CLI github token --credentials "$CREDS") gh <command>
-```
-
-The `cd`+`pwd` pattern is required because `GIT_CONFIG_GLOBAL` may be a **relative path**
-(e.g. `.moltnet/legreffier/gitconfig`). In git worktrees the CWD differs from the main
-worktree root, so a bare `$(dirname "$GIT_CONFIG_GLOBAL")` resolves incorrectly and
-`no credentials found` is printed — falling back to your personal `gh` token silently.
+When using the agent token, follow the credential-resolution snippet in
+[`.claude/rules/legreffier-gh.md`](../../rules/legreffier-gh.md). It is the
+single source of truth and covers the absolute-path requirement (works from
+any subdirectory or worktree), the `[ -f "$CREDS" ]` presence guard, and the
+`$MOLTNET_CLI` pitfall (always hardcode `moltnet` or `npx @themoltnet/cli`).
+**Do not duplicate the snippet here** — keep that file as the canonical rule.
 
 The token is cached locally (~1 hour lifetime, 5-min expiry buffer).
 


### PR DESCRIPTION
## Summary

Fixes a silent-failure mode in the canonical credential-resolution snippet
used to inject `GH_TOKEN` for MoltNet agents, and removes a stale duplicate
of that snippet that had already drifted out of sync with the rule.

## Problem

`.claude/rules/legreffier-gh.md` instructs agents to resolve their `moltnet.json`
credentials path with:

```bash
CREDS="$(cd "$(dirname "$GIT_CONFIG_GLOBAL")" 2>/dev/null && pwd)/moltnet.json"
```

`GIT_CONFIG_GLOBAL` is typically a **relative** path (e.g. `.moltnet/<agent>/gitconfig`)
that git interprets relative to the repo root, not the shell's CWD. So the moment
an agent runs `gh ...` from any subdirectory of the repo (e.g. `packages/api`),
the `cd` lands in a non-existent directory, the command substitution silently
yields an empty string for `CREDS`, `moltnet github token` prints
`no credentials found`, `GH_TOKEN` ends up empty, and `gh` falls back to the
operator's **personal** auth — exactly the failure mode the rule exists to prevent.
The failure is invisible: the API call succeeds, just attributed to the wrong identity.

The same snippet was also duplicated in `.claude/skills/legreffier/SKILL.md`,
where it had drifted: the SKILL.md copy referenced `$MOLTNET_CLI` (which the rule
explicitly forbids because it can expand to empty in ad-hoc shells and swallow the
subcommand) and was missing the `[ -f "$CREDS" ]` presence guard.

## Fix

- **`.claude/rules/legreffier-gh.md`** — Replace `cd ... && pwd` with
  `git rev-parse --show-toplevel` anchoring. The new form works from any
  subdirectory or worktree, and **fails loudly** (non-zero exit) outside a git
  repo instead of silently producing the wrong path. The "Why absolute paths
  are mandatory" section is updated to describe the new mechanism.
- **`.claude/skills/legreffier/SKILL.md`** — Delete the duplicate snippet and
  replace it with a pointer to `legreffier-gh.md`. Single source of truth → no
  drift possible.

## Reported by

Copilot review on the on-board repo's adoption of these skills:
[innovation-system/on-board#2187](https://github.com/innovation-system/on-board/pull/2187).

## Verification

```bash
cd /any/subdirectory/of/a/git/repo
GIT_CONFIG_GLOBAL=.moltnet/<agent>/gitconfig
CFG="$GIT_CONFIG_GLOBAL"
case "$CFG" in /*) ;; *) CFG="$(git rev-parse --show-toplevel)/$CFG" ;; esac
echo "$(dirname "$CFG")/moltnet.json"
# → /absolute/path/to/repo/.moltnet/<agent>/moltnet.json
```

Outside a git repo, `git rev-parse --show-toplevel` exits non-zero, so the
pipeline aborts loudly instead of silently producing the wrong path.