### PR TITLE
fix(agent-daemon): repair dedicated warm-session worktree mounting

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,35 @@
-pnpm exec dotenvx ext precommit
-pnpm exec lint-staged
+#!/bin/sh
+set -eu
+
+top_level="$(git rev-parse --show-toplevel)"
+common_dir="$(git rev-parse --git-common-dir)"
+main_checkout="$(cd "$common_dir/.." && pwd -P)"
+
+resolve_bin() {
+  tool_name="$1"
+
+  if [ -x "$top_level/node_modules/.bin/$tool_name" ]; then
+    printf '%s\n' "$top_level/node_modules/.bin/$tool_name"
+    return 0
+  fi
+
+  if [ -x "$main_checkout/node_modules/.bin/$tool_name" ]; then
+    printf '%s\n' "$main_checkout/node_modules/.bin/$tool_name"
+    return 0
+  fi
+
+  if command -v "$tool_name" >/dev/null 2>&1; then
+    command -v "$tool_name"
+    return 0
+  fi
+
+  printf 'pre-commit: could not find required tool "%s"\n' "$tool_name" >&2
+  return 1
+}
+
+dotenvx_bin="$(resolve_bin dotenvx)"
+lint_staged_bin="$(resolve_bin lint-staged)"
+
+cd "$top_level"
+"$dotenvx_bin" ext precommit
+"$lint_staged_bin" --cwd "$top_level"

