### PR TITLE
fix(task-ui): show task correlation ids

### DIFF
--- a/apps/mcp-server/__tests__/task-app.test.ts
+++ b/apps/mcp-server/__tests__/task-app.test.ts
@@ -82,6 +82,8 @@ describe('Task MCP App', () => {
     expect(content.text).toContain("name: 'tasks_list'");
     expect(content.text).toContain('id="task-type"');
     expect(content.text).toContain('id="has-attempts"');
+    expect(content.text).toContain('Correlation ID');
+    expect(content.text).toContain('No correlation ID');
     expect(content.text).toContain('queued_after: optionalDateTime');
     expect(content.text).toContain('claimed_by_agent_id: optionalValue');
     expect(content._meta).toMatchObject({

--- a/apps/mcp-server/src/task-app.ts
+++ b/apps/mcp-server/src/task-app.ts
@@ -679,6 +679,9 @@ function buildTaskAppHtml(): string {
           const attemptText = task.acceptedAttemptN
             ? 'Accepted attempt ' + task.acceptedAttemptN
             : 'No accepted attempt';
+          const correlationText = task.correlationId
+            ? 'Correlation ' + task.correlationId
+            : 'No correlation ID';
           const row = document.createElement('button');
           row.type = 'button';
           row.className = 'queue-item';
@@ -687,6 +690,8 @@ function buildTaskAppHtml(): string {
             escapeHtml(task.taskType) +
             '</strong><code class="muted mono">' +
             escapeHtml(task.id) +
+            '</code><code class="muted mono">' +
+            escapeHtml(correlationText) +
             '</code><span class="muted">' +
             escapeHtml(requesterText + ' · ' + attemptText) +
             '</span></div><span class="status queue-status">' +
@@ -722,6 +727,8 @@ function buildTaskAppHtml(): string {
           escapeHtml(task.teamId ?? '—') +
           '</span></div><div class="fact"><strong>Diary</strong><span class="mono">' +
           escapeHtml(task.diaryId ?? '—') +
+          '</span></div><div class="fact"><strong>Correlation ID</strong><span class="mono">' +
+          escapeHtml(task.correlationId ?? '—') +
           '</span></div><div class="fact"><strong>Queued</strong><span>' +
           escapeHtml(task.queuedAt ?? 'unknown') +
           '</span></div><div class="fact"><strong>Requester</strong><span class="mono">' +

--- a/libs/task-ui/src/__tests__/fixtures.ts
+++ b/libs/task-ui/src/__tests__/fixtures.ts
@@ -19,7 +19,7 @@ export const taskFixture: TaskSummary = {
       role: 'context',
     },
   ],
-  correlationId: null,
+  correlationId: '77777777-7777-4777-8777-777777777777',
   imposedByAgentId: '55555555-5555-4555-8555-555555555555',
   imposedByHumanId: null,
   acceptedAttemptN: null,

--- a/libs/task-ui/src/__tests__/task-ui.test.tsx
+++ b/libs/task-ui/src/__tests__/task-ui.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 
 import { joinTextDeltas } from '../format.js';
 import { TaskActionPanel } from '../task-action-panel.js';
+import { TaskDetailHeader } from '../task-detail-header.js';
 import { TaskMessagesTimeline } from '../task-messages-timeline.js';
 import { TaskQueueTable } from '../task-queue-table.js';
 import { TaskStatusBadge } from '../task-status-badge.js';
@@ -31,8 +32,17 @@ describe('@moltnet/task-ui', () => {
 
     expect(screen.getByText('Curate Pack')).toBeInTheDocument();
     expect(screen.getByText('Running')).toBeInTheDocument();
+    expect(screen.getByText(taskFixture.correlationId!)).toBeInTheDocument();
     expect(screen.getByText('Diary 3333')).toBeInTheDocument();
     expect(screen.getByText('Agent 5555')).toBeInTheDocument();
+  });
+
+  it('renders the correlation id in the task detail header', () => {
+    renderWithTheme(<TaskDetailHeader task={taskFixture} />);
+
+    expect(screen.getByText('Correlation ID')).toBeInTheDocument();
+    expect(screen.getAllByText(taskFixture.correlationId!)).toHaveLength(2);
+    expect(screen.getByText('Copy correlation ID')).toBeInTheDocument();
   });
 
   it('joins adjacent text deltas for readable attempt timelines', () => {

--- a/libs/task-ui/src/task-detail-header.tsx
+++ b/libs/task-ui/src/task-detail-header.tsx
@@ -33,6 +33,7 @@ export function TaskDetailHeader({
     ['Team', renderTeamLabel?.(task.teamId) ?? task.teamId],
     ['Diary', renderDiaryLabel?.(task.diaryId) ?? task.diaryId ?? '—'],
     ['Imposer', renderActorLabel?.(actorId) ?? actorId ?? '—'],
+    ['Correlation ID', task.correlationId ?? '—'],
     ['Queued', formatDateTime(task.queuedAt)],
     ['Completed', formatDateTime(task.completedAt)],
     ['Expires', formatDateTime(task.expiresAt)],
@@ -94,13 +95,21 @@ export function TaskDetailHeader({
                 style={{
                   overflowWrap: 'anywhere',
                   fontFamily:
-                    typeof value === 'string' && value.includes('-')
+                    typeof value === 'string' &&
+                    value !== '—' &&
+                    value.includes('-')
                       ? theme.font.family.mono
                       : undefined,
                 }}
               >
                 {value}
               </Text>
+              {label === 'Correlation ID' && task.correlationId ? (
+                <CopyButton
+                  value={task.correlationId}
+                  label="Copy correlation ID"
+                />
+              ) : null}
             </Stack>
           ))}
         </div>

--- a/libs/task-ui/src/task-queue-table.tsx
+++ b/libs/task-ui/src/task-queue-table.tsx
@@ -42,7 +42,7 @@ export function TaskQueueTable({
   }
 
   const columns =
-    'minmax(150px, 1.2fr) minmax(110px, .8fr) minmax(120px, 1fr) minmax(130px, 1fr) minmax(90px, .6fr) minmax(70px, .5fr)';
+    'minmax(150px, 1.1fr) minmax(110px, .7fr) minmax(190px, 1.4fr) minmax(120px, .9fr) minmax(130px, 1fr) minmax(90px, .6fr) minmax(70px, .5fr)';
 
   return (
     <div
@@ -52,7 +52,7 @@ export function TaskQueueTable({
         borderRadius: theme.radius.lg,
       }}
     >
-      <div style={{ minWidth: 760 }}>
+      <div style={{ minWidth: 980 }}>
         <div
           style={{
             display: 'grid',
@@ -68,6 +68,7 @@ export function TaskQueueTable({
         >
           <span>Type</span>
           <span>Status</span>
+          <span>Correlation</span>
           <span>Diary</span>
           <span>Requester</span>
           <span>Age</span>
@@ -121,6 +122,25 @@ export function TaskQueueTable({
               </span>
               <span>
                 <TaskStatusBadge status={task.status} />
+              </span>
+              <span
+                title={task.correlationId ?? undefined}
+                style={{ minWidth: 0 }}
+              >
+                <Text
+                  variant="caption"
+                  color={task.correlationId ? undefined : 'muted'}
+                  style={{
+                    fontFamily: task.correlationId
+                      ? theme.font.family.mono
+                      : undefined,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {task.correlationId ?? '—'}
+                </Text>
               </span>
               <span>
                 {renderDiaryLabel?.(task.diaryId) ?? task.diaryId ?? '—'}


### PR DESCRIPTION
## Summary

- Show task correlation IDs in the shared task queue table used by the console task list.
- Show a labeled, copyable correlation ID in the shared task detail header.
- Show correlation IDs in the MCP task app queue rows and selected task detail panel.
- Add task-ui and MCP app test coverage for correlation ID rendering.

Closes #1111

## Verification

- pnpm exec vitest run (from libs/task-ui)
- pnpm exec tsc -p libs/task-ui/tsconfig.json --noEmit
- pnpm exec vitest run apps/mcp-server/__tests__/task-app.test.ts
- git verify-commit HEAD with LeGreffier allowed signers