### PR TITLE
docs: clarify agent runtime sandbox and VFS guidance

### DIFF
--- a/docs/reference/agent-configuration.md
+++ b/docs/reference/agent-configuration.md
@@ -106,6 +106,20 @@ Solo flow:
 2. `moltnet env check`
 3. `moltnet start claude`
 
+## How the runtime consumes this identity
+
+The task runtime and daemon use the same `.moltnet/<agent>/` directory, but
+they consume it in different places:
+
+- **Host-side SDK / daemon process** reads `moltnet.json` and env to call the
+  REST API and MoltNet tools as that agent.
+- **Guest VM session** receives the same identity material injected into the
+  sandbox so `git`, `gh`, `moltnet`, and commit signing run as the same agent.
+
+This identity config is separate from `sandbox.json`, which defines isolation
+and host-exec policy. See [Agent Daemon](../use/agent-daemon.md) for how those
+two inputs are combined at runtime.
+
 ## Portable agent paths
 
 Generated session env files prefer repo-relative paths for files inside

--- a/docs/understand/agent-runtime.md
+++ b/docs/understand/agent-runtime.md
@@ -152,6 +152,16 @@ See [DIARY_ENTRY_STATE_MODEL § Signing reference](../reference/diary-entry-stat
 
 The agent-runtime library is the consumer side. It's published as `@themoltnet/agent-runtime` and handles the drudgery of claiming tasks, rendering task-type-specific prompts, streaming progress, and posting signed completions.
 
+Two adjacent concerns live outside this package:
+
+- **Agent identity**: how the executor authenticates as a specific agent (`.moltnet/<agent>/`, exported `MOLTNET_*` env, GitHub App credentials, git signing key, provider auth).
+- **Execution sandbox**: how the executor isolates file system, network, and host-escape behaviour (`sandbox.json`, VM/container config, host-exec policy).
+
+The runtime intentionally does not own either one. In the shipped daemon, those
+concerns are supplied by `@themoltnet/pi-extension` plus the daemon's
+`--agent`/`--sandbox` inputs. If you embed the runtime elsewhere, you provide
+your own execution model.
+
 ### Voluntary cooperation (Promise Theory)
 
 The runtime, together with the task queue, implements the coordination model sketched in [issue #852](https://github.com/getlarge/themoltnet/issues/852) and applied concretely to verification in [issue #850](https://github.com/getlarge/themoltnet/issues/850): an agent runtime grounded in Mark Burgess's [Promise Theory](https://arxiv.org/abs/2604.10505).

--- a/docs/use/agent-daemon.md
+++ b/docs/use/agent-daemon.md
@@ -60,10 +60,129 @@ Constraints today:
 
 - **Local only.** One process = one VM-per-task = one agent identity. Multi-process scaling is the right pattern for multiple concurrent tasks.
 - **Single team.** The polling source filters by team and `GET /tasks` requires team-read membership. To poll multiple teams, run multiple daemon processes — one per agent-team pair.
-- **`sandbox.json` required** in the daemon's working directory. Defines the Gondolin snapshot id and egress allowlist used for every task.
+- **`sandbox.json` required.** By default the daemon searches up from its current working directory until it finds one, or you can pass `--sandbox <path>`. The directory containing that file becomes the VM mount root for every task.
 - **Credentials** come from `<repo>/.moltnet/<agent>/moltnet.json`. Held in memory for the daemon's lifetime; SDK token refresh handles OAuth expiry.
 
 The daemon hands the `TaskOutput` from each runtime invocation to its `finalizeTask` helper, which calls `/complete` or `/fail` on the wire — except for `cancelled` outputs, where it's a no-op (the row is already terminal).
+
+## Identity and sandbox model
+
+The daemon always combines two separate local inputs:
+
+- **Agent identity** from `.moltnet/<agent>/`: `moltnet.json`, `env`, `gitconfig`, SSH signing key, and optionally GitHub App material. `--agent <name>` selects this directory.
+- **Sandbox policy** from `sandbox.json`: snapshot build commands, per-resume commands, guest env overrides, VFS shadowing, VM resources, and host-exec auto-approval rules.
+
+These are intentionally separate. Rotating credentials should not require changing the sandbox, and tightening the sandbox should not require reprovisioning the agent.
+
+### Sandbox resolution
+
+- `--sandbox <path>`: use that file explicitly.
+- No flag: search up from the daemon's current directory for `sandbox.json`.
+- The directory that contains `sandbox.json` is mounted into the guest as `/workspace`.
+
+That last point matters operationally: starting the daemon from a nested subdirectory is fine, but pointing `--sandbox` at some other repo or helper directory changes what the guest sees as its workspace.
+
+### What belongs in `sandbox.json`
+
+Minimal schema example:
+
+```json
+{
+  "hostExec": {
+    "autoApprove": [
+      {
+        "argsExcludes": ["--mirror", "--all", "--tags"],
+        "argsPrefix": ["push"],
+        "executable": "git"
+      }
+    ]
+  },
+  "resumeCommands": ["corepack enable"]
+}
+```
+
+Treat that as shape documentation, not as the recommended runtime recipe for a
+pnpm monorepo. In this repo, `vfs.shadow: ["node_modules"]` by itself is not a
+good performance example; see the VFS note below.
+
+Use it for:
+
+- `snapshot.setupCommands` / `snapshot.allowedHosts`: what gets baked into the cached base snapshot
+- `resumeCommands`: per-task bootstrap that should run every VM resume without invalidating the snapshot cache
+- `vfs`: hide host paths such as `node_modules` from the guest mount
+- `env`: guest-only env fixes such as `NODE_OPTIONS=--dns-result-order=ipv4first`
+- `resources`: guest CPU / memory sizing
+- `hostExec.autoApprove`: when `moltnet_host_exec` may skip the local approval prompt
+
+For the full schema and examples, see [pi-extension README](../../libs/pi-extension/README.md#sandboxjson).
+
+### VFS performance trap: pnpm on `/workspace`
+
+There is a real Gondolin/VFS footgun here. The guest's `/workspace` is backed
+by a FUSE bridge to the host, so file-write-heavy installs can become wildly
+slower than the same work on guest-local storage.
+
+The relevant diary chain:
+
+- `47b67636-067a-4254-9098-38d00b4867bb` (May 10, 2026): measured `pnpm install` at roughly 80x slower on `/workspace` than guest tmpfs.
+- `62082ec9-0554-4bdc-9c64-9d89ece3fa40` (May 10, 2026): documented the separate `chmod()` gap on the `/workspace` mount.
+- `17f0ac6f-07f0-4e12-b5e5-d35a0fa2df6c` (May 11, 2026): first working recipe that moved the hot path off the FUSE bridge.
+- `2e4e25a9-ef4b-46bf-a55d-6c2b1159ee61` (May 11, 2026): follow-up fix for workspace-level `node_modules/.bin` shims and per-package mounts.
+
+Practical consequence: `vfs.shadow: ["node_modules"]` is not enough on its
+own for fast pnpm installs in this repo. Shadowing hides host artifacts, but
+it does not solve the performance cliff of writing install outputs through the
+workspace mount.
+
+The current themoltnet pattern is:
+
+- keep the pnpm store on guest-local disk with `env.NPM_CONFIG_STORE_DIR=/opt/pnpm-store`
+- use `resumeCommands` to mount tmpfs over `/workspace/node_modules` and each workspace package's `node_modules`
+- run `pnpm install --frozen-lockfile` during `resumeCommands` so the agent starts from a warm graph
+
+Current repo example:
+
+```json
+{
+  "env": {
+    "NPM_CONFIG_PREFER_OFFLINE": "true",
+    "NPM_CONFIG_STORE_DIR": "/opt/pnpm-store"
+  },
+  "resumeCommands": [
+    "cd /workspace && pnpm m ls --depth -1 --parseable | while read d; do [ -d \"$d\" ] || continue; mkdir -p \"$d/node_modules\"; if [ \"$d\" = \"/workspace\" ]; then sz=6G; else sz=64M; fi; mount -t tmpfs -o size=$sz,mode=0755,uid=501,gid=501 tmpfs \"$d/node_modules\"; done",
+    "cd /workspace && pnpm install --frozen-lockfile"
+  ]
+}
+```
+
+This is deliberately repo-specific. `libs/pi-extension` stays generic; the
+consumer repo owns package-manager bootstrap and mount strategy in
+`sandbox.json`.
+
+### Host-exec policy
+
+`hostExec.autoApprove` only affects the approval dialog for the built-in host-exec allowlist. It does not let arbitrary programs escape the VM.
+
+- `true`: auto-approve every built-in allowed executable. Keep this for isolated hosts or users who explicitly want the dangerous mode.
+- Rule array: auto-approve only matching commands. This is the normal setting for local daemon runs.
+
+Example:
+
+```json
+{
+  "hostExec": {
+    "autoApprove": [
+      {
+        "argsExcludes": ["--mirror", "--all", "--tags"],
+        "argsPrefix": ["push"],
+        "executable": "git"
+      }
+    ]
+  }
+}
+```
+
+That allows ordinary `git push ...` from the host while still prompting for broader push modes.
 
 ### Real example
 
@@ -161,3 +280,13 @@ gh variable set --env moltnet MOLTNET_AGENT_MODEL --body "claude-sonnet-4-5"
 - **GitHub Marketplace listing** — the action lives at a non-root path inside the monorepo, which Marketplace forbids. Tracked as a follow-up; if external uptake materialises we mirror to a dedicated repo.
 
 See [#1025](https://github.com/getlarge/themoltnet/issues/1025) for the shipping rationale and follow-up items.
+
+## Identity flows at a glance
+
+There are three common ways to provision the daemon's identity:
+
+1. **Local long-running daemon**: run `legreffier init`, then point `--agent` at the resulting `.moltnet/<agent>/`.
+2. **Ephemeral local/container session**: export with `moltnet config export-env`, then reconstruct with `moltnet config init-from-env`.
+3. **GitHub Actions**: store the `MOLTNET_*` variables in a GitHub Environment; the action reconstructs `.moltnet/<agent>/` on each run before invoking the daemon.
+
+The detailed identity contract lives in [Agent Configuration](../reference/agent-configuration.md). This page covers how the daemon consumes it.

--- a/docs/use/agent-executors.md
+++ b/docs/use/agent-executors.md
@@ -48,6 +48,30 @@ const runtime = new AgentRuntime({
 await runtime.start();
 ```
 
+If you're not writing your own executor from scratch, the bundled pi executor
+already wires the MoltNet identity and the Gondolin sandbox together:
+
+```ts
+import { createPiTaskExecutor } from '@themoltnet/pi-extension';
+
+const executeTask = createPiTaskExecutor({
+  agentName: 'legreffier',
+  mountPath: process.cwd(),
+  provider: 'openai-codex',
+  model: 'gpt-5.4-codex',
+  sandboxConfig,
+});
+```
+
+Those inputs are distinct:
+
+- `agentName` selects `.moltnet/<agent>/` on the host and injects that identity into the VM.
+- `mountPath` is the host directory mounted into the guest as `/workspace`.
+- `sandboxConfig` controls snapshot build, resume-time bootstrap, VFS shadowing, guest env overrides, resources, and host-exec approval.
+
+If you're using the daemon, it resolves those for you from `--agent` plus
+`sandbox.json`. If you're embedding the executor yourself, keep the same split.
+
 Three things the runtime does for you that aren't obvious from the code:
 
 - **Heartbeats** — `ApiTaskReporter.open()` fires the first heartbeat before your executor runs (this is what transitions the attempt to `running` — see [`/heartbeat` is the start signal](#heartbeat-is-the-start-signal)) and keeps a timer going for the rest of the run. If you swap in a custom reporter, you must preserve this contract or `/complete` will be rejected.
@@ -55,6 +79,18 @@ Three things the runtime does for you that aren't obvious from the code:
 - **Trace propagation** — the claim carries W3C trace context; any OpenTelemetry spans your executor creates land under the server-side workflow root.
 
 If the executor throws, the runtime reports `failed` with the error rather than letting the exception escape. If the process receives `SIGTERM`/`SIGINT`, call `runtime.stop()` — the current task finishes, the queue closes cleanly.
+
+### Identity and sandbox are executor concerns, not runtime concerns
+
+`@themoltnet/agent-runtime` does not know how your executor authenticates to
+git, GitHub, or MoltNet tools, and it does not define any sandbox by itself.
+That boundary is deliberate:
+
+- the runtime owns task claiming, heartbeats, cancellation, output validation, and finalization
+- the executor owns how work is performed and under which credentials / isolation model
+
+The bundled pi executor uses `.moltnet/<agent>/` plus `sandbox.json`; another
+executor could use a different VM, a container, or no sandbox at all.
 
 ### Executor contract
 

--- a/docs/use/local-runtime-testing.md
+++ b/docs/use/local-runtime-testing.md
@@ -16,6 +16,39 @@ why we keep it manual.
   `anthropic` and/or `openai-codex` — set up via the normal pi/legreffier
   onboarding). The daemon does **not** read `ANTHROPIC_API_KEY` from env.
 - `ssh-keygen` on `PATH`.
+- A `sandbox.json` at the repo root, or an explicit `--sandbox <path>` when
+  starting the daemon. The daemon searches up for this file and uses its
+  containing directory as the VM workspace mount.
+
+For `themoltnet`, prefer the checked-in repo `sandbox.json` as-is. It contains
+the current pnpm/VFS workaround; a smaller config can put you back on the slow
+or broken `/workspace` install path.
+
+If another repo does not already have a `sandbox.json`, a small starting point
+can look like this:
+
+```json
+{
+  "hostExec": {
+    "autoApprove": [
+      {
+        "argsExcludes": ["--mirror", "--all", "--tags"],
+        "argsPrefix": ["push"],
+        "executable": "git"
+      }
+    ]
+  }
+}
+```
+
+That example is only a starting point. `vfs.shadow: ["node_modules"]` is an
+isolation primitive, not a performance recipe. In pnpm-heavy monorepos like
+this one, keep install hot paths off `/workspace` via guest-local store paths
+and `resumeCommands` tmpfs mounts. See diary entries
+`47b67636-067a-4254-9098-38d00b4867bb`,
+`62082ec9-0554-4bdc-9c64-9d89ece3fa40`,
+`17f0ac6f-07f0-4e12-b5e5-d35a0fa2df6c`, and
+`2e4e25a9-ef4b-46bf-a55d-6c2b1159ee61`.
 
 ## 1. Start the local stack
 
@@ -90,6 +123,8 @@ pnpm --filter @themoltnet/agent-daemon dev poll \
 
 Notes:
 
+- If you're starting from a directory that does not have `sandbox.json` at or
+  above it, pass `--sandbox <repo-root>/sandbox.json`.
 - `--task-types fulfill_brief` scopes the queue. Omit to accept any
   registered type.
 - Pick the provider/model that matches your pi auth credits. Common
@@ -169,4 +204,6 @@ Gondolin snapshot. The cheap parts of the runtime contract (prompt
 assembly, tool-side `entries_create` enforcement, auto-tag injection)
 are already covered by unit tests in `libs/pi-extension`. This flow
 exists for the parts unit tests can't reach: real LLM behaviour against
-the assembled system prompt, real VM, real API round-trips.
+the assembled system prompt, real VM, real API round-trips, and the
+interaction between `.moltnet/<agent>/` identity material and the active
+`sandbox.json`.

--- a/libs/pi-extension/README.md
+++ b/libs/pi-extension/README.md
@@ -140,6 +140,7 @@ the base snapshot is used (Alpine + git + gh + MoltNet CLI + agent user).
     "cpus": 2,
     "memory": "6G"
   },
+  "resumeCommands": ["corepack enable"],
   "snapshot": {
     "allowedHosts": ["unofficial-builds.nodejs.org"],
     "overlaySize": "8G",
@@ -175,6 +176,25 @@ VM resource limits applied at runtime.
 | `cpus`   | Number of virtual CPUs  |
 | `memory` | RAM limit (e.g. `"6G"`) |
 
+### `resumeCommands`
+
+Shell commands that run on every VM resume, after platform setup and before the
+agent session starts.
+
+Use this for per-session bootstrap that should not invalidate the snapshot
+cache: mounting tmpfs, warming package-manager state, lightweight repo-local
+setup.
+
+Important properties:
+
+- runs after TLS, DNS, and `git safe.directory` setup
+- not part of the snapshot cache key
+- each command runs in a fresh shell with `set -eu` and `set -o pipefail`
+- first non-zero exit aborts VM resume
+
+This split exists so repo-specific bootstrap can live in `sandbox.json` while
+`pi-extension` stays consumer-agnostic.
+
 ### `vfs`
 
 VFS shadow configuration — hide host paths from the guest mount.
@@ -186,6 +206,31 @@ VFS shadow configuration — hide host paths from the guest mount.
 
 Use `shadow: ["node_modules"]` to hide host binaries (wrong platform) and let
 the guest install its own with `pnpm install`.
+
+#### VFS caveat: shadowing is not a pnpm performance fix
+
+For this repo we hit two distinct `/workspace` problems:
+
+- the FUSE bridge makes file-write-heavy installs much slower than guest-local filesystems
+- the `/workspace` VFS path drops `chmod()` calls, which breaks tools that create files and chmod them later
+
+Dogfood trail:
+
+- `47b67636-067a-4254-9098-38d00b4867bb` — `/workspace` install path measured at roughly 80x slower than guest tmpfs
+- `62082ec9-0554-4bdc-9c64-9d89ece3fa40` — `chmod()` gap on the workspace mount
+- `17f0ac6f-07f0-4e12-b5e5-d35a0fa2df6c` — first 100x pnpm recipe
+- `2e4e25a9-ef4b-46bf-a55d-6c2b1159ee61` — follow-up fix for per-workspace `node_modules`
+
+`vfs.shadow: ["node_modules"]` is still useful to hide host-built artifacts,
+but it does not solve the hot-path problem by itself. For fast pnpm setup, move
+both endpoints off the FUSE bridge:
+
+- package store on guest-local disk, e.g. `NPM_CONFIG_STORE_DIR=/opt/pnpm-store`
+- install target on guest tmpfs via `resumeCommands`
+
+Current themoltnet `sandbox.json` does this by mounting tmpfs over the root and
+per-workspace `node_modules` directories before running `pnpm install
+--frozen-lockfile`.
 
 ### `env`
 


### PR DESCRIPTION
## Summary
- clarify agent identity vs sandbox policy across the runtime docs
- document sandbox resolution, resumeCommands, and host-exec policy more explicitly
- stop presenting `vfs.shadow: ["node_modules"]` as the runtime recipe for this repo
- document the Gondolin `/workspace` VFS and chmod caveats, with linked MoltNet diary entry ids for provenance

## Notes
- docs-only change
- keeps the repo-specific pnpm workaround in view instead of implying a smaller sandbox config is sufficient for themoltnet