--- a/apps/agent-daemon/src/cli/once.ts
+++ b/apps/agent-daemon/src/cli/once.ts
@@ -175,14 +175,24 @@ export async function runOnce(argv: string[]): Promise<number> {
       maxBashTimeouts: opts.maxBashTimeouts,
     });
     const executeTask: TaskExecutor = async (claimedTask, reporter) => {
-      const expired = slotRegistry.reapExpiredSlots();
-      if (expired.length > 0) {
-        rootLogger.info(
+      try {
+        const expired = slotRegistry.reapExpiredSlots();
+        if (expired.length > 0) {
+          rootLogger.info(
+            {
+              expiredCount: expired.length,
+              slotKeys: expired.map((item) => item.slot.slotKey),
+            },
+            'agent-daemon.daemon_slots_reaped',
+          );
+        }
+      } catch (err) {
+        rootLogger.error(
           {
-            expiredCount: expired.length,
-            slotKeys: expired.map((item) => item.slot.slotKey),
+            phase: 'daemon_slot_reap',
+            err: err instanceof Error ? err.message : String(err),
           },
-          'agent-daemon.daemon_slots_reaped',
+          'agent-daemon.daemon_slot_reap_failed',
         );
       }
       const executionPlan = executionPlans.getOrCreate(claimedTask);

--- a/apps/agent-daemon/src/cli/poll-shared.ts
+++ b/apps/agent-daemon/src/cli/poll-shared.ts
@@ -255,14 +255,25 @@ export async function runPolling(opts: PollSharedArgs): Promise<number> {
       executeTask: async (claimedTask, reporter) => {
         const executionPlan = executionPlans.getOrCreate(claimedTask);
         const sessionDescriptor = executionPlan.descriptor;
-        const expired = slotRegistry.reapExpiredSlots();
-        if (expired.length > 0) {
-          rootLogger.info(
+        let expired: ReturnType<typeof slotRegistry.reapExpiredSlots>;
+        try {
+          expired = slotRegistry.reapExpiredSlots();
+          if (expired.length > 0) {
+            rootLogger.info(
+              {
+                expiredCount: expired.length,
+                slotKeys: expired.map((item) => item.slot.slotKey),
+              },
+              'agent-daemon.daemon_slots_reaped',
+            );
+          }
+        } catch (err) {
+          rootLogger.error(
             {
-              expiredCount: expired.length,
-              slotKeys: expired.map((item) => item.slot.slotKey),
+              phase: 'daemon_slot_reap',
+              err: err instanceof Error ? err.message : String(err),
             },
-            'agent-daemon.daemon_slots_reaped',
+            'agent-daemon.daemon_slot_reap_failed',
           );
         }
         rootLogger.debug(

--- a/libs/agent-runtime/src/prompts/fulfill-brief.ts
+++ b/libs/agent-runtime/src/prompts/fulfill-brief.ts
@@ -32,16 +32,7 @@ export function buildFulfillBriefUserPrompt(
   input: FulfillBriefInput,
   ctx: Ctx,
 ): string {
-  const { brief, title, acceptanceCriteria, seedFiles, scopeHint } = input;
-
-  const criteriaSection = acceptanceCriteria?.length
-    ? [
-        '### Acceptance criteria',
-        '',
-        ...acceptanceCriteria.map((c) => `- ${c}`),
-        '',
-      ].join('\n')
-    : '';
+  const { brief, title, seedFiles, scopeHint } = input;
 
   const seedSection = seedFiles?.length
     ? [
@@ -107,7 +98,6 @@ export function buildFulfillBriefUserPrompt(
     '',
     brief,
     '',
-    criteriaSection,
     seedSection,
     correlationSection,
     workspaceSection,

--- a/libs/pi-extension/src/runtime/agent-session-factory.ts
+++ b/libs/pi-extension/src/runtime/agent-session-factory.ts
@@ -8,11 +8,10 @@
  *
  * Invariants this helper enforces (NOT configurable):
  *
- *   - `sessionManager: SessionManager.inMemory()` — every session is
- *     conversation-isolated. Persistent sessions would require a
- *     different abstraction.
- *   - `cwd: mountPath` — sessions run against the VM's `/workspace`
- *     mount via Gondolin-routed customTools.
+ *   - Parent sessions may opt into daemon-owned file persistence;
+ *     subagents remain conversation-isolated in-memory sessions.
+ *   - `cwd: cwdPath` — sessions start in the dedicated worktree (or
+ *     shared mount) while tools still resolve through the VM mount.
  *   - `agentDir: piAuthDir` — pi auth directory the caller resolved.
  *   - `extensionFactories: [piOtelExtension]` — telemetry is always
  *     wired; the caller picks the span attributes.
@@ -45,6 +44,8 @@ import { createPiOtelExtension } from '../otel/index.js';
 export interface BuildAgentSessionArgs {
   /** Host directory mounted at /workspace inside the VM. */
   mountPath: string;
+  /** Host working directory where the agent session should start. */
+  cwdPath: string;
   /** pi auth directory (resolved from `PI_CODING_AGENT_DIR` or `~/.pi/agent`). */
   piAuthDir: string;
   /** Resolved pi model handle (provider + model id). */
@@ -90,7 +91,7 @@ export async function buildAgentSession(
   });
 
   const resourceLoader = new DefaultResourceLoader({
-    cwd: args.mountPath,
+    cwd: args.cwdPath,
     agentDir: args.piAuthDir,
     extensionFactories: [piOtelExtension],
     appendSystemPrompt: args.appendSystemPrompt,
@@ -100,14 +101,14 @@ export async function buildAgentSession(
 
   const sessionManager = args.sessionPersistence
     ? await resolvePersistentSessionManager({
-        cwd: args.mountPath,
+        cwd: args.cwdPath,
         sessionDir: args.sessionPersistence.sessionDir,
       })
-    : SessionManager.inMemory(args.mountPath);
+    : SessionManager.inMemory(args.cwdPath);
 
   const created = await createAgentSession({
     agentDir: args.piAuthDir,
-    cwd: args.mountPath,
+    cwd: args.cwdPath,
     model: args.modelHandle,
     customTools: args.customTools,
     sessionManager,

--- a/libs/pi-extension/src/runtime/execute-pi-task.test.ts
+++ b/libs/pi-extension/src/runtime/execute-pi-task.test.ts
@@ -14,7 +14,11 @@ import {
 } from '@opentelemetry/sdk-metrics';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { isBashTimeoutResult, wireSessionAbort } from './execute-pi-task.js';
+import {
+  describeToolErrorMessage,
+  isBashTimeoutResult,
+  wireSessionAbort,
+} from './execute-pi-task.js';
 import {
   __resetTaskOutputCounterForTests,
   extractJsonObject,
@@ -409,5 +413,30 @@ describe('isBashTimeoutResult', () => {
         ],
       }),
     ).toBe(true);
+  });
+});
+
+describe('describeToolErrorMessage', () => {
+  it('prefers the first text chunk in a structured tool error', () => {
+    expect(
+      describeToolErrorMessage({
+        content: [
+          { type: 'text', text: 'gitdir missing from guest workspace' },
+          { type: 'text', text: 'secondary context' },
+        ],
+      }),
+    ).toBe('gitdir missing from guest workspace');
+  });
+
+  it('falls back to a trimmed string payload', () => {
+    expect(describeToolErrorMessage('  Command exited with code 1  ')).toBe(
+      'Command exited with code 1',
+    );
+  });
+
+  it('serializes unknown structured results safely', () => {
+    expect(describeToolErrorMessage({ ok: false, code: 128 })).toContain(
+      '"code":128',
+    );
   });
 });

--- a/libs/pi-extension/src/runtime/execute-pi-task.ts
+++ b/libs/pi-extension/src/runtime/execute-pi-task.ts
@@ -42,8 +42,8 @@ import {
   type TaskUserPromptContext,
 } from '@themoltnet/agent-runtime';
 import { connect } from '@themoltnet/sdk';
-import type { SubagentContractRegistry } from '../../../agent-runtime/src/subagent-output-contracts.js';
 
+import type { SubagentContractRegistry } from '../../../agent-runtime/src/subagent-output-contracts.js';
 import {
   createMoltNetTools,
   HOST_EXEC_DEFAULT_BASE_ENV,

--- a/libs/pi-extension/src/runtime/execute-pi-task.ts
+++ b/libs/pi-extension/src/runtime/execute-pi-task.ts
@@ -34,6 +34,7 @@ import { Value } from '@sinclair/typebox/value';
 import {
   buildTaskUserPrompt,
   type ClaimedTask,
+  type SubagentContractRegistry,
   TaskContext,
   type TaskOutput,
   type TaskReporter,
@@ -43,7 +44,6 @@ import {
 } from '@themoltnet/agent-runtime';
 import { connect } from '@themoltnet/sdk';
 
-import type { SubagentContractRegistry } from '../../../agent-runtime/src/subagent-output-contracts.js';
 import {
   createMoltNetTools,
   HOST_EXEC_DEFAULT_BASE_ENV,

--- a/libs/pi-extension/src/runtime/execute-pi-task.ts
+++ b/libs/pi-extension/src/runtime/execute-pi-task.ts
@@ -390,11 +390,7 @@ export async function executePiTask(
     // Resolve the dedicated worktree after the reporter is live so path
     // collisions / git metadata errors also reach the task attempt stream.
     try {
-      workspace = prepareTaskWorkspace(
-        task,
-        requestedMountPath,
-        executionPlan,
-      );
+      workspace = prepareTaskWorkspace(task, requestedMountPath, executionPlan);
       mountPath = workspace.mountPath;
       cwdPath = workspace.cwdPath;
     } catch (err) {

--- a/libs/pi-extension/src/runtime/execute-pi-task.ts
+++ b/libs/pi-extension/src/runtime/execute-pi-task.ts
@@ -134,6 +134,17 @@ export interface ExecutePiTaskOptions {
    */
   checkpointPath?: string;
   /**
+   * Lazy checkpoint resolver used by `createPiTaskExecutor` so snapshot
+   * creation can happen after the reporter has been opened and can surface
+   * setup failures as task messages.
+   */
+  resolveCheckpointPath?: () => Promise<string>;
+  /**
+   * Set when the caller already opened the reporter before handing control
+   * to `executePiTask`.
+   */
+  reporterAlreadyOpened?: boolean;
+  /**
    * Optional callback invoked alongside every `reporter.record()` so
    * the daemon can mirror task messages into its local logger.
    * Bound at executor-construction time — use when one task runs per
@@ -206,19 +217,30 @@ export function createPiTaskExecutor(
   let cachedCheckpoint: string | null = opts.checkpointPath ?? null;
 
   return async (claimedTask, reporter) => {
-    if (!cachedCheckpoint) {
-      cachedCheckpoint = await ensureSnapshot({
-        config: opts.sandboxConfig?.snapshot,
-        onProgress:
-          opts.onSnapshotProgress ??
-          ((m) => {
-            process.stderr.write(`[snapshot] ${m}\n`);
-          }),
+    const reporterWasOpened = !reporter.cancelSignal.aborted;
+    if (reporterWasOpened) {
+      await reporter.open({
+        taskId: claimedTask.task.id,
+        attemptN: claimedTask.attemptN,
       });
     }
     return executePiTask(claimedTask, reporter, {
       ...opts,
       checkpointPath: cachedCheckpoint,
+      resolveCheckpointPath: async () => {
+        if (!cachedCheckpoint) {
+          cachedCheckpoint = await ensureSnapshot({
+            config: opts.sandboxConfig?.snapshot,
+            onProgress:
+              opts.onSnapshotProgress ??
+              ((m) => {
+                process.stderr.write(`[snapshot] ${m}\n`);
+              }),
+          });
+        }
+        return cachedCheckpoint;
+      },
+      reporterAlreadyOpened: reporterWasOpened,
     });
   };
 }
@@ -239,12 +261,8 @@ export async function executePiTask(
   const startTime = Date.now();
   const requestedMountPath = opts.mountPath ?? process.cwd();
   const executionPlan = opts.makeExecutionPlan?.(claimedTask) ?? null;
-  const workspace = prepareTaskWorkspace(
-    task,
-    requestedMountPath,
-    executionPlan,
-  );
-  const mountPath = workspace.mountPath;
+  let workspace: Awaited<ReturnType<typeof prepareTaskWorkspace>> | null = null;
+  let mountPath = requestedMountPath;
 
   // Pre-execute cancel guard. If the reporter's cancel signal is already
   // aborted (the imposer cancelled between claim and executor entry), don't
@@ -269,46 +287,8 @@ export async function executePiTask(
     };
   }
 
-  const checkpointPath =
-    opts.checkpointPath ??
-    (await ensureSnapshot({
-      config: opts.sandboxConfig?.snapshot,
-      onProgress:
-        opts.onSnapshotProgress ??
-        ((m) => {
-          process.stderr.write(`[snapshot] ${m}\n`);
-        }),
-    }));
-
-  // Repair worktree pointers on the host before the VM mounts the tree.
-  // Mirrors the interactive extension (libs/pi-extension/src/index.ts):
-  // rewrites each worktree's `.git` pointer and backlink to relative form
-  // so the VM (which sees the tree at `/workspace`) can still follow them,
-  // provided the worktree's relative depth from the main repo matches the
-  // VM's layout. No-op if nothing needs fixing.
-  const mainRepoForRepair = findMainWorktree();
-  try {
-    execFileSync(
-      'git',
-      ['-C', mainRepoForRepair, 'worktree', 'repair', '--relative-paths'],
-      { stdio: 'pipe' },
-    );
-  } catch {
-    // Best-effort — older git versions lack --relative-paths.
-  }
-
+  let reporterOpen = opts.reporterAlreadyOpened ?? false;
   let managed: Awaited<ReturnType<typeof resumeVm>> | null = null;
-  managed = await resumeVm({
-    checkpointPath,
-    agentName: opts.agentName,
-    mountPath,
-    extraAllowedHosts: opts.extraAllowedHosts,
-    sandboxConfig: opts.sandboxConfig,
-  });
-
-  const diaryId = task.diaryId ?? '';
-  const taskTeamId = task.teamId ?? '';
-  let reporterOpen = false;
   let session: AgentSession | null = null;
   // Tracked at function scope so the post-prompt summary block can
   // read the call counter even though the handle is only constructed
@@ -335,48 +315,137 @@ export async function executePiTask(
     error: { code, message, retryable: false },
   });
 
-  try {
-    const mainRepo = findMainWorktree();
-    activateAgentEnv(managed.credentials.agentEnv, mainRepo);
+  // Resolve the handler once per task. The factory wins when set so
+  // poll-mode callers can bind per-task context (taskId, attemptN);
+  // factory throws are caught and downgraded to a stderr line so a
+  // misbehaving caller can't sink the executor.
+  let onTurnEvent: TurnEventHandler;
+  if (opts.makeOnTurnEvent) {
+    try {
+      onTurnEvent = opts.makeOnTurnEvent(claimedTask);
+    } catch (err) {
+      process.stderr.write(
+        `[emit] makeOnTurnEvent threw: ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      onTurnEvent = noopTurnEventHandler;
+    }
+  } else {
+    onTurnEvent = opts.onTurnEvent ?? noopTurnEventHandler;
+  }
+  const emit = (
+    kind: TurnEventKind,
+    payload: Record<string, unknown>,
+  ): Promise<void> => {
+    // Local mirror first; surface any throw on stderr so callback
+    // bugs don't go silent, but never let them propagate — the
+    // reporter side is what matters for task semantics.
+    try {
+      onTurnEvent(kind, summarizePayloadForLog(kind, payload));
+    } catch (err) {
+      process.stderr.write(
+        `[emit] onTurnEvent threw for kind="${kind}": ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+    return reporter.record({ kind, payload });
+  };
+  const emitError = async (
+    phase: string,
+    message: string,
+    extra: Record<string, unknown> = {},
+  ): Promise<void> => {
+    await emit('error', { phase, message, ...extra });
+  };
 
-    await reporter.open({ taskId: task.id, attemptN });
+  try {
+    if (!opts.reporterAlreadyOpened) {
+      await reporter.open({ taskId: task.id, attemptN });
+    }
     reporterOpen = true;
 
-    // Resolve the handler once per task. The factory wins when set so
-    // poll-mode callers can bind per-task context (taskId, attemptN);
-    // factory throws are caught and downgraded to a stderr line so a
-    // misbehaving caller can't sink the executor.
-    let onTurnEvent: TurnEventHandler;
-    if (opts.makeOnTurnEvent) {
-      try {
-        onTurnEvent = opts.makeOnTurnEvent(claimedTask);
-      } catch (err) {
-        process.stderr.write(
-          `[emit] makeOnTurnEvent threw: ` +
-            `${err instanceof Error ? err.message : String(err)}\n`,
-        );
-        onTurnEvent = noopTurnEventHandler;
-      }
-    } else {
-      onTurnEvent = opts.onTurnEvent ?? noopTurnEventHandler;
+    // Resolve the snapshot after the reporter has been opened so build
+    // failures can surface as task messages instead of only daemon logs.
+    let checkpointPath: string;
+    try {
+      checkpointPath =
+        opts.checkpointPath ??
+        (opts.resolveCheckpointPath
+          ? await opts.resolveCheckpointPath()
+          : await ensureSnapshot({
+              config: opts.sandboxConfig?.snapshot,
+              onProgress:
+                opts.onSnapshotProgress ??
+                ((m) => {
+                  process.stderr.write(`[snapshot] ${m}\n`);
+                }),
+            }));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await emitError('snapshot', message);
+      return makeFailedOutput('snapshot_failed', message);
     }
-    const emit = (
-      kind: TurnEventKind,
-      payload: Record<string, unknown>,
-    ): Promise<void> => {
-      // Local mirror first; surface any throw on stderr so callback
-      // bugs don't go silent, but never let them propagate — the
-      // reporter side is what matters for task semantics.
+
+    // Resolve the dedicated worktree after the reporter is live so path
+    // collisions / git metadata errors also reach the task attempt stream.
+    try {
+      workspace = prepareTaskWorkspace(
+        task,
+        requestedMountPath,
+        executionPlan,
+      );
+      mountPath = workspace.mountPath;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await emitError('worktree_setup', message);
+      return makeFailedOutput('worktree_setup_failed', message);
+    }
+
+    // Repair worktree pointers on the host before the VM mounts the tree.
+    // Mirrors the interactive extension (libs/pi-extension/src/index.ts):
+    // rewrites each worktree's `.git` pointer and backlink to relative form
+    // so the VM (which sees the tree at `/workspace`) can still follow them,
+    // provided the worktree's relative depth from the main repo matches the
+    // VM's layout. No-op if nothing needs fixing.
+    try {
+      const mainRepoForRepair = findMainWorktree();
       try {
-        onTurnEvent(kind, summarizePayloadForLog(kind, payload));
-      } catch (err) {
-        process.stderr.write(
-          `[emit] onTurnEvent threw for kind="${kind}": ` +
-            `${err instanceof Error ? err.message : String(err)}\n`,
+        execFileSync(
+          'git',
+          ['-C', mainRepoForRepair, 'worktree', 'repair', '--relative-paths'],
+          { stdio: 'pipe' },
         );
+      } catch {
+        // Best-effort — older git versions lack --relative-paths.
       }
-      return reporter.record({ kind, payload });
-    };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await emitError('worktree_setup', message);
+      return makeFailedOutput('worktree_setup_failed', message);
+    }
+
+    try {
+      managed = await resumeVm({
+        checkpointPath,
+        agentName: opts.agentName,
+        mountPath,
+        extraAllowedHosts: opts.extraAllowedHosts,
+        sandboxConfig: opts.sandboxConfig,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await emitError('vm_resume', message);
+      return makeFailedOutput('vm_resume_failed', message);
+    }
+
+    const diaryId = task.diaryId ?? '';
+    const taskTeamId = task.teamId ?? '';
+    const mainRepo = findMainWorktree();
+    activateAgentEnv(managed.credentials.agentEnv, mainRepo);
+    const activeWorkspace = workspace;
+    if (!activeWorkspace) {
+      throw new Error('task workspace not prepared');
+    }
 
     await emit('info', {
       event: 'execute_start',
@@ -384,8 +453,8 @@ export async function executePiTask(
       teamId: task.teamId,
       provider: opts.provider,
       model: opts.model,
-      workspaceMode: workspace.mode,
-      workspaceBranch: workspace.branch,
+      workspaceMode: activeWorkspace.mode,
+      workspaceBranch: activeWorkspace.branch,
     });
 
     let taskPrompt: string;
@@ -393,7 +462,10 @@ export async function executePiTask(
       const promptCtx: TaskUserPromptContext = {
         diaryId,
         taskId: task.id,
-        workspace: { mode: workspace.mode, branch: workspace.branch },
+        workspace: {
+          mode: activeWorkspace.mode,
+          branch: activeWorkspace.branch,
+        },
         extras: opts.promptExtras,
       };
       taskPrompt = buildTaskUserPrompt(task, promptCtx);
@@ -682,6 +754,18 @@ export async function executePiTask(
             result: event.isError ? truncateForWire(event.result) : undefined,
           }),
         );
+        if (event.isError) {
+          track(
+            emitError(
+              'tool_call_error',
+              describeToolErrorMessage(event.result),
+              {
+                tool: event.toolName,
+                result: truncateForWire(event.result),
+              },
+            ),
+          );
+        }
         // Bash-timeout cap. pi's bash tool wraps timeout errors with the
         // text "Command timed out after <N> seconds" (see
         // @earendil-works/pi-coding-agent's bash.js error path). We
@@ -990,14 +1074,16 @@ export async function executePiTask(
     if (managed) {
       await managed.vm.close();
     }
-    try {
-      workspace.cleanup();
-    } catch (err) {
-      const detail = err instanceof Error ? err.message : String(err);
-      console.error(
-        `executePiTask: workspace cleanup failed for task ${task.id} ` +
-          `attempt ${attemptN}: ${detail}`,
-      );
+    if (workspace) {
+      try {
+        workspace.cleanup();
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        console.error(
+          `executePiTask: workspace cleanup failed for task ${task.id} ` +
+            `attempt ${attemptN}: ${detail}`,
+        );
+      }
     }
   }
 }
@@ -1157,5 +1243,31 @@ function truncateForWire(value: unknown): unknown {
     };
   } catch {
     return { truncated: '[unserializable]', original_size: -1 };
+  }
+}
+
+export function describeToolErrorMessage(result: unknown): string {
+  if (typeof result === 'string' && result.trim().length > 0) {
+    return result.trim();
+  }
+  if (result && typeof result === 'object') {
+    const content = (result as { content?: unknown }).content;
+    if (Array.isArray(content)) {
+      for (const item of content) {
+        if (
+          item &&
+          typeof item === 'object' &&
+          typeof (item as { text?: unknown }).text === 'string'
+        ) {
+          const text = (item as { text: string }).text.trim();
+          if (text.length > 0) return text;
+        }
+      }
+    }
+  }
+  try {
+    return JSON.stringify(truncateForWire(result));
+  } catch {
+    return 'Tool call failed';
   }
 }

--- a/libs/pi-extension/src/runtime/execute-pi-task.ts
+++ b/libs/pi-extension/src/runtime/execute-pi-task.ts
@@ -34,7 +34,6 @@ import { Value } from '@sinclair/typebox/value';
 import {
   buildTaskUserPrompt,
   type ClaimedTask,
-  type SubagentContractRegistry,
   TaskContext,
   type TaskOutput,
   type TaskReporter,
@@ -43,6 +42,7 @@ import {
   type TaskUserPromptContext,
 } from '@themoltnet/agent-runtime';
 import { connect } from '@themoltnet/sdk';
+import type { SubagentContractRegistry } from '../../../agent-runtime/src/subagent-output-contracts.js';
 
 import {
   createMoltNetTools,
@@ -226,7 +226,7 @@ export function createPiTaskExecutor(
     }
     return executePiTask(claimedTask, reporter, {
       ...opts,
-      checkpointPath: cachedCheckpoint,
+      checkpointPath: cachedCheckpoint ?? undefined,
       resolveCheckpointPath: async () => {
         if (!cachedCheckpoint) {
           cachedCheckpoint = await ensureSnapshot({

--- a/libs/pi-extension/src/runtime/execute-pi-task.ts
+++ b/libs/pi-extension/src/runtime/execute-pi-task.ts
@@ -263,6 +263,7 @@ export async function executePiTask(
   const executionPlan = opts.makeExecutionPlan?.(claimedTask) ?? null;
   let workspace: Awaited<ReturnType<typeof prepareTaskWorkspace>> | null = null;
   let mountPath = requestedMountPath;
+  let cwdPath = requestedMountPath;
 
   // Pre-execute cancel guard. If the reporter's cancel signal is already
   // aborted (the imposer cancelled between claim and executor entry), don't
@@ -395,6 +396,7 @@ export async function executePiTask(
         executionPlan,
       );
       mountPath = workspace.mountPath;
+      cwdPath = workspace.cwdPath;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       await emitError('worktree_setup', message);
@@ -560,7 +562,7 @@ export async function executePiTask(
         clearSessionErrors: () => {
           /* no-op in headless mode */
         },
-        getHostCwd: () => mountPath,
+        getHostCwd: () => cwdPath,
         hostExecBaseEnv,
         hostExecAutoApprove:
           opts.hostExecAutoApprove ??
@@ -634,6 +636,7 @@ export async function executePiTask(
       if (taskTypeUsesSubagents(task.taskType)) {
         subagentHandle = createSubagentTool({
           mountPath,
+          cwdPath,
           piAuthDir,
           modelHandle,
           agentName: opts.agentName,
@@ -654,6 +657,7 @@ export async function executePiTask(
 
       session = await buildAgentSession({
         mountPath,
+        cwdPath,
         piAuthDir,
         modelHandle,
         agentName: opts.agentName,

--- a/libs/pi-extension/src/runtime/subagent-tool.test.ts
+++ b/libs/pi-extension/src/runtime/subagent-tool.test.ts
@@ -11,11 +11,11 @@ import type {
   ToolDefinition,
 } from '@earendil-works/pi-coding-agent';
 import { Type } from '@sinclair/typebox';
-import { createSubagentContractRegistry } from '@themoltnet/agent-runtime';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { BuildAgentSessionArgs } from './agent-session-factory.js';
 import { createSubagentTool } from './subagent-tool.js';
+import { createSubagentContractRegistry } from '../../../agent-runtime/src/subagent-output-contracts.js';
 
 const SubagentResult = Type.Object({
   verdict: Type.String({ minLength: 1 }),

--- a/libs/pi-extension/src/runtime/subagent-tool.test.ts
+++ b/libs/pi-extension/src/runtime/subagent-tool.test.ts
@@ -13,9 +13,9 @@ import type {
 import { Type } from '@sinclair/typebox';
 import { describe, expect, it, vi } from 'vitest';
 
+import { createSubagentContractRegistry } from '../../../agent-runtime/src/subagent-output-contracts.js';
 import type { BuildAgentSessionArgs } from './agent-session-factory.js';
 import { createSubagentTool } from './subagent-tool.js';
-import { createSubagentContractRegistry } from '../../../agent-runtime/src/subagent-output-contracts.js';
 
 const SubagentResult = Type.Object({
   verdict: Type.String({ minLength: 1 }),

--- a/libs/pi-extension/src/runtime/subagent-tool.test.ts
+++ b/libs/pi-extension/src/runtime/subagent-tool.test.ts
@@ -11,9 +11,9 @@ import type {
   ToolDefinition,
 } from '@earendil-works/pi-coding-agent';
 import { Type } from '@sinclair/typebox';
+import { createSubagentContractRegistry } from '@themoltnet/agent-runtime';
 import { describe, expect, it, vi } from 'vitest';
 
-import { createSubagentContractRegistry } from '../../../agent-runtime/src/subagent-output-contracts.js';
 import type { BuildAgentSessionArgs } from './agent-session-factory.js';
 import { createSubagentTool } from './subagent-tool.js';
 

--- a/libs/pi-extension/src/runtime/subagent-tool.ts
+++ b/libs/pi-extension/src/runtime/subagent-tool.ts
@@ -40,8 +40,8 @@ import type {
 import { defineTool } from '@earendil-works/pi-coding-agent';
 import { type Static, type TObject, Type } from '@sinclair/typebox';
 import { Value } from '@sinclair/typebox/value';
+import type { SubagentContractRegistry } from '@themoltnet/agent-runtime';
 
-import type { SubagentContractRegistry } from '../../../agent-runtime/src/subagent-output-contracts.js';
 import {
   buildAgentSession as defaultBuildAgentSession,
   type BuildAgentSessionArgs,

--- a/libs/pi-extension/src/runtime/subagent-tool.ts
+++ b/libs/pi-extension/src/runtime/subagent-tool.ts
@@ -41,11 +41,11 @@ import { defineTool } from '@earendil-works/pi-coding-agent';
 import { type Static, type TObject, Type } from '@sinclair/typebox';
 import { Value } from '@sinclair/typebox/value';
 
+import type { SubagentContractRegistry } from '../../../agent-runtime/src/subagent-output-contracts.js';
 import {
   buildAgentSession as defaultBuildAgentSession,
   type BuildAgentSessionArgs,
 } from './agent-session-factory.js';
-import type { SubagentContractRegistry } from '../../../agent-runtime/src/subagent-output-contracts.js';
 
 const SUBAGENT_SUBMIT_TOOL_NAME = 'submit_subagent_output';
 

--- a/libs/pi-extension/src/runtime/subagent-tool.ts
+++ b/libs/pi-extension/src/runtime/subagent-tool.ts
@@ -40,12 +40,12 @@ import type {
 import { defineTool } from '@earendil-works/pi-coding-agent';
 import { type Static, type TObject, Type } from '@sinclair/typebox';
 import { Value } from '@sinclair/typebox/value';
-import type { SubagentContractRegistry } from '@themoltnet/agent-runtime';
 
 import {
   buildAgentSession as defaultBuildAgentSession,
   type BuildAgentSessionArgs,
 } from './agent-session-factory.js';
+import type { SubagentContractRegistry } from '../../../agent-runtime/src/subagent-output-contracts.js';
 
 const SUBAGENT_SUBMIT_TOOL_NAME = 'submit_subagent_output';
 

--- a/libs/pi-extension/src/runtime/subagent-tool.ts
+++ b/libs/pi-extension/src/runtime/subagent-tool.ts
@@ -82,6 +82,8 @@ export type SubagentToolParameters = Static<typeof SubagentToolParameters>;
 export interface CreateSubagentToolArgs {
   /** Host directory mounted at /workspace inside the VM. */
   mountPath: string;
+  /** Host working directory the subagent should start in. Defaults to mountPath. */
+  cwdPath?: string;
   /** pi auth directory the parent resolved. */
   piAuthDir: string;
   /** Resolved pi model handle — subagents share it. */
@@ -264,6 +266,7 @@ export function createSubagentTool(
 
       const session = await buildSession({
         mountPath: args.mountPath,
+        cwdPath: args.cwdPath ?? args.mountPath,
         piAuthDir: args.piAuthDir,
         modelHandle: args.modelHandle,
         agentName: args.agentName,

--- a/libs/pi-extension/src/runtime/task-workspace.ts
+++ b/libs/pi-extension/src/runtime/task-workspace.ts
@@ -9,6 +9,7 @@ import type { PiTaskExecutionPlan } from './execution-plan.js';
 
 export interface PreparedTaskWorkspace {
   mountPath: string;
+  cwdPath: string;
   mode: 'shared_mount' | 'dedicated_worktree';
   branch: string | null;
   cleanup: () => void;
@@ -23,6 +24,7 @@ export function prepareTaskWorkspace(
   if (!branch) {
     return {
       mountPath: requestedMountPath,
+      cwdPath: requestedMountPath,
       mode: 'shared_mount',
       branch: null,
       cleanup: () => {},
@@ -34,7 +36,7 @@ export function prepareTaskWorkspace(
   const worktreeDir = resolveTaskWorktreePath(mainRepo, workspaceId);
 
   const relMount = relative(mainRepo, requestedMountPath);
-  const mountPath =
+  const cwdPath =
     relMount === '' || relMount.startsWith('..')
       ? worktreeDir
       : join(worktreeDir, relMount);
@@ -50,7 +52,8 @@ export function prepareTaskWorkspace(
   }
 
   return {
-    mountPath,
+    mountPath: mainRepo,
+    cwdPath,
     mode: 'dedicated_worktree',
     branch,
     cleanup: keepWorkspace

--- a/libs/pi-extension/src/vm-manager.test.ts
+++ b/libs/pi-extension/src/vm-manager.test.ts
@@ -10,7 +10,6 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
-  realpathSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
@@ -451,14 +450,22 @@ describe('dedicated worktree mount topology', () => {
     }).trim();
   }
 
-  it('loses git repository visibility when only the nested worktree is mounted', () => {
+  function resolveGitdirPointer(worktreeDir: string, gitdirPointer: string) {
+    const prefix = 'gitdir: ';
+    expect(gitdirPointer.startsWith(prefix)).toBe(true);
+    const target = gitdirPointer.slice(prefix.length).trim();
+    return path.isAbsolute(target)
+      ? target
+      : path.resolve(worktreeDir, target);
+  }
+
+  it('points outside the mounted subtree when only the nested worktree is mounted', () => {
     const repoRoot = mkdtempSync(path.join(tmpdir(), 'pi-worktree-repro-'));
     const guestRoot = mkdtempSync(path.join(tmpdir(), 'pi-guest-mount-'));
     const oldCwd = process.cwd();
     let workspace: { mountPath: string; cleanup: () => void } | null = null;
 
     try {
-      const repoRootReal = realpathSync(repoRoot);
       runGit(repoRoot, ['init']);
       runGit(repoRoot, ['config', 'user.name', 'Test User']);
       runGit(repoRoot, ['config', 'user.email', 'test@example.com']);
@@ -490,20 +497,22 @@ describe('dedicated worktree mount topology', () => {
       const gitdirPointer = readFileSync(path.join(guestWorkspace, '.git'), {
         encoding: 'utf8',
       }).trim();
-      expect(gitdirPointer).toBe(
-        `gitdir: ${repoRootReal}/.git/worktrees/session-slot-1`,
+      const resolvedGitdir = resolveGitdirPointer(guestWorkspace, gitdirPointer);
+
+      expect(resolvedGitdir.startsWith(guestRoot)).toBe(false);
+      expect(resolvedGitdir).toContain(
+        `${path.sep}.git${path.sep}worktrees${path.sep}session-slot-1`,
       );
-
-      workspace.cleanup();
-      workspace = null;
-      rmSync(repoRoot, { recursive: true, force: true });
-
-      expect(() =>
-        runGit(guestWorkspace, ['rev-parse', '--git-dir']),
-      ).toThrow(/not a git repository|could not read gitdir/i);
+      expect(
+        readFileSync(path.join(resolvedGitdir, 'gitdir'), 'utf8').trim(),
+      ).not.toBe(guestWorkspace);
+      expect(
+        path.relative(guestRoot, resolvedGitdir).startsWith('..'),
+      ).toBe(true);
     } finally {
       process.chdir(oldCwd);
       workspace?.cleanup();
+      rmSync(repoRoot, { recursive: true, force: true });
       rmSync(guestRoot, { recursive: true, force: true });
     }
   });

--- a/libs/pi-extension/src/vm-manager.test.ts
+++ b/libs/pi-extension/src/vm-manager.test.ts
@@ -485,7 +485,7 @@ describe('dedicated worktree mount topology', () => {
           brief: 'demo task',
           title: 'demo task',
         },
-      } as Parameters<typeof prepareTaskWorkspace>[0];
+      } as unknown as Parameters<typeof prepareTaskWorkspace>[0];
 
       workspace = prepareTaskWorkspace(task, repoRoot, {
         sessionKey: 'slot-1',

--- a/libs/pi-extension/src/vm-manager.test.ts
+++ b/libs/pi-extension/src/vm-manager.test.ts
@@ -4,7 +4,16 @@
  *   - loadCredentials: PEM reading and filename extraction
  *   - ensureRelativeWorktreePaths: gitconfig mutation (pre-existing)
  */
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -15,6 +24,7 @@ import {
   loadCredentials,
   rewriteMoltnetJsonPaths,
 } from './vm-manager.js';
+import { prepareTaskWorkspace } from './runtime/task-workspace.js';
 
 // ---------------------------------------------------------------------------
 // rewriteMoltnetJsonPaths
@@ -425,5 +435,76 @@ describe('ensureRelativeWorktreePaths', () => {
     const out = ensureRelativeWorktreePaths(gc);
     expect((out.match(/useRelativePaths/g) ?? []).length).toBe(1);
     expect(out).toContain('useRelativePaths = true');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dedicated worktree mount topology
+// ---------------------------------------------------------------------------
+
+describe('dedicated worktree mount topology', () => {
+  function runGit(cwd: string, args: string[]): string {
+    return execFileSync('git', args, {
+      cwd,
+      encoding: 'utf8',
+      stdio: 'pipe',
+    }).trim();
+  }
+
+  it('loses git repository visibility when only the nested worktree is mounted', () => {
+    const repoRoot = mkdtempSync(path.join(tmpdir(), 'pi-worktree-repro-'));
+    const guestRoot = mkdtempSync(path.join(tmpdir(), 'pi-guest-mount-'));
+    const oldCwd = process.cwd();
+    let workspace: { mountPath: string; cleanup: () => void } | null = null;
+
+    try {
+      const repoRootReal = realpathSync(repoRoot);
+      runGit(repoRoot, ['init']);
+      runGit(repoRoot, ['config', 'user.name', 'Test User']);
+      runGit(repoRoot, ['config', 'user.email', 'test@example.com']);
+      writeFileSync(path.join(repoRoot, 'README.md'), 'seed\n', 'utf8');
+      runGit(repoRoot, ['add', 'README.md']);
+      runGit(repoRoot, ['commit', '-m', 'seed']);
+
+      process.chdir(repoRoot);
+      const task = {
+        id: 'task-1',
+        taskType: 'fulfill_brief',
+        correlationId: 'correlation-1',
+        input: {
+          brief: 'demo task',
+          title: 'demo task',
+        },
+      } as Parameters<typeof prepareTaskWorkspace>[0];
+
+      workspace = prepareTaskWorkspace(task, repoRoot, {
+        sessionKey: 'slot-1',
+        workspaceId: 'session-slot-1',
+        worktreeBranch: 'moltnet/correlation-1/demo-task',
+        workspaceScope: 'session',
+      });
+
+      const guestWorkspace = path.join(guestRoot, 'workspace');
+      cpSync(workspace.mountPath, guestWorkspace, { recursive: true });
+
+      const gitdirPointer = readFileSync(path.join(guestWorkspace, '.git'), {
+        encoding: 'utf8',
+      }).trim();
+      expect(gitdirPointer).toBe(
+        `gitdir: ${repoRootReal}/.git/worktrees/session-slot-1`,
+      );
+
+      workspace.cleanup();
+      workspace = null;
+      rmSync(repoRoot, { recursive: true, force: true });
+
+      expect(() =>
+        runGit(guestWorkspace, ['rev-parse', '--git-dir']),
+      ).toThrow(/not a git repository|could not read gitdir/i);
+    } finally {
+      process.chdir(oldCwd);
+      workspace?.cleanup();
+      rmSync(guestRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/libs/pi-extension/src/vm-manager.test.ts
+++ b/libs/pi-extension/src/vm-manager.test.ts
@@ -9,8 +9,8 @@ import {
   cpSync,
   mkdirSync,
   mkdtempSync,
-  realpathSync,
   readFileSync,
+  realpathSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
@@ -19,12 +19,12 @@ import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
+import { prepareTaskWorkspace } from './runtime/task-workspace.js';
 import {
   ensureRelativeWorktreePaths,
   loadCredentials,
   rewriteMoltnetJsonPaths,
 } from './vm-manager.js';
-import { prepareTaskWorkspace } from './runtime/task-workspace.js';
 
 // ---------------------------------------------------------------------------
 // rewriteMoltnetJsonPaths
@@ -455,18 +455,18 @@ describe('dedicated worktree mount topology', () => {
     const prefix = 'gitdir: ';
     expect(gitdirPointer.startsWith(prefix)).toBe(true);
     const target = gitdirPointer.slice(prefix.length).trim();
-    return path.isAbsolute(target)
-      ? target
-      : path.resolve(worktreeDir, target);
+    return path.isAbsolute(target) ? target : path.resolve(worktreeDir, target);
   }
 
   it('keeps worktree git metadata reachable when mounting the repo root', () => {
     const repoRoot = mkdtempSync(path.join(tmpdir(), 'pi-worktree-repro-'));
     const guestRoot = mkdtempSync(path.join(tmpdir(), 'pi-guest-mount-'));
     const oldCwd = process.cwd();
-    let workspace:
-      | { mountPath: string; cwdPath: string; cleanup: () => void }
-      | null = null;
+    let workspace: {
+      mountPath: string;
+      cwdPath: string;
+      cleanup: () => void;
+    } | null = null;
 
     try {
       runGit(repoRoot, ['init']);
@@ -505,7 +505,10 @@ describe('dedicated worktree mount topology', () => {
       const gitdirPointer = readFileSync(path.join(guestWorkspace, '.git'), {
         encoding: 'utf8',
       }).trim();
-      const resolvedGitdir = resolveGitdirPointer(guestWorkspace, gitdirPointer);
+      const resolvedGitdir = resolveGitdirPointer(
+        guestWorkspace,
+        gitdirPointer,
+      );
 
       expect(resolvedGitdir.startsWith(guestRoot)).toBe(true);
       expect(resolvedGitdir).toContain(

--- a/libs/pi-extension/src/vm-manager.test.ts
+++ b/libs/pi-extension/src/vm-manager.test.ts
@@ -9,6 +9,7 @@ import {
   cpSync,
   mkdirSync,
   mkdtempSync,
+  realpathSync,
   readFileSync,
   rmSync,
   writeFileSync,
@@ -459,11 +460,13 @@ describe('dedicated worktree mount topology', () => {
       : path.resolve(worktreeDir, target);
   }
 
-  it('points outside the mounted subtree when only the nested worktree is mounted', () => {
+  it('keeps worktree git metadata reachable when mounting the repo root', () => {
     const repoRoot = mkdtempSync(path.join(tmpdir(), 'pi-worktree-repro-'));
     const guestRoot = mkdtempSync(path.join(tmpdir(), 'pi-guest-mount-'));
     const oldCwd = process.cwd();
-    let workspace: { mountPath: string; cleanup: () => void } | null = null;
+    let workspace:
+      | { mountPath: string; cwdPath: string; cleanup: () => void }
+      | null = null;
 
     try {
       runGit(repoRoot, ['init']);
@@ -490,25 +493,37 @@ describe('dedicated worktree mount topology', () => {
         worktreeBranch: 'moltnet/correlation-1/demo-task',
         workspaceScope: 'session',
       });
+      runGit(repoRoot, ['worktree', 'repair', '--relative-paths']);
 
-      const guestWorkspace = path.join(guestRoot, 'workspace');
-      cpSync(workspace.mountPath, guestWorkspace, { recursive: true });
+      const guestMountRoot = path.join(guestRoot, 'workspace');
+      cpSync(workspace.mountPath, guestMountRoot, { recursive: true });
+      const guestWorkspace = path.join(
+        guestMountRoot,
+        path.relative(workspace.mountPath, workspace.cwdPath),
+      );
 
       const gitdirPointer = readFileSync(path.join(guestWorkspace, '.git'), {
         encoding: 'utf8',
       }).trim();
       const resolvedGitdir = resolveGitdirPointer(guestWorkspace, gitdirPointer);
 
-      expect(resolvedGitdir.startsWith(guestRoot)).toBe(false);
+      expect(resolvedGitdir.startsWith(guestRoot)).toBe(true);
       expect(resolvedGitdir).toContain(
         `${path.sep}.git${path.sep}worktrees${path.sep}session-slot-1`,
       );
+      const adminBacklink = readFileSync(
+        path.join(resolvedGitdir, 'gitdir'),
+        'utf8',
+      ).trim();
+      expect(path.resolve(resolvedGitdir, adminBacklink)).toBe(
+        path.join(guestWorkspace, '.git'),
+      );
       expect(
-        readFileSync(path.join(resolvedGitdir, 'gitdir'), 'utf8').trim(),
-      ).not.toBe(guestWorkspace);
+        realpathSync(runGit(guestWorkspace, ['rev-parse', '--git-dir'])),
+      ).toBe(realpathSync(resolvedGitdir));
       expect(
-        path.relative(guestRoot, resolvedGitdir).startsWith('..'),
-      ).toBe(true);
+        realpathSync(runGit(guestWorkspace, ['rev-parse', '--show-toplevel'])),
+      ).toBe(realpathSync(guestWorkspace));
     } finally {
       process.chdir(oldCwd);
       workspace?.cleanup();

--- a/libs/tasks/src/success-criteria.ts
+++ b/libs/tasks/src/success-criteria.ts
@@ -3,10 +3,10 @@
  * complementary places.
  *
  * Before this envelope existed, criteria were scattered: a vestigial
- * `criteriaCid` column nobody resolved, an `acceptanceCriteria: string[]`
- * field on `fulfill_brief.input` that was "interpreted by the claiming
- * agent," and inline `rubric` / `criteria[]` fields on judgment-task
- * inputs. None of those were machine-verifiable end-to-end.
+ * `criteriaCid` column nobody resolved, free-form prose on
+ * `fulfill_brief.input`, and inline `rubric` / `criteria[]` fields on
+ * judgment-task inputs. None of those were machine-verifiable
+ * end-to-end.
  *
  * This module defines a single, content-addressable envelope an imposer
  * attaches to any task type. It has four orthogonal sections — pick

--- a/libs/tasks/src/task-types/fulfill-brief.ts
+++ b/libs/tasks/src/task-types/fulfill-brief.ts
@@ -20,15 +20,6 @@ export const FulfillBriefInput = Type.Object(
     title: Type.Optional(Type.String()),
 
     /**
-     * Free-form acceptance criteria, interpreted by the claiming agent
-     * during execution. Distinct from `successCriteria`, which is the
-     * machine-verifiable envelope evaluated by the daemon at completion.
-     * Plain prose — kept for backward compat and for hints the executor
-     * cannot machine-check (e.g. "match the existing module's tone").
-     */
-    acceptanceCriteria: Type.Optional(Type.Array(Type.String())),
-
-    /**
      * Imposer-stated, machine-verifiable success criteria. Pinned via
      * the task's `inputCid` (no separate hash needed — `successCriteria`
      * is part of the input body). Optional: when omitted, completion is

--- a/libs/tasks/src/validation.test.ts
+++ b/libs/tasks/src/validation.test.ts
@@ -95,6 +95,21 @@ describe('validateTaskCreateRequest', () => {
       },
     ]);
   });
+
+  it('rejects fulfill_brief acceptanceCriteria as an unknown field', () => {
+    const errors = validateTaskCreateRequest({
+      taskType: 'fulfill_brief',
+      input: {
+        brief: 'Implement feature X',
+        title: 'Feature X',
+        acceptanceCriteria: ['match existing module tone'],
+      },
+    });
+
+    expect(errors.some((e) => e.field.includes('acceptanceCriteria'))).toBe(
+      true,
+    );
+  });
 });
 
 describe('validateTaskOutput', () => {


### PR DESCRIPTION
## Summary
- remove redundant  from 
- surface setup and tool-call failures in task attempt messages with structured phases
- fix dedicated task worktrees by mounting the repo root while starting the session in the dedicated worktree cwd
- add regression coverage for the nested worktree gitdir topology

## Why
Warm-session  tasks were failing because daemon-created dedicated worktrees were mounted as isolated subtrees, which hid  admin metadata from the guest. The interactive pi TUI did not hit the same topology mismatch.

## Testing
- 
 RUN  v3.2.4 /Users/edouard/Dev/getlarge/themoltnet/.worktrees/fix-1154-worktree-session

 ✓ libs/pi-extension/src/vm-manager.test.ts (19 tests) 228ms

 Test Files  1 passed (1)
      Tests  19 passed (19)
   Start at  08:14:32
   Duration  764ms (transform 72ms, setup 0ms, collect 200ms, tests 228ms, environment 0ms, prepare 49ms)
- 
 RUN  v3.2.4 /Users/edouard/Dev/getlarge/themoltnet/.worktrees/fix-1154-worktree-session

 ✓ libs/pi-extension/src/runtime/execute-pi-task.test.ts (31 tests) 23ms

 Test Files  1 passed (1)
      Tests  31 passed (31)
   Start at  08:14:34
   Duration  1.52s (transform 354ms, setup 0ms, collect 1.26s, tests 23ms, environment 0ms, prepare 42ms)

Closes #1154