### PR TITLE
[codex] Add propose-issue daemon workflow skill

### DIFF
--- a/.agents/skills/propose-issue/SKILL.md
+++ b/.agents/skills/propose-issue/SKILL.md
@@ -232,7 +232,9 @@ const brief = [
   `- The issue is addressed with the smallest coherent change.`,
   `- Tests or validation commands are run and reported.`,
   `- Final task output includes branch, commits, PR URL if created, diary entry ids, and a concise summary.`,
-].filter(Boolean).join('\n');
+]
+  .filter(Boolean)
+  .join('\n');
 
 const agent = await connect(configDir ? { configDir } : {});
 const task = await agent.tasks.create({

--- a/.agents/skills/propose-issue/SKILL.md
+++ b/.agents/skills/propose-issue/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: propose-issue
+description: Propose a GitHub issue as a MoltNet daemon task. Use when the user wants to turn a getlarge/themoltnet issue into an enriched fulfill_brief task proposal for daemon agents without claiming the issue locally, assigning it, creating a worktree, or using repo-internal task scripts.
+---
+
+# propose-issue
+
+Create a high-quality task proposal from a GitHub issue for daemon agents to
+voluntarily claim later. This is the daemon-oriented sibling of
+`claim-issue`.
+
+## Scope
+
+Inputs:
+
+- Issue number: `123`
+- Issue URL: `https://github.com/getlarge/themoltnet/issues/123`
+
+Default repo: `getlarge/themoltnet`. If a URL points elsewhere, stop and ask
+for confirmation.
+
+Use the word **publish** for creating the task. Do not call this "impose" in
+user-facing text.
+
+## Hard rules
+
+- Load the `legreffier` skill first; it owns identity, GitHub App token, and
+  `.moltnet/<agent>/` resolution.
+- Do not assign the issue, add labels, create branches, create worktrees, or
+  push commits from the proposer side.
+- Do not run `pnpm --filter @moltnet/tools task:fulfill-brief` or any other
+  repo-local helper. This skill must work when published outside this repo.
+- Use the released MoltNet CLI only for operational token/config helpers
+  (`moltnet` on PATH, or `npx @themoltnet/cli` fallback).
+- Use the published SDK (`@themoltnet/sdk`) to publish the task.
+- Preview the proposal and ask once before publishing.
+- If a GitHub token cannot be resolved from the agent credentials, stop rather
+  than falling back to a human token.
+
+## Workflow
+
+### 1. Resolve identity and credentials
+
+Use `legreffier` activation. Resolve:
+
+- `AGENT_NAME`
+- absolute credentials path: `.moltnet/<AGENT_NAME>/moltnet.json`
+- env file: `.moltnet/<AGENT_NAME>/env`
+- `MOLTNET_TEAM_ID`
+- `MOLTNET_DIARY_ID`
+
+If `MOLTNET_TEAM_ID` or `MOLTNET_DIARY_ID` is missing, stop and tell the user
+to finish LeGreffier onboarding.
+
+Mint an agent GitHub App token with the released CLI:
+
+```bash
+GH_TOKEN=$(moltnet github token --credentials "<ABSOLUTE-CREDS-PATH>")
+```
+
+If `moltnet` is not available, use:
+
+```bash
+GH_TOKEN=$(npx @themoltnet/cli github token --credentials "<ABSOLUTE-CREDS-PATH>")
+```
+
+If this prints an empty token, stop.
+
+### 2. Fetch issue metadata
+
+Fetch the issue and recent comments with the agent token. Use either `gh` with
+`GH_TOKEN` set or GitHub REST. Do not run bare `gh`.
+
+Required fields:
+
+- number, title, body, html URL, state, labels
+- recent comments, ideally the latest 5
+
+If the issue is closed, ask whether to continue before drafting.
+
+### 3. Enrich the brief
+
+Add only task-relevant context. Good enrichment:
+
+- issue labels and useful recent comments
+- likely files/modules from quick local search
+- related issues, PRs, or diary findings if discovered
+- non-goals and risk notes
+- suggested validation commands
+- explicit acceptance criteria
+
+Do not paste generic system policy. The daemon runtime already has its own
+execution instructions.
+
+Recommended brief shape:
+
+```md
+## Goal
+
+Resolve GitHub issue #<n>: <title>
+
+## Source
+
+<issue-url>
+
+## Issue Context
+
+<body, labels, useful recent comments>
+
+## Added Context From Proposer
+
+<local notes, diary findings, related PRs/issues, constraints>
+
+## Expected Workflow
+
+- Inspect relevant code before changing behavior.
+- Prefer existing repository patterns and package boundaries.
+- Work in an isolated branch/worktree if available.
+- If you decide to work on this proposal, self-assign GitHub issue #<n>
+  using your GitHub App identity. Do not assign other agents or humans.
+- Commit with the accountable diary workflow.
+- Push a branch and open a PR referencing issue #<n>, unless the issue or
+  proposer explicitly says no PR is needed.
+
+## Acceptance Criteria
+
+- <specific observable criterion>
+- Tests or validation commands are run and reported.
+- Final task output includes branch, commits, PR URL if created, diary entry
+  ids, and a concise summary.
+
+## Suggested Validation
+
+- `<command>`
+```
+
+### 4. Preview before publishing
+
+Show a compact preview:
+
+- issue URL and state
+- selected team id and diary id
+- task type: `fulfill_brief`
+- title and scope hint
+- correlation id
+- acceptance criteria
+- timeout/executor pinning if any
+- full brief or a concise but complete excerpt
+
+Ask once before publishing. If the user only asked for a draft, stop after the
+preview.
+
+### 5. Publish using the SDK
+
+Use ESM and the published SDK. This snippet is intentionally self-contained so
+the skill can be published by LeGreffier without depending on this repository's
+internal tools.
+
+```js
+import { randomUUID } from 'node:crypto';
+import { connect } from '@themoltnet/sdk';
+
+const required = (name) => {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing ${name}`);
+  return value;
+};
+
+const teamId = required('MOLTNET_TEAM_ID');
+const diaryId = required('MOLTNET_DIARY_ID');
+const githubToken = required('GITHUB_TOKEN');
+const issueNumber = required('ISSUE_NUMBER');
+const repo = process.env.GITHUB_REPOSITORY ?? 'getlarge/themoltnet';
+const configDir = process.env.MOLTNET_CONFIG_DIR;
+const correlationId = process.env.MOLTNET_CORRELATION_ID ?? randomUUID();
+
+const gh = async (path) => {
+  const response = await fetch(`https://api.github.com${path}`, {
+    headers: {
+      accept: 'application/vnd.github+json',
+      authorization: `Bearer ${githubToken}`,
+      'user-agent': 'moltnet-propose-issue-skill',
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`GitHub API ${path} failed: ${response.status}`);
+  }
+  return response.json();
+};
+
+const issue = await gh(`/repos/${repo}/issues/${issueNumber}`);
+const comments = await gh(
+  `/repos/${repo}/issues/${issueNumber}/comments?per_page=100`,
+);
+
+const labels = (issue.labels ?? [])
+  .map((label) => (typeof label === 'string' ? label : label.name))
+  .filter(Boolean)
+  .join(', ');
+
+const recentComments = comments
+  .slice(-5)
+  .map((comment) => `**${comment.user?.login ?? 'unknown'}**: ${comment.body}`)
+  .join('\n\n');
+
+const brief = [
+  `## Goal`,
+  ``,
+  `Resolve GitHub issue #${issue.number}: ${issue.title}`,
+  ``,
+  `## Source`,
+  ``,
+  issue.html_url,
+  ``,
+  `## Issue Context`,
+  ``,
+  labels ? `Labels: ${labels}` : '',
+  issue.body || '_No description provided._',
+  recentComments ? `\n### Recent comments\n\n${recentComments}` : '',
+  ``,
+  `## Expected Workflow`,
+  ``,
+  `- Inspect relevant code before changing behavior.`,
+  `- Prefer existing repository patterns and package boundaries.`,
+  `- Work in an isolated branch/worktree if available.`,
+  `- If you decide to work on this proposal, self-assign GitHub issue #${issue.number} using your GitHub App identity. Do not assign other agents or humans.`,
+  `- Commit with the accountable diary workflow.`,
+  `- Push a branch and open a PR referencing issue #${issue.number}, unless explicitly unnecessary.`,
+  ``,
+  `## Acceptance Criteria`,
+  ``,
+  `- The issue is addressed with the smallest coherent change.`,
+  `- Tests or validation commands are run and reported.`,
+  `- Final task output includes branch, commits, PR URL if created, diary entry ids, and a concise summary.`,
+].filter(Boolean).join('\n');
+
+const agent = await connect(configDir ? { configDir } : {});
+const task = await agent.tasks.create({
+  taskType: 'fulfill_brief',
+  teamId,
+  diaryId,
+  correlationId,
+  input: {
+    title: issue.title,
+    brief,
+    scopeHint: 'issue',
+  },
+  references: [
+    {
+      taskId: null,
+      outputCid: `gh:issue:${repo}#${issue.number}`,
+      role: 'context',
+      external: {
+        kind: 'github_issue',
+        repo,
+        issue: issue.number,
+        url: issue.html_url,
+      },
+    },
+  ],
+});
+
+console.log(JSON.stringify({ taskId: task.id, correlationId }, null, 2));
+```
+
+Run the snippet with:
+
+```bash
+MOLTNET_TEAM_ID="<team-id>" \
+MOLTNET_DIARY_ID="<diary-id>" \
+MOLTNET_CONFIG_DIR="<ABSOLUTE-AGENT-DIR>" \
+GITHUB_TOKEN="<agent-github-app-token>" \
+GITHUB_REPOSITORY="getlarge/themoltnet" \
+ISSUE_NUMBER="<n>" \
+node propose-issue.mjs
+```
+
+If `@themoltnet/sdk` is not installed in the current environment, install or
+invoke it as a published package; do not switch to repo-local tooling.
+
+## Public docs
+
+Reference public docs when useful:
+
+- https://docs.themolt.net/use/sdk-and-integrations.html
+- https://docs.themolt.net/use/tasks.html
+- https://docs.themolt.net/use/agent-daemon.html
+
+## Handoff
+
+Report:
+
+- published task id or "draft only"
+- correlation id
+- issue URL
+- team and diary ids used
+- whether the proposer avoided assignment and branch/worktree side effects
+- next daemon command only if the user asks how to run a daemon

--- a/.claude/skills/propose-issue/SKILL.md
+++ b/.claude/skills/propose-issue/SKILL.md
@@ -232,7 +232,9 @@ const brief = [
   `- The issue is addressed with the smallest coherent change.`,
   `- Tests or validation commands are run and reported.`,
   `- Final task output includes branch, commits, PR URL if created, diary entry ids, and a concise summary.`,
-].filter(Boolean).join('\n');
+]
+  .filter(Boolean)
+  .join('\n');
 
 const agent = await connect(configDir ? { configDir } : {});
 const task = await agent.tasks.create({

--- a/.claude/skills/propose-issue/SKILL.md
+++ b/.claude/skills/propose-issue/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: propose-issue
+description: Propose a GitHub issue as a MoltNet daemon task. Use when the user wants to turn a getlarge/themoltnet issue into an enriched fulfill_brief task proposal for daemon agents without claiming the issue locally, assigning it, creating a worktree, or using repo-internal task scripts.
+---
+
+# propose-issue
+
+Create a high-quality task proposal from a GitHub issue for daemon agents to
+voluntarily claim later. This is the daemon-oriented sibling of
+`claim-issue`.
+
+## Scope
+
+Inputs:
+
+- Issue number: `123`
+- Issue URL: `https://github.com/getlarge/themoltnet/issues/123`
+
+Default repo: `getlarge/themoltnet`. If a URL points elsewhere, stop and ask
+for confirmation.
+
+Use the word **publish** for creating the task. Do not call this "impose" in
+user-facing text.
+
+## Hard rules
+
+- Load the `legreffier` skill first; it owns identity, GitHub App token, and
+  `.moltnet/<agent>/` resolution.
+- Do not assign the issue, add labels, create branches, create worktrees, or
+  push commits from the proposer side.
+- Do not run `pnpm --filter @moltnet/tools task:fulfill-brief` or any other
+  repo-local helper. This skill must work when published outside this repo.
+- Use the released MoltNet CLI only for operational token/config helpers
+  (`moltnet` on PATH, or `npx @themoltnet/cli` fallback).
+- Use the published SDK (`@themoltnet/sdk`) to publish the task.
+- Preview the proposal and ask once before publishing.
+- If a GitHub token cannot be resolved from the agent credentials, stop rather
+  than falling back to a human token.
+
+## Workflow
+
+### 1. Resolve identity and credentials
+
+Use `legreffier` activation. Resolve:
+
+- `AGENT_NAME`
+- absolute credentials path: `.moltnet/<AGENT_NAME>/moltnet.json`
+- env file: `.moltnet/<AGENT_NAME>/env`
+- `MOLTNET_TEAM_ID`
+- `MOLTNET_DIARY_ID`
+
+If `MOLTNET_TEAM_ID` or `MOLTNET_DIARY_ID` is missing, stop and tell the user
+to finish LeGreffier onboarding.
+
+Mint an agent GitHub App token with the released CLI:
+
+```bash
+GH_TOKEN=$(moltnet github token --credentials "<ABSOLUTE-CREDS-PATH>")
+```
+
+If `moltnet` is not available, use:
+
+```bash
+GH_TOKEN=$(npx @themoltnet/cli github token --credentials "<ABSOLUTE-CREDS-PATH>")
+```
+
+If this prints an empty token, stop.
+
+### 2. Fetch issue metadata
+
+Fetch the issue and recent comments with the agent token. Use either `gh` with
+`GH_TOKEN` set or GitHub REST. Do not run bare `gh`.
+
+Required fields:
+
+- number, title, body, html URL, state, labels
+- recent comments, ideally the latest 5
+
+If the issue is closed, ask whether to continue before drafting.
+
+### 3. Enrich the brief
+
+Add only task-relevant context. Good enrichment:
+
+- issue labels and useful recent comments
+- likely files/modules from quick local search
+- related issues, PRs, or diary findings if discovered
+- non-goals and risk notes
+- suggested validation commands
+- explicit acceptance criteria
+
+Do not paste generic system policy. The daemon runtime already has its own
+execution instructions.
+
+Recommended brief shape:
+
+```md
+## Goal
+
+Resolve GitHub issue #<n>: <title>
+
+## Source
+
+<issue-url>
+
+## Issue Context
+
+<body, labels, useful recent comments>
+
+## Added Context From Proposer
+
+<local notes, diary findings, related PRs/issues, constraints>
+
+## Expected Workflow
+
+- Inspect relevant code before changing behavior.
+- Prefer existing repository patterns and package boundaries.
+- Work in an isolated branch/worktree if available.
+- If you decide to work on this proposal, self-assign GitHub issue #<n>
+  using your GitHub App identity. Do not assign other agents or humans.
+- Commit with the accountable diary workflow.
+- Push a branch and open a PR referencing issue #<n>, unless the issue or
+  proposer explicitly says no PR is needed.
+
+## Acceptance Criteria
+
+- <specific observable criterion>
+- Tests or validation commands are run and reported.
+- Final task output includes branch, commits, PR URL if created, diary entry
+  ids, and a concise summary.
+
+## Suggested Validation
+
+- `<command>`
+```
+
+### 4. Preview before publishing
+
+Show a compact preview:
+
+- issue URL and state
+- selected team id and diary id
+- task type: `fulfill_brief`
+- title and scope hint
+- correlation id
+- acceptance criteria
+- timeout/executor pinning if any
+- full brief or a concise but complete excerpt
+
+Ask once before publishing. If the user only asked for a draft, stop after the
+preview.
+
+### 5. Publish using the SDK
+
+Use ESM and the published SDK. This snippet is intentionally self-contained so
+the skill can be published by LeGreffier without depending on this repository's
+internal tools.
+
+```js
+import { randomUUID } from 'node:crypto';
+import { connect } from '@themoltnet/sdk';
+
+const required = (name) => {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing ${name}`);
+  return value;
+};
+
+const teamId = required('MOLTNET_TEAM_ID');
+const diaryId = required('MOLTNET_DIARY_ID');
+const githubToken = required('GITHUB_TOKEN');
+const issueNumber = required('ISSUE_NUMBER');
+const repo = process.env.GITHUB_REPOSITORY ?? 'getlarge/themoltnet';
+const configDir = process.env.MOLTNET_CONFIG_DIR;
+const correlationId = process.env.MOLTNET_CORRELATION_ID ?? randomUUID();
+
+const gh = async (path) => {
+  const response = await fetch(`https://api.github.com${path}`, {
+    headers: {
+      accept: 'application/vnd.github+json',
+      authorization: `Bearer ${githubToken}`,
+      'user-agent': 'moltnet-propose-issue-skill',
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`GitHub API ${path} failed: ${response.status}`);
+  }
+  return response.json();
+};
+
+const issue = await gh(`/repos/${repo}/issues/${issueNumber}`);
+const comments = await gh(
+  `/repos/${repo}/issues/${issueNumber}/comments?per_page=100`,
+);
+
+const labels = (issue.labels ?? [])
+  .map((label) => (typeof label === 'string' ? label : label.name))
+  .filter(Boolean)
+  .join(', ');
+
+const recentComments = comments
+  .slice(-5)
+  .map((comment) => `**${comment.user?.login ?? 'unknown'}**: ${comment.body}`)
+  .join('\n\n');
+
+const brief = [
+  `## Goal`,
+  ``,
+  `Resolve GitHub issue #${issue.number}: ${issue.title}`,
+  ``,
+  `## Source`,
+  ``,
+  issue.html_url,
+  ``,
+  `## Issue Context`,
+  ``,
+  labels ? `Labels: ${labels}` : '',
+  issue.body || '_No description provided._',
+  recentComments ? `\n### Recent comments\n\n${recentComments}` : '',
+  ``,
+  `## Expected Workflow`,
+  ``,
+  `- Inspect relevant code before changing behavior.`,
+  `- Prefer existing repository patterns and package boundaries.`,
+  `- Work in an isolated branch/worktree if available.`,
+  `- If you decide to work on this proposal, self-assign GitHub issue #${issue.number} using your GitHub App identity. Do not assign other agents or humans.`,
+  `- Commit with the accountable diary workflow.`,
+  `- Push a branch and open a PR referencing issue #${issue.number}, unless explicitly unnecessary.`,
+  ``,
+  `## Acceptance Criteria`,
+  ``,
+  `- The issue is addressed with the smallest coherent change.`,
+  `- Tests or validation commands are run and reported.`,
+  `- Final task output includes branch, commits, PR URL if created, diary entry ids, and a concise summary.`,
+].filter(Boolean).join('\n');
+
+const agent = await connect(configDir ? { configDir } : {});
+const task = await agent.tasks.create({
+  taskType: 'fulfill_brief',
+  teamId,
+  diaryId,
+  correlationId,
+  input: {
+    title: issue.title,
+    brief,
+    scopeHint: 'issue',
+  },
+  references: [
+    {
+      taskId: null,
+      outputCid: `gh:issue:${repo}#${issue.number}`,
+      role: 'context',
+      external: {
+        kind: 'github_issue',
+        repo,
+        issue: issue.number,
+        url: issue.html_url,
+      },
+    },
+  ],
+});
+
+console.log(JSON.stringify({ taskId: task.id, correlationId }, null, 2));
+```
+
+Run the snippet with:
+
+```bash
+MOLTNET_TEAM_ID="<team-id>" \
+MOLTNET_DIARY_ID="<diary-id>" \
+MOLTNET_CONFIG_DIR="<ABSOLUTE-AGENT-DIR>" \
+GITHUB_TOKEN="<agent-github-app-token>" \
+GITHUB_REPOSITORY="getlarge/themoltnet" \
+ISSUE_NUMBER="<n>" \
+node propose-issue.mjs
+```
+
+If `@themoltnet/sdk` is not installed in the current environment, install or
+invoke it as a published package; do not switch to repo-local tooling.
+
+## Public docs
+
+Reference public docs when useful:
+
+- https://docs.themolt.net/use/sdk-and-integrations.html
+- https://docs.themolt.net/use/tasks.html
+- https://docs.themolt.net/use/agent-daemon.html
+
+## Handoff
+
+Report:
+
+- published task id or "draft only"
+- correlation id
+- issue URL
+- team and diary ids used
+- whether the proposer avoided assignment and branch/worktree side effects
+- next daemon command only if the user asks how to run a daemon

--- a/evals/propose-issue/scenario-0/capability.txt
+++ b/evals/propose-issue/scenario-0/capability.txt
@@ -1,0 +1,1 @@
+Propose a GitHub issue as a daemon task without claiming or assigning it

--- a/evals/propose-issue/scenario-0/criteria.json
+++ b/evals/propose-issue/scenario-0/criteria.json
@@ -1,0 +1,41 @@
+{
+  "checklist": [
+    {
+      "description": "Attempt messages or final answer show use of the propose-issue workflow, including issue metadata gathering and proposal drafting rather than starting implementation",
+      "max_score": 16,
+      "name": "Proposal workflow used"
+    },
+    {
+      "description": "The answer clearly keeps claimant-side actions separate from proposer-side actions",
+      "max_score": 14,
+      "name": "Proposer/claimant boundary"
+    },
+    {
+      "description": "No GitHub assignment, label mutation, branch creation, worktree creation, commit, push, or PR creation is attempted by the proposer",
+      "max_score": 18,
+      "name": "No local claim side effects"
+    },
+    {
+      "description": "The proposed brief tells the daemon claimant to self-assign with its GitHub App identity if it decides to work, and not to assign other agents or humans",
+      "max_score": 14,
+      "name": "Self-assignment instruction"
+    },
+    {
+      "description": "The proposal includes task-relevant enrichment beyond raw issue body, such as labels/comments, local context, non-goals, risks, acceptance criteria, or validation commands",
+      "max_score": 16,
+      "name": "Brief enrichment"
+    },
+    {
+      "description": "The agent previews the task proposal and asks for explicit confirmation before publishing it",
+      "max_score": 16,
+      "name": "Preview before publish"
+    },
+    {
+      "description": "User-facing text uses publish/propose wording and avoids saying the task will be imposed",
+      "max_score": 6,
+      "name": "Correct terminology"
+    }
+  ],
+  "context": "Positive proposal scenario: issue work should be offered to daemon agents without the current session claiming ownership.",
+  "type": "weighted_checklist"
+}

--- a/evals/propose-issue/scenario-0/eval.json
+++ b/evals/propose-issue/scenario-0/eval.json
@@ -1,0 +1,1 @@
+{ "mode": "vitro", "workspace": "none" }

--- a/evals/propose-issue/scenario-0/task.md
+++ b/evals/propose-issue/scenario-0/task.md
@@ -1,0 +1,16 @@
+# Propose Issue Without Claiming
+
+The user asks:
+
+> Use the propose-issue skill for issue #123. I want this to go to a daemon
+> agent, not to the current session. Prepare the proposal and publish it only
+> after I confirm.
+
+## Expectations
+
+- Treat this as a proposal for daemon agents, not local work.
+- Load or follow the propose-issue workflow.
+- Do not assign the GitHub issue from the proposer side.
+- Do not create a branch, worktree, commit, or PR from the proposer side.
+- Build an enriched `fulfill_brief` task proposal.
+- Preview the task proposal and ask for confirmation before publishing.

--- a/evals/propose-issue/scenario-1/capability.txt
+++ b/evals/propose-issue/scenario-1/capability.txt
@@ -1,0 +1,1 @@
+Use published MoltNet SDK and released CLI helpers instead of repo-internal task scripts

--- a/evals/propose-issue/scenario-1/criteria.json
+++ b/evals/propose-issue/scenario-1/criteria.json
@@ -1,0 +1,41 @@
+{
+  "checklist": [
+    {
+      "description": "The response does not recommend or run `pnpm --filter @moltnet/tools task:fulfill-brief`, `tools/src/tasks/fulfill-brief.ts`, or any repo-local task helper",
+      "max_score": 20,
+      "name": "No internal task tooling"
+    },
+    {
+      "description": "The proposed publish path uses `@themoltnet/sdk` and `agent.tasks.create` or the equivalent SDK task namespace",
+      "max_score": 18,
+      "name": "Published SDK task creation"
+    },
+    {
+      "description": "The code or instructions use ESM JavaScript and environment/config inputs suitable for a published skill outside this repository",
+      "max_score": 14,
+      "name": "Portable ESM snippet"
+    },
+    {
+      "description": "GitHub metadata is fetched with an agent GitHub App token and the response fails closed if the token cannot be resolved",
+      "max_score": 16,
+      "name": "Agent GitHub token only"
+    },
+    {
+      "description": "The response uses released MoltNet CLI forms only for operational helper commands, not workspace-built binaries",
+      "max_score": 12,
+      "name": "Released CLI helper only"
+    },
+    {
+      "description": "The task payload includes `taskType: fulfill_brief`, `teamId`, `diaryId`, `correlationId`, a structured input brief, and a GitHub issue reference",
+      "max_score": 16,
+      "name": "Complete task payload"
+    },
+    {
+      "description": "The response points users toward public MoltNet docs for SDK, tasks, or daemon usage instead of relying only on repository docs",
+      "max_score": 4,
+      "name": "Public docs reference"
+    }
+  ],
+  "context": "Publishability scenario: the skill should work when distributed through LeGreffier, not only from this monorepo checkout.",
+  "type": "weighted_checklist"
+}

--- a/evals/propose-issue/scenario-1/eval.json
+++ b/evals/propose-issue/scenario-1/eval.json
@@ -1,0 +1,1 @@
+{ "mode": "vitro", "workspace": "none" }

--- a/evals/propose-issue/scenario-1/task.md
+++ b/evals/propose-issue/scenario-1/task.md
@@ -1,0 +1,17 @@
+# Publishable Skill Surface
+
+The user asks:
+
+> Draft the command/code path this publishable skill should use for proposing
+> issue #456. This must work outside the MoltNet repository, so do not use
+> internal pnpm workspace scripts.
+
+## Expectations
+
+- Avoid `pnpm --filter @moltnet/tools task:fulfill-brief`.
+- Use a published SDK based JavaScript ESM snippet for task creation.
+- Use released MoltNet CLI only for operational helpers such as minting the
+  GitHub App token.
+- Fail closed instead of falling back to a human GitHub token.
+- Mention public docs rather than internal-only tooling as the external user
+  reference point.

--- a/evals/propose-issue/scenario-2/capability.txt
+++ b/evals/propose-issue/scenario-2/capability.txt
@@ -1,0 +1,1 @@
+Enrich a daemon brief with useful instructions without overstepping runtime responsibilities

--- a/evals/propose-issue/scenario-2/criteria.json
+++ b/evals/propose-issue/scenario-2/criteria.json
@@ -1,0 +1,41 @@
+{
+  "checklist": [
+    {
+      "description": "The drafted brief has clear sections such as Goal, Source, Issue Context, Added Context, Expected Workflow, Acceptance Criteria, and Suggested Validation",
+      "max_score": 16,
+      "name": "Structured brief"
+    },
+    {
+      "description": "The brief includes task-relevant context beyond the issue body, such as labels/comments, related files/modules, constraints, non-goals, or risk notes",
+      "max_score": 16,
+      "name": "Relevant enrichment"
+    },
+    {
+      "description": "The brief includes concrete acceptance criteria and validation commands or validation guidance",
+      "max_score": 16,
+      "name": "Acceptance and validation"
+    },
+    {
+      "description": "The brief instructs the daemon claimant to self-assign only if it decides to work, and forbids assigning other agents or humans",
+      "max_score": 12,
+      "name": "Claimant self-assignment only"
+    },
+    {
+      "description": "The response avoids broad generic policy dumps and does not duplicate runtime-level instructions unrelated to the issue",
+      "max_score": 14,
+      "name": "No generic policy dump"
+    },
+    {
+      "description": "The current session does not begin implementation, create local worktrees, or perform GitHub/project mutations",
+      "max_score": 14,
+      "name": "No execution side effects"
+    },
+    {
+      "description": "The response stops at draft/preview and asks for confirmation before any publication",
+      "max_score": 12,
+      "name": "Confirmation gate"
+    }
+  ],
+  "context": "Brief-quality scenario: propose-issue should improve the daemon's task input while preserving the daemon's autonomy and runtime boundary.",
+  "type": "weighted_checklist"
+}

--- a/evals/propose-issue/scenario-2/eval.json
+++ b/evals/propose-issue/scenario-2/eval.json
@@ -1,0 +1,1 @@
+{ "mode": "vitro", "workspace": "none" }

--- a/evals/propose-issue/scenario-2/task.md
+++ b/evals/propose-issue/scenario-2/task.md
@@ -1,0 +1,16 @@
+# Brief Enrichment Quality
+
+The user asks:
+
+> For issue #789, propose the daemon brief. Add the extra instructions you
+> think the daemon needs, but don't dump generic policy or start the work.
+
+## Expectations
+
+- Create a brief shape suitable for a `fulfill_brief` task.
+- Include only issue-relevant context and workflow instructions.
+- Include acceptance criteria and suggested validation.
+- Include self-assignment as an optional claimant-side action.
+- Do not include broad generic agent policy or duplicate runtime-level
+  instructions.
+- Do not execute or publish unless the user confirms.


### PR DESCRIPTION
## Summary

- Add a `propose-issue` skill in both `.agents/skills` and `.claude/skills` for turning GitHub issues into daemon task proposals.
- Define the proposer/claimant boundary: no proposer-side assignment, labels, branches, worktrees, commits, pushes, or PRs.
- Add three daemon-eval scenarios for proposal boundary behavior, publishable SDK usage, and brief enrichment quality.

## Why

This gives us a workflow for offering issue work to daemon agents without claiming it in the current session. The skill uses the published SDK path and released CLI helpers so it can be distributed through LeGreffier instead of relying on repo-internal tooling.

## Validation

- `node -e "for (const f of require('fs').readdirSync('evals/propose-issue',{withFileTypes:true}).flatMap(d=>d.isDirectory()?['evals/propose-issue/'+d.name+'/eval.json','evals/propose-issue/'+d.name+'/criteria.json']:[])) JSON.parse(require('fs').readFileSync(f,'utf8')); console.log('json ok')"`

MoltNet-Diary: 67c8aa3c-14ec-484b-bf90-06712f10efe4

<!-- legreffier-correlation: b0d9b549-7616-4ca3-ae34-d07e4f556994 -->
