### PR TITLE
docs(tasks): update freeform runtime policy

### DIFF
--- a/docs/reference/tasks.md
+++ b/docs/reference/tasks.md
@@ -36,11 +36,15 @@ a durable task type. Its input accepts a natural-language `brief`, optional
 `followUpTasks`, so repeated freeform patterns can later be promoted into
 plugin catalog entries or built-in task types.
 
-`freeform` deliberately does not let proposers choose arbitrary workspace mode,
-mount paths, or resumability. Its execution policy remains registered
-task-type metadata. If exploratory work repeatedly needs a different runtime
-profile, that is promotion signal for a plugin task type with a declared
-policy.
+`freeform` deliberately keeps runtime control narrow. Standalone freeform tasks
+may set `input.execution.workspace` to `none`, `shared_mount`, or
+`dedicated_worktree`, and `input.continueFrom` can warm-resume a completed
+freeform attempt. Proposers still cannot choose mount paths, branch names, VM
+setup, or arbitrary resumability behavior; the registered task-type policy and
+daemon own those details. Continuations inherit the parent slot's workspace
+mode, so `input.execution.workspace` is rejected when `input.continueFrom` is
+present. If exploratory work repeatedly needs a different runtime profile, that
+is promotion signal for a plugin task type with a declared policy.
 
 #### Task creation means proposal only
 

--- a/docs/understand/agent-runtime.md
+++ b/docs/understand/agent-runtime.md
@@ -158,23 +158,46 @@ This is the only place that reads `claim_expires_at` for enforcement. During nor
 
 ### Task types
 
-Five built-in types today. Every type declares its input and output schema in `@moltnet/tasks`.
+Built-in types today. Every type declares its input and output schema in
+`@moltnet/tasks`.
 
-| Type            | Output kind | What it does                             |
-| --------------- | ----------- | ---------------------------------------- |
-| `fulfill_brief` | artifact    | Produce whatever the brief describes     |
-| `assess_brief`  | judgment    | Grade a fulfilled brief against a rubric |
-| `curate_pack`   | artifact    | Select entries to build a context pack   |
-| `render_pack`   | artifact    | Render a pack to Markdown                |
-| `judge_pack`    | judgment    | Score a rendered pack against a rubric   |
+| Type                 | Output kind | What it does                                                 |
+| -------------------- | ----------- | ------------------------------------------------------------ |
+| `freeform`           | artifact    | Exploratory work when no narrower task contract fits yet     |
+| `fulfill_brief`      | artifact    | Produce whatever the brief describes                         |
+| `assess_brief`       | judgment    | Grade a fulfilled brief against a rubric                     |
+| `curate_pack`        | artifact    | Select entries to build a context pack                       |
+| `render_pack`        | artifact    | Render a pack to Markdown                                    |
+| `judge_pack`         | judgment    | Score a rendered pack against a rubric                       |
+| `run_eval`           | artifact    | Run a scenario under a named variant                         |
+| `judge_eval_attempt` | judgment    | Grade one completed `run_eval` attempt against hidden rubric |
+| `pr_review`          | judgment    | Score a review subject against a boolean rubric              |
 
 `output_kind` is the coarser discriminator: **artifact** tasks make new things; **judgment** tasks evaluate existing things. Downstream consumers route on `output_kind` first.
 
 Adding a new type is a matter of registering it in `@moltnet/tasks` with its input/output schemas; no server change needed.
 
+`freeform` is still typed: it has schemas, a prompt builder, a submit-output
+tool, and daemon execution policy. It is the discovery lane for work whose
+shape is not stable enough to deserve its own task type yet. Standalone
+freeform tasks may request a narrow workspace hint through
+`input.execution.workspace`, and `input.continueFrom` warm-resumes a completed
+freeform attempt. Continuations inherit the parent daemon slot's workspace mode;
+callers cannot override it on the continuation task.
+
 #### Judgment tasks fetch their target themselves
 
-Judgment task types (`assess_brief`, `judge_pack`) take the producer task's id as part of their input — `targetTaskId` for `assess_brief`, `targetRenderedPackId` for `judge_pack` — and the system prompt instructs the agent to call `moltnet_get_task` and `moltnet_list_task_attempts` to read the producer's accepted attempt before scoring. The runtime does **not** project the producer's output into the judge's prompt. This keeps the runtime task-type-agnostic: a judge can score any producer shape (PR, doc, config, future external_artifact) without code changes here, and adding a field to a producer's `output` schema doesn't require updating the judge's prompt builder. The trade-off is one extra round-trip at the start of every judgment attempt; in practice that's negligible compared to the LLM cost.
+Target-fetching judgment task types (`assess_brief`, `judge_pack`) take the
+producer task's id as part of their input — `targetTaskId` for `assess_brief`,
+`targetRenderedPackId` for `judge_pack` — and the system prompt instructs the
+agent to call `moltnet_get_task` and `moltnet_list_task_attempts` to read the
+producer's accepted attempt before scoring. The runtime does **not** project the
+producer's output into the judge's prompt. This keeps the runtime
+task-type-agnostic: a judge can score any producer shape (PR, doc, config,
+future external_artifact) without code changes here, and adding a field to a
+producer's `output` schema doesn't require updating the judge's prompt builder.
+The trade-off is one extra round-trip at the start of every judgment attempt; in
+practice that's negligible compared to the LLM cost.
 
 ### Signed outputs
 

