### PR TITLE
feat: expose team role management in SDK and CLI

### DIFF
--- a/apps/moltnet-cli/cobra_teams.go
+++ b/apps/moltnet-cli/cobra_teams.go
@@ -68,6 +68,7 @@ func newTeamsMembersCmd() *cobra.Command {
 	}
 	membersCmd.AddCommand(newTeamsMembersListCmd())
 	membersCmd.AddCommand(newTeamsMembersRemoveCmd())
+	membersCmd.AddCommand(newTeamsMembersUpdateRoleCmd())
 	return membersCmd
 }
 
@@ -97,6 +98,25 @@ func newTeamsMembersRemoveCmd() *cobra.Command {
 			return runTeamsMemberRemoveCmd(apiURL, credPath, args[0], args[1])
 		},
 	}
+}
+
+func newTeamsMembersUpdateRoleCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update-role <team-id> <subject-id>",
+		Short: "Update a member role (owner/manager only)",
+		Example: `  moltnet teams members update-role 6e4d9948-... 1a2b3c4d-... --role manager
+  moltnet teams members update-role 6e4d9948-... 1a2b3c4d-... --role member`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			credPath, _ := cmd.Flags().GetString("credentials")
+			apiURL := resolveAPIURL(cmd, credPath)
+			role, _ := cmd.Flags().GetString("role")
+			return runTeamsMemberUpdateRoleCmd(apiURL, credPath, args[0], args[1], role)
+		},
+	}
+	cmd.Flags().String("role", "", "Role to assign: member or manager (required)")
+	_ = cmd.MarkFlagRequired("role")
+	return cmd
 }
 
 func newTeamsCreateCmd() *cobra.Command {

--- a/apps/moltnet-cli/e2e_team_management_test.go
+++ b/apps/moltnet-cli/e2e_team_management_test.go
@@ -148,7 +148,7 @@ func TestE2E_CLI_TeamLifecycle(t *testing.T) {
 	}
 	foundInvitee = false
 	for _, m := range members.Items {
-		if m.SubjectId == inviteeAgentID && m.Role == "manager" {
+		if m.SubjectId == inviteeAgentID && m.Role == "managers" {
 			foundInvitee = true
 			break
 		}
@@ -170,6 +170,26 @@ func TestE2E_CLI_TeamLifecycle(t *testing.T) {
 	decodeJSON(t, stdout, &updatedRole)
 	if !updatedRole.Updated || updatedRole.Role != "member" {
 		t.Fatalf("demote to member failed: %+v", updatedRole)
+	}
+
+	membersRes, err = e2eClient.ListTeamMembers(context.Background(),
+		moltnetapi.ListTeamMembersParams{ID: teamID})
+	if err != nil {
+		t.Fatalf("list team members after demote: %v", err)
+	}
+	members, ok = membersRes.(*moltnetapi.ListTeamMembersOK)
+	if !ok {
+		t.Fatalf("unexpected team members response after demote: %T", membersRes)
+	}
+	foundInvitee = false
+	for _, m := range members.Items {
+		if m.SubjectId == inviteeAgentID && m.Role == "members" {
+			foundInvitee = true
+			break
+		}
+	}
+	if !foundInvitee {
+		t.Fatalf("invitee agent %s not demoted back to member", inviteeAgentID)
 	}
 
 	// 5. owner grants writer on the shared e2e diary to the invitee

--- a/apps/moltnet-cli/e2e_team_management_test.go
+++ b/apps/moltnet-cli/e2e_team_management_test.go
@@ -117,6 +117,61 @@ func TestE2E_CLI_TeamLifecycle(t *testing.T) {
 		t.Fatalf("invitee agent %s not found in team members", inviteeAgentID)
 	}
 
+	// 4a. owner promotes the invitee to manager, then demotes back to member
+	stdout, _ = h.run(
+		t,
+		"teams",
+		"members",
+		"update-role",
+		teamID.String(),
+		inviteeAgentID.String(),
+		"--role",
+		"manager",
+	)
+	var updatedRole struct {
+		Updated bool   `json:"updated"`
+		Role    string `json:"role"`
+	}
+	decodeJSON(t, stdout, &updatedRole)
+	if !updatedRole.Updated || updatedRole.Role != "manager" {
+		t.Fatalf("promote to manager failed: %+v", updatedRole)
+	}
+
+	membersRes, err = e2eClient.ListTeamMembers(context.Background(),
+		moltnetapi.ListTeamMembersParams{ID: teamID})
+	if err != nil {
+		t.Fatalf("list team members after promote: %v", err)
+	}
+	members, ok = membersRes.(*moltnetapi.ListTeamMembersOK)
+	if !ok {
+		t.Fatalf("unexpected team members response after promote: %T", membersRes)
+	}
+	foundInvitee = false
+	for _, m := range members.Items {
+		if m.SubjectId == inviteeAgentID && m.Role == "manager" {
+			foundInvitee = true
+			break
+		}
+	}
+	if !foundInvitee {
+		t.Fatalf("invitee agent %s not promoted to manager", inviteeAgentID)
+	}
+
+	stdout, _ = h.run(
+		t,
+		"teams",
+		"members",
+		"update-role",
+		teamID.String(),
+		inviteeAgentID.String(),
+		"--role",
+		"member",
+	)
+	decodeJSON(t, stdout, &updatedRole)
+	if !updatedRole.Updated || updatedRole.Role != "member" {
+		t.Fatalf("demote to member failed: %+v", updatedRole)
+	}
+
 	// 5. owner grants writer on the shared e2e diary to the invitee
 	stdout, _ = h.run(t, "diary", "grants", "create", e2eDiaryID.String(),
 		"--subject-id", inviteeAgentID.String(),

--- a/apps/moltnet-cli/go.mod
+++ b/apps/moltnet-cli/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/XiaoConstantine/dspy-go v0.82.2
 	github.com/getlarge/themoltnet/libs/dspy-adapters v0.9.2
-	github.com/getlarge/themoltnet/libs/moltnet-api-client v1.28.2
+	github.com/getlarge/themoltnet/libs/moltnet-api-client v1.29.0
 	github.com/go-faster/jx v1.2.0
 	github.com/google/uuid v1.6.0
 	github.com/ipfs/go-cid v0.6.0

--- a/apps/moltnet-cli/go.sum
+++ b/apps/moltnet-cli/go.sum
@@ -35,6 +35,8 @@ github.com/getlarge/themoltnet/libs/dspy-adapters v0.9.2 h1:Rz0SMPs3rNlvIzuMDbc8
 github.com/getlarge/themoltnet/libs/dspy-adapters v0.9.2/go.mod h1:LrIk92Gxsga2Ol11P8nV+aa/tM81/kSv7F4MitweIYc=
 github.com/getlarge/themoltnet/libs/moltnet-api-client v1.28.2 h1:h4WiBvbxb5v6aGvSrBN685mNVzKHEuGd1D/A7BTDETk=
 github.com/getlarge/themoltnet/libs/moltnet-api-client v1.28.2/go.mod h1:2NM6Nj6POFphfql+G6u6/4F2i3EIo5Jd95DBX1lhPLM=
+github.com/getlarge/themoltnet/libs/moltnet-api-client v1.29.0 h1:+hdK0p+gdH43qFRmwLsP4ty7d87H0RM9ssn2PCXtKeM=
+github.com/getlarge/themoltnet/libs/moltnet-api-client v1.29.0/go.mod h1:2NM6Nj6POFphfql+G6u6/4F2i3EIo5Jd95DBX1lhPLM=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-faster/errors v0.7.1 h1:MkJTnDoEdi9pDabt1dpWf7AA8/BaSYZqibYyhZ20AYg=

--- a/apps/moltnet-cli/teams.go
+++ b/apps/moltnet-cli/teams.go
@@ -192,6 +192,37 @@ func runTeamsMemberRemoveCmd(apiURL, credPath, teamID, subjectID string) error {
 	return printJSON(ok)
 }
 
+// runTeamsMemberUpdateRoleCmd updates a team member's role.
+func runTeamsMemberUpdateRoleCmd(apiURL, credPath, teamID, subjectID, role string) error {
+	teamUUID, err := uuid.Parse(teamID)
+	if err != nil {
+		return fmt.Errorf("invalid team ID %q: %w", teamID, err)
+	}
+	subjectUUID, err := uuid.Parse(subjectID)
+	if err != nil {
+		return fmt.Errorf("invalid subject ID %q: %w", subjectID, err)
+	}
+	client, err := newClientFromCreds(apiURL, credPath)
+	if err != nil {
+		return err
+	}
+	req := &moltnetapi.UpdateTeamMemberRoleReq{
+		Role: moltnetapi.UpdateTeamMemberRoleReqRole(role),
+	}
+	res, err := client.UpdateTeamMemberRole(context.Background(), req, moltnetapi.UpdateTeamMemberRoleParams{
+		ID:        teamUUID,
+		SubjectId: subjectUUID,
+	})
+	if err != nil {
+		return fmt.Errorf("teams members update-role: %w", formatTransportError(err))
+	}
+	updated, ok := res.(*moltnetapi.UpdateTeamMemberRoleOK)
+	if !ok {
+		return formatAPIError(res)
+	}
+	return printJSON(updated)
+}
+
 // runTeamsInviteDeleteCmd deletes a team invite code.
 func runTeamsInviteDeleteCmd(apiURL, credPath, teamID, inviteID string) error {
 	teamUUID, err := uuid.Parse(teamID)

--- a/apps/moltnet-cli/teams_test.go
+++ b/apps/moltnet-cli/teams_test.go
@@ -47,7 +47,7 @@ func TestTeamsMembersHelp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	for _, sub := range []string{"list", "remove"} {
+	for _, sub := range []string{"list", "remove", "update-role"} {
 		if !strings.Contains(stdout, sub) {
 			t.Errorf("expected members help to contain %q, got: %s", sub, stdout)
 		}
@@ -73,6 +73,53 @@ func TestTeamsMembersRemoveRequiresArgs(t *testing.T) {
 	_, _, err = executeCommand(root, "teams", "members", "remove", "team-id-only")
 	if err == nil {
 		t.Fatal("expected error when subject ID is missing")
+	}
+}
+
+func TestTeamsMembersUpdateRoleRequiresArgs(t *testing.T) {
+	t.Parallel()
+	root := NewRootCmd("test", "")
+	_, _, err := executeCommand(root, "teams", "members", "update-role")
+	if err == nil {
+		t.Fatal("expected error when team and subject IDs are missing")
+	}
+	_, _, err = executeCommand(root, "teams", "members", "update-role", "team-id-only")
+	if err == nil {
+		t.Fatal("expected error when subject ID is missing")
+	}
+}
+
+func TestTeamsMembersUpdateRoleRequiresRoleFlag(t *testing.T) {
+	t.Parallel()
+	root := NewRootCmd("test", "")
+	_, _, err := executeCommand(
+		root,
+		"teams",
+		"members",
+		"update-role",
+		"00000000-0000-0000-0000-000000000000",
+		"00000000-0000-0000-0000-000000000000",
+	)
+	if err == nil {
+		t.Fatal("expected error when --role is missing")
+	}
+	if !strings.Contains(err.Error(), "role") {
+		t.Errorf("expected error to mention --role, got: %v", err)
+	}
+}
+
+func TestTeamsMembersUpdateRoleHelp(t *testing.T) {
+	t.Parallel()
+	root := NewRootCmd("test", "")
+	stdout, _, err := executeCommand(root, "teams", "members", "update-role", "--help")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stdout, "--role") {
+		t.Errorf("expected update-role help to contain --role, got: %s", stdout)
+	}
+	if !strings.Contains(stdout, "manager") || !strings.Contains(stdout, "member") {
+		t.Errorf("expected update-role help to mention member and manager roles, got: %s", stdout)
 	}
 }
 

--- a/docs/use/teams.md
+++ b/docs/use/teams.md
@@ -36,7 +36,7 @@ Invites can be listed (`teams_invite_list`) and revoked (`teams_invite_delete`) 
 
 ### Managing members
 
-Owners and managers can remove members with `teams_member_remove`. Owners can't be removed by anyone except themselves — ownership transfer is an explicit, symmetrical operation, not a demotion.
+Owners and managers can update a member's role between `member` and `manager` with `updateTeamMemberRole` / `teams members update-role`, and remove members with `teams_member_remove`. Owners can't be removed by anyone except themselves — ownership transfer is an explicit, symmetrical operation, not a demotion.
 
 ## Groups
 

--- a/go.work.sum
+++ b/go.work.sum
@@ -19,6 +19,7 @@ github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xW
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/getlarge/themoltnet/libs/moltnet-api-client v1.27.0/go.mod h1:2NM6Nj6POFphfql+G6u6/4F2i3EIo5Jd95DBX1lhPLM=
+github.com/getlarge/themoltnet/libs/moltnet-api-client v1.29.0/go.mod h1:2NM6Nj6POFphfql+G6u6/4F2i3EIo5Jd95DBX1lhPLM=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/s2a-go v0.1.7/go.mod h1:50CgR4k1jNlWBu4UfS4AcfhVe1r6pdZPygJ3R8F0Qdw=

--- a/libs/sdk/__tests__/agent.test.ts
+++ b/libs/sdk/__tests__/agent.test.ts
@@ -53,6 +53,7 @@ import {
   updateContextPack,
   updateDiary,
   updateDiaryEntryById,
+  updateTeamMemberRole,
   verifyAgentSignature,
   verifyCryptoSignature,
   verifyDiaryEntryById,
@@ -115,6 +116,7 @@ vi.mock('@moltnet/api-client', async (importOriginal) => {
     joinTeam: vi.fn(),
     deleteTeam: vi.fn(),
     removeTeamMember: vi.fn(),
+    updateTeamMemberRole: vi.fn(),
     createTeamInvite: vi.fn(),
     listTeamInvites: vi.fn(),
     deleteTeamInvite: vi.fn(),
@@ -1314,6 +1316,29 @@ describe('Agent facade', () => {
       expect(deleteTeamInvite).toHaveBeenCalledWith(
         expect.objectContaining({
           path: { id: 'team-1', inviteId: 'invite-1' },
+        }),
+      );
+    });
+
+    it('teams.updateMemberRole sends path params and role body', async () => {
+      const updated = { updated: true, role: 'manager' };
+      vi.mocked(updateTeamMemberRole).mockResolvedValueOnce({
+        data: updated,
+        error: undefined,
+      } as any);
+
+      const agent = makeAgent();
+      const result = await agent.teams.updateMemberRole(
+        'team-1',
+        'subject-1',
+        'manager',
+      );
+
+      expect(result).toEqual(updated);
+      expect(updateTeamMemberRole).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: { id: 'team-1', subjectId: 'subject-1' },
+          body: { role: 'manager' },
         }),
       );
     });

--- a/libs/sdk/src/agent.ts
+++ b/libs/sdk/src/agent.ts
@@ -100,6 +100,8 @@ import type {
   UpdateDiaryData,
   UpdateDiaryEntryByIdData,
   UpdateRenderedPackData,
+  UpdateTeamMemberRoleData,
+  UpdateTeamMemberRoleResponse,
   VerifyResult,
   Voucher,
 } from '@moltnet/api-client';
@@ -386,6 +388,11 @@ export interface TeamsNamespace {
     teamId: string,
     subjectId: string,
   ): Promise<RemoveTeamMemberResponse>;
+  updateMemberRole(
+    teamId: string,
+    subjectId: string,
+    role: UpdateTeamMemberRoleData['body']['role'],
+  ): Promise<UpdateTeamMemberRoleResponse>;
   invites: {
     create(
       teamId: string,

--- a/libs/sdk/src/namespaces/teams.ts
+++ b/libs/sdk/src/namespaces/teams.ts
@@ -9,6 +9,7 @@ import {
   listTeamMembers,
   listTeams,
   removeTeamMember,
+  updateTeamMemberRole,
 } from '@moltnet/api-client';
 
 import type { TeamsNamespace } from '../agent.js';
@@ -51,6 +52,17 @@ export function createTeamsNamespace(context: AgentContext): TeamsNamespace {
           client,
           auth,
           path: { id: teamId, subjectId },
+        }),
+      );
+    },
+
+    async updateMemberRole(teamId, subjectId, role) {
+      return unwrapResult(
+        await updateTeamMemberRole({
+          client,
+          auth,
+          path: { id: teamId, subjectId },
+          body: { role },
         }),
       );
     },

--- a/packages/agent-daemon-action/dist/main.js
+++ b/packages/agent-daemon-action/dist/main.js
@@ -29327,6 +29327,32 @@ var removeTeamMember = (options) => (options.client ?? client).delete({
 	...options
 });
 /**
+* Update a member role between member and manager. Requires manage_members permission.
+*/
+var updateTeamMemberRole = (options) => (options.client ?? client).patch({
+	security: [
+		{
+			scheme: "bearer",
+			type: "http"
+		},
+		{
+			name: "X-Moltnet-Session-Token",
+			type: "apiKey"
+		},
+		{
+			in: "cookie",
+			name: "ory_kratos_session",
+			type: "apiKey"
+		}
+	],
+	url: "/teams/{id}/members/{subjectId}",
+	...options,
+	headers: {
+		"Content-Type": "application/json",
+		...options.headers
+	}
+});
+/**
 * List invite codes. Requires manage_members permission.
 */
 var listTeamInvites = (options) => (options.client ?? client).get({
@@ -32389,6 +32415,17 @@ function createTeamsNamespace(context) {
 					id: teamId,
 					subjectId
 				}
+			}));
+		},
+		async updateMemberRole(teamId, subjectId, role) {
+			return unwrapResult(await updateTeamMemberRole({
+				client,
+				auth,
+				path: {
+					id: teamId,
+					subjectId
+				},
+				body: { role }
 			}));
 		},
 		invites: {


### PR DESCRIPTION
## Summary
- expose `teams.updateMemberRole` in `@themoltnet/sdk`
- add `moltnet teams members update-role` to the CLI and cover the new flow in tests
- bump `github.com/getlarge/themoltnet/libs/moltnet-api-client` to `v1.29.0` for `apps/moltnet-cli`
- sync `packages/agent-daemon-action/dist/main.js` after the SDK surface change

## Testing
- pnpm exec vitest run libs/sdk/__tests__/agent.test.ts
- go test ./apps/moltnet-cli -run "TestTeams"
- go test ./apps/moltnet-cli -tags=e2e -run TestE2E_CLI_TeamLifecycle -v
- CI rerun: `agent-daemon-action dist sync` and `E2E Tests (Go CLI)` now pass

## Follow-up
- tracked server-side role serialization mismatch in #1203 (`listTeamMembers` still returns plural Keto relation names while `updateTeamMemberRole` uses singular roles)