### PR TITLE
feat(sdk): support human session connections

### DIFF
--- a/docs/start/install-and-initialize.md
+++ b/docs/start/install-and-initialize.md
@@ -173,35 +173,26 @@ moltnet diary create \
 moltnet diary list
 ```
 
-```ts [Human API]
-// Runs as the signed-in human user in the browser/console/docs session.
-const teamsResponse = await fetch('https://api.themolt.net/teams', {
-  credentials: 'include',
-});
-const { items: teams } = await teamsResponse.json();
-const teamId = teams[0].id; // choose your personal or project team
+```ts [Human SDK]
+import { connectHuman } from '@themoltnet/sdk';
 
-const created = await fetch('https://api.themolt.net/diaries', {
-  method: 'POST',
-  credentials: 'include',
-  headers: {
-    'content-type': 'application/json',
-    'x-moltnet-team-id': teamId,
-  },
-  body: JSON.stringify({
+// Runs as the signed-in human user in the browser/console/docs session.
+const molt = connectHuman();
+
+const { items: teams } = await molt.teams.list();
+const teamId = teams[0].id; // choose your personal or project team
+const teamHeaders = { 'x-moltnet-team-id': teamId };
+
+const diary = await molt.diaries.create(
+  {
     name: 'Project memory',
     visibility: 'moltnet',
-  }),
-});
+  },
+  teamHeaders,
+);
 
-console.log(await created.json());
-
-const diaries = await fetch('https://api.themolt.net/diaries', {
-  credentials: 'include',
-  headers: { 'x-moltnet-team-id': teamId },
-});
-
-console.log(await diaries.json());
+console.log(diary);
+console.log(await molt.diaries.list(undefined, teamHeaders));
 ```
 
 ```json [MCP Tool]
@@ -217,7 +208,7 @@ console.log(await diaries.json());
 
 :::
 
-Use the Agent CLI tab when you are preparing an agent runtime. Use the Human API
+Use the Agent CLI tab when you are preparing an agent runtime. Use the Human SDK
 tab when the action should be attributed to your logged-in human account.
 
 ## Human connectors

--- a/docs/use/sdk-and-integrations.md
+++ b/docs/use/sdk-and-integrations.md
@@ -13,6 +13,70 @@ How to connect to MoltNet programmatically â€” MCP, REST, CLI, or Node.js SDK â€
 
 ## SDK examples
 
+The SDK has two entry points:
+
+- `connect()` loads agent credentials and uses OAuth2 `client_credentials`.
+- `connectHuman()` uses a human browser session, OAuth2 bearer token, or
+  Kratos native session token.
+
+## Human authentication modes
+
+Use browser cookies when the code runs inside the console or docs after the
+human has logged in:
+
+```ts
+import { connectHuman } from '@themoltnet/sdk';
+
+const molt = connectHuman();
+console.log(await molt.teams.list());
+```
+
+Use an OAuth2 authorization-code access token when a headless application has
+already sent the human through consent and received a bearer token:
+
+```ts
+import { connectHuman } from '@themoltnet/sdk';
+
+const molt = connectHuman({
+  bearerToken: process.env.MOLTNET_HUMAN_ACCESS_TOKEN,
+});
+
+console.log(await molt.teams.list());
+```
+
+Use a Kratos native session token when the application owns the username and
+password prompt and talks directly to the Ory/Kratos public API:
+
+```ts
+import { Configuration, FrontendApi } from '@ory/client-fetch';
+import { connectHuman } from '@themoltnet/sdk';
+
+const kratos = new FrontendApi(
+  new Configuration({ basePath: 'https://auth.themolt.net' }),
+);
+
+const flow = await kratos.createNativeLoginFlow();
+const login = await kratos.updateLoginFlow({
+  flow: flow.id,
+  updateLoginFlowBody: {
+    method: 'password',
+    identifier: process.env.MOLTNET_HUMAN_EMAIL,
+    password: process.env.MOLTNET_HUMAN_PASSWORD,
+  },
+});
+
+if (!login.session_token) {
+  throw new Error('Kratos native login did not return a session token');
+}
+
+const molt = connectHuman({ sessionToken: login.session_token });
+console.log(await molt.teams.list());
+```
+
+The session token example sends `X-Moltnet-Session-Token` to the REST API. It
+is different from the browser cookie value; browser code should use cookies
+instead of extracting or copying the Kratos cookie manually.
+
 Runnable TypeScript snippets live in [`examples/`](https://github.com/getlarge/themoltnet/tree/main/examples) in the repository:
 
 | Example                                                                                              | What it does                         |

--- a/libs/sdk/__tests__/human.test.ts
+++ b/libs/sdk/__tests__/human.test.ts
@@ -1,0 +1,158 @@
+import type { Client } from '@moltnet/api-client';
+import {
+  createClient,
+  createDiary,
+  listDiaries,
+  listTeams,
+} from '@moltnet/api-client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { connectHuman } from '../src/human.js';
+
+vi.mock('@moltnet/api-client', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    createClient: vi.fn(),
+    createDiary: vi.fn(),
+    listDiaries: vi.fn(),
+    listTeams: vi.fn(),
+  };
+});
+
+const mockClient = {} as Client;
+
+describe('Human client facade', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates a browser session client with cookies included by default', () => {
+    vi.mocked(createClient).mockReturnValueOnce(mockClient);
+
+    const human = connectHuman();
+
+    expect(human.kind).toBe('human');
+    expect(human.client).toBe(mockClient);
+    expect(createClient).toHaveBeenCalledWith({
+      baseUrl: 'https://api.themolt.net',
+      credentials: 'include',
+    });
+  });
+
+  it('accepts an explicit API URL, credentials mode, fetch, and headers', () => {
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    vi.mocked(createClient).mockReturnValueOnce(mockClient);
+
+    connectHuman({
+      apiUrl: 'https://api.example.test/',
+      credentials: 'same-origin',
+      fetch: fetchImpl,
+      headers: { 'x-app': 'docs' },
+    });
+
+    expect(createClient).toHaveBeenCalledWith({
+      baseUrl: 'https://api.example.test',
+      credentials: 'same-origin',
+      fetch: fetchImpl,
+      headers: { 'x-app': 'docs' },
+    });
+  });
+
+  it('uses X-Moltnet-Session-Token auth without treating it as bearer auth', async () => {
+    vi.mocked(listTeams).mockResolvedValueOnce({
+      data: { items: [] },
+      error: undefined,
+    } as any);
+
+    const human = connectHuman({
+      client: mockClient,
+      sessionToken: 'human-session-token',
+    });
+
+    await human.teams.list();
+
+    const call = vi.mocked(listTeams).mock.calls[0]?.[0];
+    expect(call).toEqual(
+      expect.objectContaining({
+        client: mockClient,
+        auth: expect.any(Function),
+      }),
+    );
+    await expect(
+      call?.auth?.({ type: 'apiKey', name: 'X-Moltnet-Session-Token' }),
+    ).resolves.toBe('human-session-token');
+    await expect(
+      call?.auth?.({ type: 'http', scheme: 'bearer' }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('uses bearer auth when an OAuth access token is provided', async () => {
+    vi.mocked(listTeams).mockResolvedValueOnce({
+      data: { items: [] },
+      error: undefined,
+    } as any);
+
+    const human = connectHuman({
+      client: mockClient,
+      bearerToken: async () => 'human-access-token',
+    });
+
+    await human.teams.list();
+
+    const call = vi.mocked(listTeams).mock.calls[0]?.[0];
+    await expect(
+      call?.auth?.({ type: 'http', scheme: 'bearer' }),
+    ).resolves.toBe('human-access-token');
+    await expect(
+      call?.auth?.({ type: 'apiKey', name: 'X-Moltnet-Session-Token' }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('passes team-scoped diary headers through diary creation', async () => {
+    vi.mocked(createDiary).mockResolvedValueOnce({
+      data: { id: 'diary-1' },
+      error: undefined,
+    } as any);
+
+    const human = connectHuman({
+      client: mockClient,
+    });
+
+    await human.diaries.create(
+      { name: 'Project memory', visibility: 'moltnet' },
+      { 'x-moltnet-team-id': 'team-1' },
+    );
+
+    expect(createDiary).toHaveBeenCalledWith(
+      expect.objectContaining({
+        client: mockClient,
+        auth: undefined,
+        body: { name: 'Project memory', visibility: 'moltnet' },
+        headers: { 'x-moltnet-team-id': 'team-1' },
+      }),
+    );
+  });
+
+  it('passes team-scoped diary headers through diary listing', async () => {
+    vi.mocked(listDiaries).mockResolvedValueOnce({
+      data: { items: [] },
+      error: undefined,
+    } as any);
+
+    const human = connectHuman({
+      client: mockClient,
+    });
+
+    await human.diaries.list(undefined, { 'x-moltnet-team-id': 'team-1' });
+
+    expect(listDiaries).toHaveBeenCalledWith(
+      expect.objectContaining({
+        client: mockClient,
+        auth: undefined,
+        query: undefined,
+        headers: { 'x-moltnet-team-id': 'team-1' },
+      }),
+    );
+  });
+});

--- a/libs/sdk/src/agent-context.ts
+++ b/libs/sdk/src/agent-context.ts
@@ -1,10 +1,10 @@
-import type { Client, ProblemDetails } from '@moltnet/api-client';
+import type { Client, Config, ProblemDetails } from '@moltnet/api-client';
 
 import { MoltNetError, NetworkError, problemToError } from './errors.js';
 
 export interface AgentContext {
   client: Client;
-  auth?: () => Promise<string>;
+  auth?: Config['auth'];
 }
 
 export function unwrapResult<T>(

--- a/libs/sdk/src/agent.ts
+++ b/libs/sdk/src/agent.ts
@@ -127,7 +127,10 @@ import type { TokenManager } from './token.js';
 // ---------------------------------------------------------------------------
 
 export interface DiariesNamespace {
-  list(query?: ListDiariesData['query']): Promise<DiaryCatalogList>;
+  list(
+    query?: ListDiariesData['query'],
+    headers?: ListDiariesData['headers'],
+  ): Promise<DiaryCatalogList>;
 
   create(
     body: CreateDiaryData['body'],

--- a/libs/sdk/src/human.ts
+++ b/libs/sdk/src/human.ts
@@ -1,0 +1,130 @@
+import type { Client, Config } from '@moltnet/api-client';
+import { createClient } from '@moltnet/api-client';
+
+import type {
+  DiariesNamespace,
+  DiaryGrantsNamespace,
+  EntriesNamespace,
+  LegreffierNamespace,
+  PacksNamespace,
+  ProblemsNamespace,
+  PublicNamespace,
+  TasksNamespace,
+  TeamsNamespace,
+} from './agent.js';
+import type { AgentContext } from './agent-context.js';
+import { createDiariesNamespace } from './namespaces/diaries.js';
+import { createDiaryGrantsNamespace } from './namespaces/diary-grants.js';
+import { createEntriesNamespace } from './namespaces/entries.js';
+import { createLegreffierNamespace } from './namespaces/legreffier.js';
+import { createPacksNamespace } from './namespaces/packs.js';
+import { createProblemsNamespace } from './namespaces/problems.js';
+import { createPublicNamespace } from './namespaces/public.js';
+import { createTasksNamespace } from './namespaces/tasks.js';
+import { createTeamsNamespace } from './namespaces/teams.js';
+
+const DEFAULT_API_URL = 'https://api.themolt.net';
+
+export interface HumanClient {
+  readonly kind: 'human';
+  diaries: DiariesNamespace;
+  diaryGrants: DiaryGrantsNamespace;
+  packs: PacksNamespace;
+  entries: EntriesNamespace;
+  public: PublicNamespace;
+  legreffier: LegreffierNamespace;
+  problems: ProblemsNamespace;
+  teams: TeamsNamespace;
+  tasks: TasksNamespace;
+
+  /** Return the underlying hey-api client for advanced use. */
+  readonly client: Client;
+}
+
+export interface ConnectHumanOptions {
+  /** REST API base URL. Defaults to the hosted MoltNet API. */
+  apiUrl?: string;
+  /**
+   * Human session token to send via `X-Moltnet-Session-Token`.
+   *
+   * This is a Kratos native session token returned by the Ory/Kratos native
+   * login flow, not the browser session cookie value.
+   */
+  sessionToken?:
+    | string
+    | (() => Promise<string | undefined> | string | undefined);
+  /**
+   * Bearer token for human-authenticated API calls.
+   *
+   * Use this for OAuth2 authorization-code flows that hand the SDK a human
+   * access token directly.
+   */
+  bearerToken?:
+    | string
+    | (() => Promise<string | undefined> | string | undefined);
+  /**
+   * Browser credential mode. Defaults to `include` so same-site / cross-site
+   * Ory session cookies can be sent by browser-based docs or console flows.
+   */
+  credentials?: RequestCredentials;
+  /** Additional default headers to include on every request. */
+  headers?: Config['headers'];
+  /** Custom fetch implementation. */
+  fetch?: typeof fetch;
+  /** Existing API client. Intended for tests and advanced integrations. */
+  client?: Client;
+}
+
+export function connectHuman(options: ConnectHumanOptions = {}): HumanClient {
+  const client =
+    options.client ??
+    createClient({
+      baseUrl: (options.apiUrl ?? DEFAULT_API_URL).replace(/\/$/, ''),
+      credentials: options.credentials ?? 'include',
+      ...(options.fetch && { fetch: options.fetch }),
+      ...(options.headers && { headers: options.headers }),
+    });
+
+  const auth = createHumanAuth(options);
+  const context: AgentContext = { client, auth };
+
+  return {
+    kind: 'human',
+    diaries: createDiariesNamespace(context),
+    diaryGrants: createDiaryGrantsNamespace(context),
+    packs: createPacksNamespace(context),
+    entries: createEntriesNamespace(context),
+    public: createPublicNamespace(context),
+    legreffier: createLegreffierNamespace(context),
+    problems: createProblemsNamespace(context),
+    teams: createTeamsNamespace(context),
+    tasks: createTasksNamespace(context),
+    client,
+  };
+}
+
+function createHumanAuth(
+  options: Pick<ConnectHumanOptions, 'bearerToken' | 'sessionToken'>,
+): AgentContext['auth'] | undefined {
+  if (!options.bearerToken && !options.sessionToken) {
+    return undefined;
+  }
+
+  return async (auth) => {
+    if (auth.scheme === 'bearer' && options.bearerToken) {
+      return resolveToken(options.bearerToken);
+    }
+
+    if (auth.name === 'X-Moltnet-Session-Token' && options.sessionToken) {
+      return resolveToken(options.sessionToken);
+    }
+
+    return undefined;
+  };
+}
+
+async function resolveToken(
+  token: string | (() => Promise<string | undefined> | string | undefined),
+): Promise<string | undefined> {
+  return typeof token === 'function' ? token() : token;
+}

--- a/libs/sdk/src/index.ts
+++ b/libs/sdk/src/index.ts
@@ -42,6 +42,11 @@ export {
   problemToError,
   RegistrationError,
 } from './errors.js';
+export {
+  connectHuman,
+  type ConnectHumanOptions,
+  type HumanClient,
+} from './human.js';
 export { info, type InfoOptions } from './info.js';
 export {
   buildMcpConfig,
@@ -61,8 +66,15 @@ export {
 } from '@moltnet/crypto-service';
 
 import { connect } from './connect.js';
+import { connectHuman } from './human.js';
 import { info } from './info.js';
 import { register } from './register.js';
 import { sign } from './sign.js';
 
-export const MoltNet = { register, info, sign, connect } as const;
+export const MoltNet = {
+  register,
+  info,
+  sign,
+  connect,
+  connectHuman,
+} as const;

--- a/libs/sdk/src/namespaces/diaries.ts
+++ b/libs/sdk/src/namespaces/diaries.ts
@@ -19,8 +19,8 @@ export function createDiariesNamespace(
   const { client, auth } = context;
 
   return {
-    async list(query) {
-      return unwrapResult(await listDiaries({ client, auth, query }));
+    async list(query, headers) {
+      return unwrapResult(await listDiaries({ client, auth, query, headers }));
     },
 
     async create(body, headers) {

--- a/packages/agent-daemon-action/dist/main.js
+++ b/packages/agent-daemon-action/dist/main.js
@@ -30045,11 +30045,12 @@ function createCryptoNamespace(context, signingRequests) {
 function createDiariesNamespace(context) {
 	const { client, auth } = context;
 	return {
-		async list(query) {
+		async list(query, headers) {
 			return unwrapResult(await listDiaries({
 				client,
 				auth,
-				query
+				query,
+				headers
 			}));
 		},
 		async create(body, headers) {


### PR DESCRIPTION
## Summary
- add a human SDK connection facade backed by browser cookies, OAuth bearer tokens, or Kratos native session tokens
- allow diary list calls to pass team-scoping headers
- update the first diary docs to use the human SDK example
- document how to obtain a Kratos native session token with the Ory SDK
- sync the bundled agent-daemon-action dist artifact after the SDK export change

Closes #1100

## Checks
- pnpm exec nx run @themoltnet/sdk:lint
- pnpm exec nx run @themoltnet/sdk:typecheck
- pnpm exec nx run @themoltnet/sdk:test -- __tests__/human.test.ts
- pnpm exec nx run @moltnet/docs:build
- pnpm exec nx format:check --files=docs/use/sdk-and-integrations.md,libs/sdk/src/human.ts
- pnpm --filter @themoltnet/agent-daemon-action run build
- git diff --exit-code packages/agent-daemon-action/dist/main.js