--- a/docs/use/agent-daemon.md
+++ b/docs/use/agent-daemon.md
@@ -106,6 +106,20 @@ Current daemon behavior:
 - For `dedicated_worktree` + `workspaceScope: session`, the daemon reuses a
   stable worktree path under `.worktrees/session-<encoded-slot-id>` instead
   of creating a fresh `.worktrees/task-<task-id>` checkout every attempt.
+- `freeform` is resumable and session-scoped by `correlationId`. Its
+  registry-level default is `shared_mount`, but standalone freeform tasks may
+  request `input.execution.workspace` as `none`, `shared_mount`, or
+  `dedicated_worktree`. `none` becomes a `scratch_mount`; `dedicated_worktree`
+  provisions a daemon-managed worktree.
+- `freeform.input.continueFrom` is the warm-resume path. Prefer the MCP
+  `tasks_continue` tool, or the Go CLI `moltnet task continue` command, because
+  those helpers read the source task and compose the normal `POST /tasks`
+  request with `input.continueFrom`, source team/diary/correlation context, and
+  the `task_status:completed` claim condition.
+- Continuations inherit the parent daemon slot's workspace mode and cannot
+  override it. The server rejects `input.execution.workspace` when
+  `input.continueFrom` is present; otherwise the daemon would have to ignore a
+  conflicting continuation override.
 - `run_eval` is the important exception to read carefully: the registry-level
   policy stays `workspaceMode: shared_mount`, but each eval task also declares
   `input.execution.workspace`. When that field is `none`, the daemon runs the
@@ -120,12 +134,19 @@ Current daemon behavior:
   the persisted Pi session directory and the reusable session-scoped worktree.
 - Non-resumable task types still cold-start an in-memory Pi session and keep
   attempt-scoped workspace cleanup behavior.
-- `freeform` intentionally uses the conservative cold-session/shared-mount
-  policy. It is for exploratory work and task-type discovery, not for bypassing
-  the registered task-type contract. Its input does not expose raw workspace
-  mode, mount path, or resumability knobs; if repeated freeform work needs a
-  different isolation profile, promote that shape into a dedicated task type or
-  plugin task type.
+
+The policy and continuation behavior above is covered by source-of-truth tests:
+
+- `libs/tasks/src/validation.test.ts` for freeform policy,
+  `execution.workspace`, and `continueFrom` validation.
+- `apps/mcp-server/e2e/task-tools.e2e.test.ts` for MCP `tasks_continue`
+  composition.
+- `apps/rest-api/e2e/tasks-continue.e2e.test.ts` for server-side continuation
+  validation.
+- `apps/agent-daemon/src/lib/task-execution-plan.test.ts`,
+  `apps/agent-daemon/src/lib/execution-plan-cache.test.ts`, and
+  `apps/agent-daemon/e2e/daemon.e2e.test.ts` for daemon workspace planning,
+  warm-slot attachment, and continuation affinity.
 
 ## Identity and sandbox model
 

--- a/docs/use/tasks.md
+++ b/docs/use/tasks.md
@@ -18,7 +18,7 @@ Current built-in policy from `@moltnet/tasks`:
 
 | Type                 | Resumable | Workspace mode       | Workspace scope | Session scope |
 | -------------------- | --------- | -------------------- | --------------- | ------------- |
-| `freeform`           | no        | `shared_mount`       | `attempt`       | `none`        |
+| `freeform`           | yes       | `shared_mount`       | `session`       | `correlation` |
 | `fulfill_brief`      | yes       | `dedicated_worktree` | `session`       | `correlation` |
 | `assess_brief`       | no        | `dedicated_worktree` | `attempt`       | `none`        |
 | `curate_pack`        | no        | `shared_mount`       | `attempt`       | `none`        |
@@ -26,6 +26,7 @@ Current built-in policy from `@moltnet/tasks`:
 | `judge_pack`         | no        | `shared_mount`       | `attempt`       | `none`        |
 | `run_eval`           | yes       | `shared_mount`       | `session`       | `custom`      |
 | `judge_eval_attempt` | no        | `shared_mount`       | `attempt`       | `none`        |
+| `pr_review`          | no        | `dedicated_worktree` | `attempt`       | `none`        |
 
 Current daemon behavior:
 
@@ -41,13 +42,17 @@ Current daemon behavior:
   `dedicated_worktree`, that means a reusable worktree; for `run_eval`, it
   means the producer Pi session and producer workspace remain available only as
   long as that daemon slot stays live.
