### PR TITLE
[codex] Reduce rest-api CI shard parallelism

### DIFF
--- a/.nx/workflows/assignment-rules.yml
+++ b/.nx/workflows/assignment-rules.yml
@@ -11,6 +11,16 @@ assignment-rules:
       - agent: linux-medium
         parallelism: 3
 
+  # rest-api's atomized route suites are still expensive per file, and
+  # multiple co-scheduled vitest tasks can starve the parent RPC loop on
+  # 4-vCPU agents. Keep only this project's test-ci shards at 2-way
+  # parallelism while preserving the denser default for the rest.
+  - projects: ['@moltnet/rest-api']
+    targets: ['test-ci--*']
+    run-on:
+      - agent: linux-medium
+        parallelism: 2
+
   # Atomized per-file vitest tasks (test-ci--<file>). Each is a single
   # vitest invocation on one file with bounded RPC pressure, so we can
   # safely co-schedule a few per agent — one of the main reasons we


### PR DESCRIPTION
## What changed
Lowered Nx Cloud assignment parallelism only for `@moltnet/rest-api` atomized `test-ci--*` tasks from 3 to 2 in `.nx/workflows/assignment-rules.yml`.

## Why
The `@moltnet/rest-api:test-ci--__tests__/diary-entries.test.ts` shard has been unstable in CI with Vitest worker RPC timeouts (`[vitest-worker]: Timeout calling "onTaskUpdate"`). The rest-api route suites are relatively expensive per atomized file, and co-scheduling too many of them on a 4-vCPU GitHub-hosted runner can starve Vitest's parent-worker RPC loop.

## Impact
This keeps the denser default scheduling for other atomized test tasks, while making rest-api shards less likely to oversubscribe CPU on Nx Cloud agents.

## Validation
Investigated the failing shard locally and confirmed the exact atomized target passes but takes roughly 32 seconds for a single file, which is consistent with a CI scheduling issue rather than an assertion failure.

No code-path or test logic changes were made.
