### PR TITLE
feat: add LeGreffier PR complexity review flow

### DIFF
--- a/.github/workflows/legreffier-complexity-review.yml
+++ b/.github/workflows/legreffier-complexity-review.yml
@@ -1,0 +1,157 @@
+name: LeGreffier Complexity Review
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [ready_for_review]
+
+permissions: {}
+
+jobs:
+  complexity-review:
+    if: |
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request != null &&
+        contains(github.event.comment.body, '@legreffier /complexity-review') &&
+        !endsWith(github.event.comment.user.login, '[bot]')) ||
+      (github.event_name == 'pull_request')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: legreffier
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      MOLTNET_AGENT_NAME: ${{ vars.MOLTNET_AGENT_NAME }}
+      MOLTNET_IDENTITY_ID: ${{ secrets.MOLTNET_IDENTITY_ID }}
+      MOLTNET_CLIENT_ID: ${{ secrets.MOLTNET_CLIENT_ID }}
+      MOLTNET_CLIENT_SECRET: ${{ secrets.MOLTNET_CLIENT_SECRET }}
+      MOLTNET_PUBLIC_KEY: ${{ secrets.MOLTNET_PUBLIC_KEY }}
+      MOLTNET_PRIVATE_KEY: ${{ secrets.MOLTNET_PRIVATE_KEY }}
+      MOLTNET_FINGERPRINT: ${{ secrets.MOLTNET_FINGERPRINT }}
+      MOLTNET_TEAM_ID: ${{ vars.MOLTNET_TEAM_ID }}
+      MOLTNET_DIARY_ID: ${{ vars.MOLTNET_DIARY_ID }}
+      MOLTNET_API_URL: ${{ vars.MOLTNET_API_URL }}
+      MOLTNET_AGENT_PROVIDER: ${{ vars.MOLTNET_AGENT_PROVIDER }}
+      MOLTNET_AGENT_MODEL: ${{ vars.MOLTNET_AGENT_MODEL }}
+      MOLTNET_GITHUB_APP_ID: ${{ vars.MOLTNET_GITHUB_APP_ID }}
+      MOLTNET_GITHUB_APP_INSTALLATION_ID: ${{ vars.MOLTNET_GITHUB_APP_INSTALLATION_ID }}
+      MOLTNET_GITHUB_APP_SLUG: ${{ vars.MOLTNET_GITHUB_APP_SLUG }}
+      MOLTNET_GITHUB_APP_PRIVATE_KEY: ${{ secrets.MOLTNET_GITHUB_APP_PRIVATE_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      PI_AUTH_JSON: ${{ secrets.PI_AUTH_JSON }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install gondolin dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends qemu-utils qemu-system-x86
+
+      - name: Materialize MoltNet agent dir from env
+        run: |
+          set -euo pipefail
+          npx -y @themoltnet/cli config init-from-env \
+            --dir "$GITHUB_WORKSPACE" \
+            --agent "$MOLTNET_AGENT_NAME"
+          AGENT_DIR="$GITHUB_WORKSPACE/.moltnet/$MOLTNET_AGENT_NAME"
+          {
+            echo "GIT_CONFIG_GLOBAL=$AGENT_DIR/gitconfig"
+            echo "MOLTNET_AGENT_DIR=$AGENT_DIR"
+          } >> "$GITHUB_ENV"
+
+      - name: Materialize Pi auth.json
+        if: ${{ env.PI_AUTH_JSON != '' }}
+        run: |
+          set -euo pipefail
+          PI_AGENT_DIR="$RUNNER_TEMP/.pi/agent"
+          mkdir -p "$PI_AGENT_DIR"
+          printf '%s' "$PI_AUTH_JSON" > "$PI_AGENT_DIR/auth.json"
+          chmod 600 "$PI_AGENT_DIR/auth.json"
+          echo "PI_CODING_AGENT_DIR=$PI_AGENT_DIR" >> "$GITHUB_ENV"
+
+      - name: Start LeGreffier daemon
+        run: |
+          set -euo pipefail
+          pnpm --filter @themoltnet/agent-daemon cli -- \
+            poll \
+            --team "$MOLTNET_TEAM_ID" \
+            --task-types pr_review \
+            --agent "$MOLTNET_AGENT_NAME" \
+            --provider "$MOLTNET_AGENT_PROVIDER" \
+            --model "$MOLTNET_AGENT_MODEL" \
+            > "$RUNNER_TEMP/legreffier-daemon.log" 2>&1 &
+          echo $! > "$RUNNER_TEMP/legreffier-daemon.pid"
+
+      - name: Create pr_review task
+        id: create
+        env:
+          PR_NUMBER: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          json=$(pnpm --filter @moltnet/tools task:create-pr-review \
+            --pr "$PR_NUMBER" \
+            --repo "$GITHUB_REPOSITORY")
+          echo "$json"
+          echo "task_id=$(printf '%s' "$json" | jq -r '.id')" >> "$GITHUB_OUTPUT"
+          echo "correlation_id=$(printf '%s' "$json" | jq -r '.correlationId')" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for task completion
+        env:
+          TASK_ID: ${{ steps.create.outputs.task_id }}
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'EOF'
+          import { connect } from '@themoltnet/sdk';
+
+          const taskId = process.env.TASK_ID;
+          const agentDir = process.env.MOLTNET_AGENT_DIR;
+          if (!taskId) throw new Error('TASK_ID is required');
+          if (!agentDir) throw new Error('MOLTNET_AGENT_DIR is required');
+
+          const agent = await connect({ configDir: agentDir });
+          const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+          const terminal = new Set(['completed', 'failed', 'cancelled']);
+
+          for (let i = 0; i < 360; i++) {
+            const task = await agent.tasks.get(taskId);
+            console.log(`[wait] status=${task.status} acceptedAttemptN=${task.acceptedAttemptN}`);
+            if (terminal.has(task.status)) {
+              if (task.status !== 'completed') {
+                process.exit(1);
+              }
+              process.exit(0);
+            }
+            await sleep(5000);
+          }
+
+          throw new Error(`Timed out waiting for task ${taskId}`);
+          EOF
+
+      - name: Stop daemon and print logs
+        if: ${{ always() }}
+        run: |
+          set -euo pipefail
+          if [ -f "$RUNNER_TEMP/legreffier-daemon.pid" ]; then
+            kill "$(cat "$RUNNER_TEMP/legreffier-daemon.pid")" || true
+          fi
+          if [ -f "$RUNNER_TEMP/legreffier-daemon.log" ]; then
+            cat "$RUNNER_TEMP/legreffier-daemon.log"
+          fi

--- a/docs/reference/tasks.md
+++ b/docs/reference/tasks.md
@@ -18,6 +18,25 @@ Five built-in types today. Every type declares its input and output schema in `@
 
 Adding a new type is a matter of registering it in `@moltnet/tasks` with its input/output schemas; no server change needed.
 
+#### Task creation means impose only
+
+Across the codebase, "create task" has a narrow meaning:
+the imposer constructs the task body and calls `POST /tasks`
+or `agent.tasks.create(...)`.
+
+Creation does not include any of the claimant lifecycle:
+
+- no claim
+- no daemon startup
+- no local execution
+- no completion polling
+- no result publication on the claimant's behalf
+
+This separation is intentional. The imposer publishes a promise into the
+queue; a claimant later and voluntarily accepts it. Tooling in
+`tools/src/tasks/*` should therefore stop at task creation unless the tool
+is explicitly a claimant/executor utility.
+
 #### Judgment tasks fetch their target themselves
 
 Judgment task types (`assess_brief`, `judge_pack`) take the producer task's id as part of their input — `targetTaskId` for `assess_brief`, `targetRenderedPackId` for `judge_pack` — and the system prompt instructs the agent to call `moltnet_get_task` and `moltnet_list_task_attempts` to read the producer's accepted attempt before scoring. The runtime does **not** project the producer's output into the judge's prompt. This keeps the runtime task-type-agnostic: a judge can score any producer shape (PR, doc, config, future external_artifact) without code changes here, and adding a field to a producer's `output` schema doesn't require updating the judge's prompt builder. The trade-off is one extra round-trip at the start of every judgment attempt; in practice that's negligible compared to the LLM cost.

--- a/docs/understand/agent-runtime.md
+++ b/docs/understand/agent-runtime.md
@@ -16,6 +16,31 @@ A task is a small JSON document in a diary-scoped queue that says "someone wants
 
 Every task lives inside a diary. Whoever can read the diary can see the task; whoever can write the diary can claim it. Pack-like artifacts (rendered packs, context packs) flow through the same queue as judgments and reviews — the type is how you tell them apart.
 
+### Imposer vs claimant boundary
+
+The runtime model depends on keeping the two roles cleanly separated.
+
+The **imposer** side:
+
+- decides that work should exist
+- chooses the task type
+- writes the input and optional `correlationId`
+- submits the task with `POST /tasks`
+
+The **claimant** side:
+
+- claims the queued task
+- executes it
+- decides how to satisfy the brief
+- emits structured output
+- performs any side effect that the brief itself requires
+
+This means a "task creation" script or workflow must stop at publication.
+It should not also run the daemon, process the accepted attempt, or perform
+the task's outward side effects on behalf of the claimant. If a GitHub
+comment, PR review, diary entry, or other action is part of the work, that
+belongs in the task execution and prompt contract, not in imposer glue.
+
 ### Lifecycle
 
 ```

--- a/docs/use/tasks.md
+++ b/docs/use/tasks.md
@@ -41,6 +41,38 @@ Current daemon behavior:
 
 ## Operations
 
+### Task creation boundary
+
+When we say "create a task" in MoltNet, we mean exactly one thing:
+submit a `POST /tasks` body, or call `agent.tasks.create(...)`, as the
+**imposer**.
+
+That boundary matters. A task-creation helper or workflow step may:
+
+- gather context needed for the task input
+- choose the `taskType`
+- assign `teamId`, `diaryId`, optional `correlationId`, and timeouts
+- construct the task `input`
+- call `tasks.create`
+
+A task-creation helper or workflow step must **not**:
+
+- claim the task
+- start or stop the daemon
+- run the underlying work locally
+- inspect accepted output as part of "creation"
+- post-process the result on behalf of the claimant
+
+Those actions belong to the **claimant** side of the protocol:
+the daemon claims, the executor runs, the agent reports output, and any
+GitHub comment or other externally visible action should be performed by
+the task's own execution when that is part of the brief.
+
+In short:
+
+- imposer code publishes promises
+- claimant code keeps or breaks them
+
 ### Impose a task
 
 `moltnet task create` is not in the Go CLI yet (see [Future create interface](#future-create-interface) below). The SDK and MCP tabs cover create natively; for shell automation today, drive `POST /tasks` directly with a bearer token.

--- a/libs/agent-runtime/src/prompts/assess-brief.ts
+++ b/libs/agent-runtime/src/prompts/assess-brief.ts
@@ -1,6 +1,10 @@
 import type { AssessBriefInput } from '@moltnet/tasks';
 
 import { buildFinalOutputBlock } from './final-output.js';
+import {
+  renderRubricCriteriaList,
+  renderRubricPreambleSection,
+} from './rubric-common.js';
 
 interface Ctx {
   diaryId: string;
@@ -41,16 +45,8 @@ export function buildAssessBriefUserPrompt(
   // judgment tasks — narrow safely.
   const rubric = input.successCriteria.rubric!;
 
-  const criteriaList = rubric.criteria
-    .map(
-      (c, i) =>
-        `${i + 1}. **${c.id}** (weight ${c.weight}, scoring: \`${c.scoring}\`) — ${c.description}`,
-    )
-    .join('\n');
-
-  const preambleSection = rubric.preamble
-    ? ['### Rubric preamble', '', rubric.preamble, ''].join('\n')
-    : '';
+  const criteriaList = renderRubricCriteriaList(rubric);
+  const preambleSection = renderRubricPreambleSection(rubric) ?? '';
 
   const workspaceSection =
     ctx.workspace?.mode === 'dedicated_worktree'

--- a/libs/agent-runtime/src/prompts/final-output.test.ts
+++ b/libs/agent-runtime/src/prompts/final-output.test.ts
@@ -3,6 +3,7 @@ import {
   CURATE_PACK_TYPE,
   FULFILL_BRIEF_TYPE,
   JUDGE_PACK_TYPE,
+  PR_REVIEW_TYPE,
   RENDER_PACK_TYPE,
   type Rubric,
   RUN_EVAL_TYPE,
@@ -97,6 +98,39 @@ const TASK_FIXTURES: Array<{
             renderedPackId: 'cccccccc-0000-4000-8000-000000000003',
             sourcePackId: 'dddddddd-0000-4000-8000-000000000004',
             successCriteria: { version: 1, rubric },
+          },
+        }),
+        ctx,
+      ),
+  },
+  {
+    label: 'pr_review',
+    submitTool: 'submit_pr_review_output',
+    schema: 'PrReviewOutput',
+    prompt: () =>
+      buildTaskUserPrompt(
+        makeFulfillBriefTask({
+          taskType: PR_REVIEW_TYPE,
+          input: {
+            subject: {
+              title: 'Review title',
+              summary: 'Review summary',
+            },
+            successCriteria: {
+              version: 1,
+              rubric: {
+                rubricId: 'pr-complexity-binary',
+                version: 'v1',
+                criteria: [
+                  {
+                    id: 'c1',
+                    description: 'd',
+                    weight: 1,
+                    scoring: 'boolean',
+                  },
+                ],
+              },
+            },
           },
         }),
         ctx,

--- a/libs/agent-runtime/src/prompts/index.test.ts
+++ b/libs/agent-runtime/src/prompts/index.test.ts
@@ -1,4 +1,4 @@
-import { ASSESS_BRIEF_TYPE } from '@moltnet/tasks';
+import { ASSESS_BRIEF_TYPE, PR_REVIEW_TYPE } from '@moltnet/tasks';
 import { describe, expect, it } from 'vitest';
 
 import { makeFulfillBriefTask } from '../test-fixtures.js';
@@ -91,6 +91,46 @@ describe('buildTaskUserPrompt', () => {
     expect(prompt).toContain('dedicated disposable git');
     expect(prompt).toContain('If you need to check out the target');
     expect(prompt).toContain('task/assess-brief-11111111');
+  });
+
+  it('builds a generic pr_review prompt without GitHub-specific runtime assumptions', () => {
+    const task = makeFulfillBriefTask({
+      taskType: PR_REVIEW_TYPE,
+      input: {
+        subject: {
+          title: 'Generated change review',
+          summary: 'Review this change artifact for complexity.',
+          resourceUrls: ['https://example.test/review/123'],
+          inspectionHints: ['Inspect the local checkout before scoring.'],
+        },
+        taskPrompt:
+          'Use the consumer-supplied review flow and publish the review before final output.',
+        successCriteria: {
+          version: 1,
+          rubric: {
+            rubricId: 'pr-complexity-binary',
+            version: 'v1',
+            criteria: [
+              {
+                id: 'c1',
+                description: 'Works',
+                weight: 1,
+                scoring: 'boolean',
+              },
+            ],
+          },
+        },
+      },
+    });
+    const prompt = buildTaskUserPrompt(task, ctx);
+    expect(prompt).toContain('Generated change review');
+    expect(prompt).toContain('https://example.test/review/123');
+    expect(prompt).toContain('submit_pr_review_output');
+    expect(prompt).toContain('task-specific instructions');
+    expect(prompt).toContain(
+      'Use the consumer-supplied review flow and publish the review before final output.',
+    );
+    expect(prompt).not.toContain('gh pr diff');
   });
 
   it('embeds correlation branch + trailer instructions when correlationId is set', () => {

--- a/libs/agent-runtime/src/prompts/index.ts
+++ b/libs/agent-runtime/src/prompts/index.ts
@@ -9,6 +9,8 @@ import {
   JUDGE_PACK_TYPE,
   JudgeEvalVariantInput,
   JudgePackInput,
+  PR_REVIEW_TYPE,
+  PrReviewInput,
   RENDER_PACK_TYPE,
   RenderPackInput,
   RUN_EVAL_TYPE,
@@ -22,6 +24,7 @@ import { buildCuratePackUserPrompt } from './curate-pack.js';
 import { buildFulfillBriefUserPrompt } from './fulfill-brief.js';
 import { buildJudgeEvalVariantUserPrompt } from './judge-eval-variant.js';
 import { buildJudgePackUserPrompt } from './judge-pack.js';
+import { buildPrReviewUserPrompt } from './pr-review.js';
 import { buildRenderPackUserPrompt } from './render-pack.js';
 import { buildRunEvalUserPrompt } from './run-eval.js';
 
@@ -30,6 +33,7 @@ export * from './curate-pack.js';
 export * from './fulfill-brief.js';
 export * from './judge-eval-variant.js';
 export * from './judge-pack.js';
+export * from './pr-review.js';
 export * from './render-pack.js';
 export * from './run-eval.js';
 
@@ -133,6 +137,20 @@ export function buildTaskUserPrompt(
       return buildJudgePackUserPrompt(task.input, {
         diaryId: ctx.diaryId,
         taskId: ctx.taskId,
+      });
+    }
+
+    case PR_REVIEW_TYPE: {
+      if (!Value.Check(PrReviewInput, task.input)) {
+        const errors = [...Value.Errors(PrReviewInput, task.input)];
+        throw new Error(
+          `pr_review input failed validation: ${JSON.stringify(errors.slice(0, 3))}`,
+        );
+      }
+      return buildPrReviewUserPrompt(task.input, {
+        diaryId: ctx.diaryId,
+        taskId: ctx.taskId,
+        workspace: ctx.workspace,
       });
     }
 

--- a/libs/agent-runtime/src/prompts/judge-pack.ts
+++ b/libs/agent-runtime/src/prompts/judge-pack.ts
@@ -1,6 +1,10 @@
 import type { JudgePackInput } from '@moltnet/tasks';
 
 import { buildFinalOutputBlock } from './final-output.js';
+import {
+  renderRubricCriteriaList,
+  renderRubricPreambleSection,
+} from './rubric-common.js';
 
 interface Ctx {
   diaryId: string;
@@ -16,16 +20,8 @@ export function buildJudgePackUserPrompt(
   // judgment tasks — narrow safely.
   const rubric = successCriteria.rubric!;
 
-  const criteriaList = rubric.criteria
-    .map(
-      (c, i) =>
-        `${i + 1}. **${c.id}** (weight ${c.weight}, scoring: \`${c.scoring}\`) — ${c.description}`,
-    )
-    .join('\n');
-
-  const preambleSection = rubric.preamble
-    ? ['### Rubric preamble', '', rubric.preamble, ''].join('\n')
-    : null;
+  const criteriaList = renderRubricCriteriaList(rubric);
+  const preambleSection = renderRubricPreambleSection(rubric);
 
   const lines: Array<string | null> = [
     '# Judge Pack Agent',

--- a/libs/agent-runtime/src/prompts/pr-review.ts
+++ b/libs/agent-runtime/src/prompts/pr-review.ts
@@ -1,0 +1,138 @@
+import type { PrReviewInput } from '@moltnet/tasks';
+
+import { buildFinalOutputBlock } from './final-output.js';
+import {
+  renderRubricCriteriaList,
+  renderRubricPreambleSection,
+} from './rubric-common.js';
+
+interface Ctx {
+  diaryId: string;
+  taskId: string;
+  workspace?: {
+    mode: 'shared_mount' | 'dedicated_worktree';
+    branch?: string | null;
+  };
+}
+
+export function buildPrReviewUserPrompt(
+  input: PrReviewInput,
+  ctx: Ctx,
+): string {
+  const rubric = input.successCriteria.rubric!;
+  const criteriaList = renderRubricCriteriaList(rubric);
+  const preambleSection = renderRubricPreambleSection(rubric);
+  const taskPromptSection = input.taskPrompt
+    ? ['## Task-specific instructions', '', input.taskPrompt, ''].join('\n')
+    : '';
+  const resourceSection =
+    input.subject.resourceUrls && input.subject.resourceUrls.length > 0
+      ? [
+          '### Resources',
+          '',
+          ...input.subject.resourceUrls.map((url) => `- ${url}`),
+          '',
+        ].join('\n')
+      : '';
+  const hintsSection =
+    input.subject.inspectionHints && input.subject.inspectionHints.length > 0
+      ? [
+          '### Inspection hints',
+          '',
+          ...input.subject.inspectionHints.map((hint) => `- ${hint}`),
+          '',
+        ].join('\n')
+      : '';
+  const workspaceSection =
+    ctx.workspace?.mode === 'dedicated_worktree'
+      ? [
+          '### Workspace',
+          '',
+          'This review attempt is running inside a dedicated disposable git',
+          'worktree. Inspect and reason inside this workspace only.',
+          ctx.workspace.branch
+            ? `The current review branch is \`${ctx.workspace.branch}\`.`
+            : 'The current checkout is disposable and will be cleaned up when the task ends.',
+          '',
+        ].join('\n')
+      : '';
+
+  const lines = [
+    '# Review Agent',
+    '',
+    'You are an independent judge. You did NOT produce the subject under review.',
+    'Assess it strictly against the rubric below and emit a structured judgment.',
+    'You may inspect the local workspace and the referenced resources, but do NOT modify anything.',
+    '',
+    `Your diary ID is: ${ctx.diaryId}`,
+    `This task's id is: ${ctx.taskId}`,
+    '',
+    '## Subject',
+    '',
+    `**Title:** ${input.subject.title}`,
+    '',
+    input.subject.summary,
+    '',
+    resourceSection,
+    hintsSection,
+    workspaceSection,
+    '### Execution contract',
+    '',
+    'Treat the provided subject, resources, inspection hints, and any',
+    'task-specific instructions as the full',
+    'review contract for this task.',
+    '',
+    'If the task-specific instructions or inspection hints require an outward action tied to the review',
+    '(for example publishing the judgment somewhere), perform that action as',
+    'part of the task before reporting structured output.',
+    '',
+    '## Review workflow',
+    '',
+    '1. Read the subject summary, resources, inspection hints, and any',
+    '   task-specific instructions before scoring.',
+    '2. Inspect the target artefact directly using the tools and resources the',
+    '   task makes available.',
+    '3. If you are in a dedicated disposable worktree and need the review target',
+    '   checked out locally, do that work inside this disposable workspace only.',
+    '4. Apply the rubric strictly. This task is about complexity and',
+    '   reviewability, not correctness or feature desirability.',
+    '5. Perform any required outward action before emitting the final',
+    '   structured output.',
+    '',
+    taskPromptSection,
+    preambleSection,
+    '## Criteria',
+    '',
+    criteriaList,
+    '',
+    '### Scoring rules',
+    '',
+    '- Every criterion uses binary scoring only.',
+    '- Score `1` when the subject clearly clears the criterion.',
+    '- Score `0` when it does not, or when the evidence is ambiguous.',
+    '- `rationale` is REQUIRED for every score. Keep it concrete and audit-friendly.',
+    '- Compute `composite = Σ(weight_i × score_i)` exactly; the runtime rejects mismatches.',
+    '',
+    'Write a signed diary entry (tags: `judgment`, `pr_review`) capturing the rationale before reporting structured output.',
+    '',
+    buildFinalOutputBlock({
+      taskType: 'pr_review',
+      outputSchemaName: 'PrReviewOutput',
+      shapeSketch: [
+        '{',
+        '  "scores": [',
+        '    { "criterionId": "...", "score": 0, "rationale": "..." }',
+        '  ],',
+        '  "composite": <sum-of-weighted-binary-scores>,',
+        '  "verdict": "<1-3 sentence overall>"',
+        '}',
+      ].join('\n'),
+      extraNotes: [
+        '`scores` MUST stay in the same order as the rubric criteria.',
+        '`score` MUST be exactly `0` or `1` for every criterion.',
+      ],
+    }),
+  ];
+
+  return lines.filter(Boolean).join('\n');
+}

--- a/libs/agent-runtime/src/prompts/rubric-common.ts
+++ b/libs/agent-runtime/src/prompts/rubric-common.ts
@@ -1,0 +1,15 @@
+import type { Rubric } from '@moltnet/tasks';
+
+export function renderRubricCriteriaList(rubric: Rubric): string {
+  return rubric.criteria
+    .map(
+      (c, i) =>
+        `${i + 1}. **${c.id}** (weight ${c.weight}, scoring: \`${c.scoring}\`) — ${c.description}`,
+    )
+    .join('\n');
+}
+
+export function renderRubricPreambleSection(rubric: Rubric): string | null {
+  if (!rubric.preamble) return null;
+  return ['### Rubric preamble', '', rubric.preamble, ''].join('\n');
+}

--- a/libs/tasks/src/task-types/index.ts
+++ b/libs/tasks/src/task-types/index.ts
@@ -41,6 +41,13 @@ import {
   validateJudgePackOutput,
 } from './judge-pack.js';
 import {
+  PR_REVIEW_TYPE,
+  PrReviewInput,
+  PrReviewOutput,
+  validatePrReviewInput,
+  validatePrReviewOutput,
+} from './pr-review.js';
+import {
   RENDER_PACK_TYPE,
   RenderPackInput,
   RenderPackOutput,
@@ -58,6 +65,7 @@ export * from './curate-pack.js';
 export * from './fulfill-brief.js';
 export * from './judge-eval-variant.js';
 export * from './judge-pack.js';
+export * from './pr-review.js';
 export * from './render-pack.js';
 export * from './run-eval.js';
 
@@ -245,6 +253,18 @@ export const BUILT_IN_TASK_TYPES = {
     requiresReferences: true,
     validateInput: validateJudgmentInput,
     validateInputAsync: validateAssessBriefInputAsync,
+  },
+  [PR_REVIEW_TYPE]: {
+    name: PR_REVIEW_TYPE,
+    inputSchema: PrReviewInput,
+    outputSchema: PrReviewOutput,
+    outputKind: 'judgment',
+    workspaceMode: 'dedicated_worktree',
+    workspaceScope: 'attempt',
+    sessionScope: 'none',
+    requiresReferences: false,
+    validateInput: validatePrReviewInput,
+    validateOutput: validatePrReviewOutput,
   },
   [CURATE_PACK_TYPE]: {
     name: CURATE_PACK_TYPE,

--- a/libs/tasks/src/task-types/pr-review.ts
+++ b/libs/tasks/src/task-types/pr-review.ts
@@ -1,0 +1,107 @@
+import { type Static, Type } from '@sinclair/typebox';
+
+import type { Rubric } from '../rubric.js';
+import { validateRubricWeights } from '../rubric.js';
+import { SuccessCriteria } from '../success-criteria.js';
+
+export const PR_REVIEW_TYPE = 'pr_review' as const;
+
+export const PrReviewSubject = Type.Object(
+  {
+    title: Type.String({ minLength: 1 }),
+    summary: Type.String({ minLength: 1 }),
+    resourceUrls: Type.Optional(Type.Array(Type.String({ minLength: 1 }))),
+    inspectionHints: Type.Optional(Type.Array(Type.String({ minLength: 1 }))),
+  },
+  { $id: 'PrReviewSubject', additionalProperties: false },
+);
+export type PrReviewSubject = Static<typeof PrReviewSubject>;
+
+export const PrReviewInput = Type.Object(
+  {
+    subject: PrReviewSubject,
+    taskPrompt: Type.Optional(Type.String({ minLength: 1 })),
+    successCriteria: SuccessCriteria,
+  },
+  { $id: 'PrReviewInput', additionalProperties: false },
+);
+export type PrReviewInput = Static<typeof PrReviewInput>;
+
+export const PrReviewScore = Type.Object(
+  {
+    criterionId: Type.String({ minLength: 1 }),
+    score: Type.Union([Type.Literal(0), Type.Literal(1)]),
+    rationale: Type.String({ minLength: 1 }),
+  },
+  { $id: 'PrReviewScore', additionalProperties: false },
+);
+export type PrReviewScore = Static<typeof PrReviewScore>;
+
+export const PrReviewOutput = Type.Object(
+  {
+    scores: Type.Array(PrReviewScore, { minItems: 1 }),
+    composite: Type.Number({ minimum: 0, maximum: 1 }),
+    verdict: Type.String({ minLength: 1 }),
+  },
+  { $id: 'PrReviewOutput', additionalProperties: false },
+);
+export type PrReviewOutput = Static<typeof PrReviewOutput>;
+
+function requireBooleanRubric(rubric: Rubric): string | null {
+  for (const criterion of rubric.criteria) {
+    if (criterion.scoring !== 'boolean') {
+      return (
+        `pr_review requires boolean scoring for every rubric criterion; ` +
+        `criterion "${criterion.id}" uses "${criterion.scoring}"`
+      );
+    }
+  }
+  return null;
+}
+
+export function validatePrReviewInput(input: unknown): string | null {
+  const sc = (input as { successCriteria?: { rubric?: Rubric } })
+    .successCriteria;
+  if (!sc) return 'successCriteria is required for judgment tasks';
+  if (!sc.rubric)
+    return 'successCriteria.rubric is required for judgment tasks';
+  return validateRubricWeights(sc.rubric) ?? requireBooleanRubric(sc.rubric);
+}
+
+export function validatePrReviewOutput(
+  output: unknown,
+  input?: unknown,
+): string | null {
+  if (!input) return null;
+
+  const scores = (output as PrReviewOutput).scores;
+  const rubric = (input as PrReviewInput).successCriteria.rubric;
+  if (!rubric) return null;
+
+  if (scores.length !== rubric.criteria.length) {
+    return (
+      `scores length ${scores.length} does not match rubric criteria length ` +
+      `${rubric.criteria.length}`
+    );
+  }
+
+  let composite = 0;
+  for (let i = 0; i < rubric.criteria.length; i++) {
+    const criterion = rubric.criteria[i];
+    const score = scores[i];
+    if (score.criterionId !== criterion.id) {
+      return (
+        `scores[${i}] has criterionId "${score.criterionId}" but rubric ` +
+        `expects "${criterion.id}" in that position`
+      );
+    }
+    composite += criterion.weight * score.score;
+  }
+
+  const claimed = (output as PrReviewOutput).composite;
+  if (Math.abs(claimed - composite) > 1e-6) {
+    return `composite ${claimed} does not match weighted sum ${composite.toFixed(6)}`;
+  }
+
+  return null;
+}

--- a/libs/tasks/src/task-types/registry.test.ts
+++ b/libs/tasks/src/task-types/registry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { BUILT_IN_TASK_TYPES, RUN_EVAL_TYPE } from './index.js';
+import { BUILT_IN_TASK_TYPES, PR_REVIEW_TYPE, RUN_EVAL_TYPE } from './index.js';
 
 describe('BUILT_IN_TASK_TYPES — run_eval', () => {
   it('includes run_eval as an artifact-kind type', () => {
@@ -12,5 +12,18 @@ describe('BUILT_IN_TASK_TYPES — run_eval', () => {
     expect(entry.validateOutput).toBeDefined();
     // No validateInput on run_eval (input has no cross-field invariants).
     expect('validateInput' in entry).toBe(false);
+  });
+});
+
+describe('BUILT_IN_TASK_TYPES — pr_review', () => {
+  it('includes pr_review as a judgment-kind dedicated-worktree type', () => {
+    const entry = BUILT_IN_TASK_TYPES[PR_REVIEW_TYPE];
+    expect(entry).toBeDefined();
+    expect(entry.name).toBe('pr_review');
+    expect(entry.outputKind).toBe('judgment');
+    expect(entry.requiresReferences).toBe(false);
+    expect(entry.workspaceMode).toBe('dedicated_worktree');
+    expect(entry.workspaceScope).toBe('attempt');
+    expect(entry.sessionScope).toBe('none');
   });
 });

--- a/libs/tasks/src/validation.test.ts
+++ b/libs/tasks/src/validation.test.ts
@@ -96,6 +96,40 @@ describe('validateTaskCreateRequest', () => {
     ]);
   });
 
+  it('rejects pr_review rubrics that are not boolean-only', () => {
+    const errors = validateTaskCreateRequest({
+      taskType: 'pr_review',
+      input: {
+        subject: {
+          title: 'Review X',
+          summary: 'Review this change.',
+        },
+        successCriteria: {
+          version: 1,
+          rubric: {
+            rubricId: 'pr-complexity',
+            version: 'v1',
+            criteria: [
+              {
+                id: 'c1',
+                description: 'desc',
+                weight: 1,
+                scoring: 'llm_score',
+              },
+            ],
+          },
+        },
+      },
+    });
+    expect(errors).toEqual([
+      {
+        field: 'input',
+        message:
+          'pr_review requires boolean scoring for every rubric criterion; criterion "c1" uses "llm_score"',
+      },
+    ]);
+  });
+
   it('rejects fulfill_brief acceptanceCriteria as an unknown field', () => {
     const errors = validateTaskCreateRequest({
       taskType: 'fulfill_brief',
@@ -330,6 +364,119 @@ describe('validateTaskOutput', () => {
       expect(errors).toEqual([]);
     });
   });
+
+  describe('pr_review output validation', () => {
+    const input = {
+      subject: {
+        title: 'PR review',
+        summary: 'Inspect the change.',
+      },
+      successCriteria: {
+        version: 1,
+        rubric: {
+          rubricId: 'pr-complexity-binary',
+          version: 'v1',
+          criteria: [
+            {
+              id: 'cognitive_load',
+              description: 'desc',
+              weight: 0.6,
+              scoring: 'boolean' as const,
+            },
+            {
+              id: 'blast_radius',
+              description: 'desc',
+              weight: 0.4,
+              scoring: 'boolean' as const,
+            },
+          ],
+        },
+      },
+    };
+
+    it('accepts valid binary weighted output', () => {
+      const errors = validateTaskOutput(
+        'pr_review',
+        {
+          scores: [
+            {
+              criterionId: 'cognitive_load',
+              score: 1,
+              rationale: 'Focused change.',
+            },
+            {
+              criterionId: 'blast_radius',
+              score: 0,
+              rationale: 'Touches shared API.',
+            },
+          ],
+          composite: 0.6,
+          verdict: 'Moderate review cost.',
+        },
+        input,
+      );
+      expect(errors).toEqual([]);
+    });
+
+    it('rejects criterion order mismatches', () => {
+      const errors = validateTaskOutput(
+        'pr_review',
+        {
+          scores: [
+            {
+              criterionId: 'blast_radius',
+              score: 1,
+              rationale: 'wrong order',
+            },
+            {
+              criterionId: 'cognitive_load',
+              score: 1,
+              rationale: 'wrong order',
+            },
+          ],
+          composite: 1,
+          verdict: 'Bad ordering.',
+        },
+        input,
+      );
+      expect(errors).toEqual([
+        {
+          field: 'output',
+          message:
+            'scores[0] has criterionId "blast_radius" but rubric expects "cognitive_load" in that position',
+        },
+      ]);
+    });
+
+    it('rejects composite mismatches', () => {
+      const errors = validateTaskOutput(
+        'pr_review',
+        {
+          scores: [
+            {
+              criterionId: 'cognitive_load',
+              score: 1,
+              rationale: 'ok',
+            },
+            {
+              criterionId: 'blast_radius',
+              score: 1,
+              rationale: 'ok',
+            },
+          ],
+          composite: 0.5,
+          verdict: 'Wrong composite.',
+        },
+        input,
+      );
+      expect(errors).toEqual([
+        {
+          field: 'output',
+          message: 'composite 0.5 does not match weighted sum 1.000000',
+        },
+      ]);
+    });
+  });
 });
 
 describe('taskTypeUsesSubagents', () => {
@@ -367,6 +514,7 @@ describe('taskTypeWorkspaceMode', () => {
     expect(taskTypeWorkspaceMode('render_pack')).toBe('shared_mount');
     expect(taskTypeWorkspaceMode('judge_pack')).toBe('shared_mount');
     expect(taskTypeWorkspaceMode('run_eval')).toBe('shared_mount');
+    expect(taskTypeWorkspaceMode('pr_review')).toBe('dedicated_worktree');
   });
 });
 
@@ -397,6 +545,7 @@ describe('taskTypeWorkspaceScope', () => {
 
   it('keeps other built-ins attempt-scoped', () => {
     expect(taskTypeWorkspaceScope('assess_brief')).toBe('attempt');
+    expect(taskTypeWorkspaceScope('pr_review')).toBe('attempt');
     expect(taskTypeWorkspaceScope('run_eval')).toBe('attempt');
     expect(taskTypeWorkspaceScope('judge_eval_variant')).toBe('attempt');
   });
@@ -413,6 +562,7 @@ describe('taskTypeSessionScope', () => {
 
   it('keeps review tasks non-reusable by default', () => {
     expect(taskTypeSessionScope('assess_brief')).toBe('none');
+    expect(taskTypeSessionScope('pr_review')).toBe('none');
     expect(taskTypeSessionScope('judge_pack')).toBe('none');
   });
 

--- a/rubrics/pr-complexity-binary-v1.json
+++ b/rubrics/pr-complexity-binary-v1.json
@@ -1,0 +1,38 @@
+{
+  "criteria": [
+    {
+      "description": "Pass only when the change stays single-purpose, the concepts touched are coherent, and a reviewer does not need to juggle multiple intertwined concerns at once. Fail when the diff mixes unrelated refactor, behavior change, dependency churn, or otherwise forces high cognitive load.",
+      "id": "cognitive_load",
+      "scoring": "boolean",
+      "weight": 0.25
+    },
+    {
+      "description": "Pass only when the change is well isolated and a regression would have a small blast radius. Fail when it changes public contracts, schema, migrations, auth paths, shared utilities, or other surfaces where mistakes propagate broadly.",
+      "id": "blast_radius",
+      "scoring": "boolean",
+      "weight": 0.25
+    },
+    {
+      "description": "Pass only when tests are added or updated proportionally to the risk introduced by the change. Fail when meaningful behavior changes land without adequate tests, or when tests are weakened or removed to make the change pass.",
+      "id": "test_coverage_delta",
+      "scoring": "boolean",
+      "weight": 0.2
+    },
+    {
+      "description": "Pass only when the change does not materially increase security review surface or when the security-sensitive parts remain obviously low-risk and well-contained. Fail when it touches authentication, authorization, cryptography, secrets, or external egress in a way that demands deeper review.",
+      "id": "security_surface",
+      "scoring": "boolean",
+      "weight": 0.2
+    },
+    {
+      "description": "Pass only when the reviewer is well oriented by the title, description, commits, and any supporting rationale. Fail when the change lacks a clear explanation of what changed and why, leaving the reviewer to reconstruct intent from the diff alone.",
+      "id": "reviewer_orientation",
+      "scoring": "boolean",
+      "weight": 0.1
+    }
+  ],
+  "preamble": "You are reviewing a change artifact for complexity: how hard it is to review safely, not whether the feature is desirable. Use binary scoring only. When evidence is ambiguous, fail the criterion and explain why.",
+  "rubricId": "pr-complexity-binary-v1",
+  "scope": "change_review",
+  "version": "v1"
+}

--- a/tools/package.json
+++ b/tools/package.json
@@ -19,6 +19,7 @@
     "task:create": "tsx src/tasks/create-task.ts",
     "task:fulfill-brief": "tsx src/tasks/fulfill-brief.ts",
     "task:assess-pr": "tsx src/tasks/assess-pr.ts",
+    "task:create-pr-review": "tsx src/tasks/create-pr-review.ts",
     "task:run": "tsx src/tasks/run-task.ts",
     "fulfill-brief": "tsx src/tasks/fulfill-brief.ts",
     "resolve-issue": "tsx src/tasks/fulfill-brief.ts",

--- a/tools/src/tasks/create-pr-review.ts
+++ b/tools/src/tasks/create-pr-review.ts
@@ -1,0 +1,294 @@
+/**
+ * create-pr-review.ts — impose a generic `pr_review` task for a GitHub PR.
+ *
+ * Scope boundary
+ * --------------
+ * This script is imposer-only. It MAY:
+ * - inspect PR metadata needed to build task input
+ * - recover or mint a correlationId
+ * - persist the LeGreffier PR-body marker
+ * - create the task via `agent.tasks.create(...)`
+ *
+ * It MUST NOT:
+ * - claim the task
+ * - start the daemon
+ * - execute the review
+ * - post the review comment itself
+ *
+ * Any PR comment is part of the claimant's execution contract and is
+ * delegated to the `pr_review` prompt via repo-specific `inspectionHints`.
+ */
+import { execFileSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { isAbsolute, join, resolve } from 'node:path';
+import { parseArgs, parseEnv } from 'node:util';
+
+import type { Rubric as RubricType } from '@moltnet/tasks';
+import { PR_REVIEW_TYPE, type PrReviewInput, Rubric } from '@moltnet/tasks';
+import { Value } from '@sinclair/typebox/value';
+import { connect } from '@themoltnet/sdk';
+
+const { values: args } = parseArgs({
+  options: {
+    pr: { type: 'string', short: 'p' },
+    repo: { type: 'string', short: 'r' },
+    agent: { type: 'string', short: 'a', default: 'legreffier' },
+    rubric: {
+      type: 'string',
+      default: 'rubrics/pr-complexity-binary-v1.json',
+    },
+    'dry-run': { type: 'boolean', default: false },
+  },
+});
+
+if (!args.pr || !args.repo) {
+  console.error(
+    'Usage: tsx tools/src/tasks/create-pr-review.ts --pr <number> --repo <owner/repo> [--agent <name>] [--rubric <path>] [--dry-run]',
+  );
+  process.exit(1);
+}
+
+const prNumber = Number(args.pr);
+if (!Number.isInteger(prNumber) || prNumber < 1) {
+  console.error(`Invalid --pr "${args.pr}": must be a positive integer.`);
+  process.exit(1);
+}
+
+const repoSlug = args.repo!;
+if (!/^[^/\s]+\/[^/\s]+$/.test(repoSlug)) {
+  console.error(`Invalid --repo "${repoSlug}": expected owner/repo.`);
+  process.exit(1);
+}
+
+const agentName = args.agent!;
+const rubricArg = args.rubric!;
+const dryRun = args['dry-run']!;
+
+if (!/^[a-zA-Z0-9_-]+$/.test(agentName)) {
+  console.error(
+    `Invalid --agent "${agentName}": must match /^[a-zA-Z0-9_-]+$/`,
+  );
+  process.exit(1);
+}
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const BRANCH_RE = /^moltnet\/([0-9a-f-]{36})\//i;
+const TRAILER_RE = /^Moltnet-Correlation-Id:\s*([0-9a-f-]{36})\s*$/im;
+const MOLTNET_MARKER_RE =
+  /<!--\s*moltnet-correlation:\s*([0-9a-f-]{36})\s*-->/i;
+const LEGREFFIER_MARKER_RE =
+  /<!--\s*legreffier-correlation:\s*([0-9a-f-]{36})\s*-->/i;
+
+interface PullRequestInfo {
+  title: string;
+  body: string;
+  url: string;
+  headRefName: string;
+  commitMessages: string[];
+}
+
+function ghJson<T>(ghArgs: string[]): T {
+  const out = execFileSync('gh', ghArgs, {
+    encoding: 'utf8',
+    env: process.env,
+  });
+  return JSON.parse(out) as T;
+}
+
+function gh(ghArgs: string[]): string {
+  return execFileSync('gh', ghArgs, {
+    encoding: 'utf8',
+    env: process.env,
+  });
+}
+
+function getPullRequestInfo(): PullRequestInfo {
+  const pr = ghJson<{
+    title: string;
+    body: string | null;
+    url: string;
+    headRefName: string;
+    commits: Array<{ messageHeadline: string; messageBody?: string | null }>;
+  }>([
+    'pr',
+    'view',
+    String(prNumber),
+    '--repo',
+    repoSlug,
+    '--json',
+    'title,body,url,headRefName,commits',
+  ]);
+
+  return {
+    title: pr.title,
+    body: pr.body ?? '',
+    url: pr.url,
+    headRefName: pr.headRefName,
+    commitMessages: pr.commits.map((commit) =>
+      [commit.messageHeadline, commit.messageBody ?? '']
+        .filter((part) => part.length > 0)
+        .join('\n\n'),
+    ),
+  };
+}
+
+function resolveCorrelationId(pr: PullRequestInfo): string {
+  const branchMatch = pr.headRefName.match(BRANCH_RE);
+  if (branchMatch) return branchMatch[1];
+
+  for (const message of pr.commitMessages) {
+    const trailerMatch = message.match(TRAILER_RE);
+    if (trailerMatch) return trailerMatch[1];
+  }
+
+  const legreffierMarkerMatch = pr.body.match(LEGREFFIER_MARKER_RE);
+  if (legreffierMarkerMatch) return legreffierMarkerMatch[1];
+
+  const moltnetMarkerMatch = pr.body.match(MOLTNET_MARKER_RE);
+  if (moltnetMarkerMatch) return moltnetMarkerMatch[1];
+
+  return randomUUID();
+}
+
+function ensureLegreffierMarker(body: string, correlationId: string): string {
+  if (!UUID_RE.test(correlationId)) {
+    throw new Error(`Invalid correlationId "${correlationId}"`);
+  }
+
+  const marker = `<!-- legreffier-correlation: ${correlationId} -->`;
+  if (LEGREFFIER_MARKER_RE.test(body)) {
+    return body.replace(LEGREFFIER_MARKER_RE, marker);
+  }
+
+  const trimmed = body.trimEnd();
+  return trimmed.length > 0 ? `${trimmed}\n\n${marker}\n` : `${marker}\n`;
+}
+
+function updatePrBody(body: string): void {
+  gh([
+    'api',
+    `repos/${repoSlug}/pulls/${prNumber}`,
+    '--method',
+    'PATCH',
+    '--raw-field',
+    `body=${body}`,
+  ]);
+}
+
+function readRubric(repoRoot: string): RubricType {
+  const rubricPath = isAbsolute(rubricArg)
+    ? rubricArg
+    : resolve(repoRoot, rubricArg);
+  const parsed = JSON.parse(readFileSync(rubricPath, 'utf8')) as unknown;
+  if (!Value.Check(Rubric, parsed)) {
+    const errors = [...Value.Errors(Rubric, parsed)].slice(0, 5);
+    throw new Error(
+      `Rubric at ${rubricPath} does not match the @moltnet/tasks Rubric schema.\n` +
+        errors.map((e) => `  - ${e.path || '(root)'}: ${e.message}`).join('\n'),
+    );
+  }
+  return parsed;
+}
+
+function buildPrReviewInput(
+  pr: PullRequestInfo,
+  rubric: RubricType,
+): PrReviewInput {
+  return {
+    subject: {
+      title: `PR #${prNumber}: ${pr.title}`,
+      summary:
+        `This subject is the GitHub pull request at ${pr.url}. ` +
+        `Review its complexity and reviewability, not functional correctness.`,
+      resourceUrls: [pr.url],
+      inspectionHints: [
+        'Use the local checkout to read touched files and surrounding code as needed.',
+      ],
+    },
+    taskPrompt: [
+      'This review target is a GitHub pull request.',
+      '',
+      `1. Inspect the PR with \`gh pr view ${prNumber} --repo ${repoSlug}\` and \`gh pr diff ${prNumber} --repo ${repoSlug}\`.`,
+      '2. Use the local checkout to inspect the touched files and enough surrounding code to judge reviewer burden.',
+      `3. Before your final structured output, post exactly one advisory PR comment with \`gh pr comment ${prNumber} --repo ${repoSlug} --body <review>\`.`,
+      '4. That PR comment must include the composite score, the overall verdict, each criterion as pass/fail, and concise rationale explaining the main complexity drivers.',
+      '5. This is a complexity/reviewability judgment, not a correctness review.',
+    ].join('\n'),
+    successCriteria: {
+      version: 1,
+      rubric,
+    },
+  };
+}
+
+async function main() {
+  const repoRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+    encoding: 'utf8',
+  }).trim();
+  const agentDir = join(repoRoot, '.moltnet', agentName);
+  const envRaw = readFileSync(join(agentDir, 'env'), 'utf8');
+  const envMap = parseEnv(envRaw);
+  const teamId = envMap['MOLTNET_TEAM_ID'];
+  const diaryId = envMap['MOLTNET_DIARY_ID'];
+  if (!teamId) {
+    throw new Error(`Missing MOLTNET_TEAM_ID in ${join(agentDir, 'env')}`);
+  }
+  if (!diaryId) {
+    throw new Error(`Missing MOLTNET_DIARY_ID in ${join(agentDir, 'env')}`);
+  }
+
+  const pr = getPullRequestInfo();
+  const correlationId = resolveCorrelationId(pr);
+  const nextBody = ensureLegreffierMarker(pr.body, correlationId);
+  const rubric = readRubric(repoRoot);
+  const input = buildPrReviewInput(pr, rubric);
+
+  if (dryRun) {
+    console.log(
+      JSON.stringify(
+        {
+          taskType: PR_REVIEW_TYPE,
+          teamId,
+          diaryId,
+          correlationId,
+          input,
+          prBodyUpdateRequired: nextBody !== pr.body,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  if (nextBody !== pr.body) {
+    updatePrBody(nextBody);
+  }
+
+  const agent = await connect({ configDir: agentDir });
+  const task = await agent.tasks.create({
+    taskType: PR_REVIEW_TYPE,
+    teamId,
+    diaryId,
+    correlationId,
+    input: input as unknown as Record<string, unknown>,
+  });
+
+  console.error(
+    `[task] created ${task.id} (status=${task.status}) correlationId=${correlationId}`,
+  );
+  console.log(
+    JSON.stringify(
+      { id: task.id, status: task.status, correlationId },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch((err) => {
+  console.error('[fatal]', err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Add a generic \ judgment task plus a repo-local LeGreffier workflow for PR complexity review.

## What changed
- add generic \ task type with binary rubric validation
- keep shared runtime prompt generic and allow consumer-supplied task instructions
- add \ as an imposer-only helper
- add repo-local workflow for manual \ and \
- document the imposer vs claimant boundary for task creation

## Notes
The workflow starts the daemon first and creates the task second. PR inspection and PR comment publication are part of the claimant prompt contract, not imposer glue.

## Testing
- pnpm exec vitest run libs/tasks/src/task-types/registry.test.ts libs/tasks/src/validation.test.ts libs/agent-runtime/src/prompts/index.test.ts libs/agent-runtime/src/prompts/final-output.test.ts