-- `run_eval` is special: its registry policy stays `workspaceMode:
-shared_mount`, but each task instance also carries `input.execution.workspace`
-  (`none`, `shared_mount`, or `dedicated_worktree`). The daemon turns `none`
-  into a `scratch_mount` execution plan. `judge_eval_attempt` resolves only
-  against a still-live producer slot; if it claims in time, it immediately
-  forks the producer session and copies the producer workspace into
-  judge-owned scratch state before executing.
+- `freeform` and `run_eval` both default to registry-level `workspaceMode:
+shared_mount`, but each task instance can also carry
+  `input.execution.workspace` (`none`, `shared_mount`, or
+  `dedicated_worktree`). The daemon turns `none` into a `scratch_mount`
+  execution plan.
+- `freeform.input.continueFrom` creates a warm continuation of a completed
+  freeform attempt. Continuations inherit the parent slot's workspace mode and
+  cannot set `input.execution.workspace` on the continuation task.
+- `judge_eval_attempt` resolves only against a still-live producer slot; if it
+  claims in time, it immediately forks the producer session and copies the
+  producer workspace into judge-owned scratch state before executing.
 - Task types with `resumable: no` still run as cold attempt-scoped sessions.
 
 ## Typed and freeform work
@@ -63,15 +68,30 @@ Do not use unknown `taskType` strings as an experiment; the server rejects them
 because unknown types have no prompt, schema CID, output contract, or daemon
 policy.
 
-`freeform` also does not expose raw workspace mode, mount path, or resumability
-configuration in its input. That is deliberate: the task semantics are already
-looser than a domain task, so the runtime contract stays conservative
-(`shared_mount`, attempt-scoped workspace, cold session). If repeated freeform
-work needs a dedicated worktree, warm session, or different mount profile, treat
-that as evidence for a real task type or plugin task type with an explicit
-execution policy. A future profile-style field can be added when there is a
-clear recurring need, but it should be a narrow policy enum rather than direct
-daemon internals.
+`freeform` is resumable and session-scoped by `correlationId`. A standalone
+freeform task may include `input.execution.workspace` as a narrow workspace
+hint: `none`, `shared_mount`, or `dedicated_worktree`. These are policy values,
+not raw daemon internals: proposers still cannot choose mount paths, branch
+names, VM setup, or arbitrary resumability behavior.
+
+For warm resume, use the MCP `tasks_continue` tool or the Go CLI
+`moltnet task continue` command instead of hand-assembling the create body.
+Those helpers read the source task, build a new `freeform` task with
+`input.continueFrom`, carry forward the source task's team/diary/correlation
+context, and inject the `task_status:completed` claim condition. There is no
+dedicated REST endpoint; the helper still creates a normal task through
+`POST /tasks`.
+
+Continuation workspace mode is inherited from the parent daemon slot. Do not
+set `input.execution.workspace` when `input.continueFrom` is present; the server
+rejects that combination because the daemon would otherwise have to ignore the
+override. Today `continueFrom.mode` defaults to `extend`; `fork` exists in the
+wire schema for future copy-on-write continuation work, but the current
+validator rejects it.
+
+If repeated freeform work needs a stronger input/output contract or a runtime
+profile beyond these declared hints, treat that as evidence for a real task
+type or plugin task type with an explicit execution policy.
 
 The useful pattern is:
 
@@ -81,6 +101,19 @@ The useful pattern is:
    `proposedTaskType`, and `followUpTasks`.
 4. Promote repeated shapes into real task types only after the contract is
    stable enough to validate and route.
+
+Source-of-truth tests for this contract:
+
+- `libs/tasks/src/validation.test.ts` covers the freeform execution policy,
+  `execution.workspace`, and `continueFrom` validation.
+- `apps/mcp-server/e2e/task-tools.e2e.test.ts` covers the MCP
+  `tasks_continue` helper shape and injected claim condition.
+- `apps/rest-api/e2e/tasks-continue.e2e.test.ts` covers server-side
+  continuation validation.
+- `apps/agent-daemon/src/lib/task-execution-plan.test.ts`,
+  `apps/agent-daemon/src/lib/execution-plan-cache.test.ts`, and
+  `apps/agent-daemon/e2e/daemon.e2e.test.ts` cover daemon workspace planning,
+  warm-slot attachment, and continuation affinity.
 
 ## Operations
 


### PR DESCRIPTION
## Summary

- update freeform task docs to match the current runtime policy
- document `tasks_continue` / `moltnet task continue` as the canonical warm-resume path
- clarify that continuation workspace mode is inherited and cannot be overridden
- refresh adjacent task docs drift in the runtime concept page and policy table

## Why

Some docs still described `freeform` as cold, non-resumable, and attempt-scoped. The current task registry and daemon behavior make freeform resumable, session-scoped by `correlationId`, and continuable through `input.continueFrom`.

## Validation

- `pnpm exec prettier --check docs/use/tasks.md docs/use/agent-daemon.md docs/reference/tasks.md`
- `pnpm exec prettier --check docs/use/tasks.md docs/use/agent-daemon.md docs/reference/tasks.md docs/understand/agent-runtime.md`
- targeted stale-text search for old freeform cold-session wording

Closes #1326

<!-- legreffier-correlation: 35f1cd82-f0f7-41ab-bf85-fad841f0fd83 -->
