### PR TITLE
fix(moltnet-cli): force release for api client sync

### DIFF
--- a/apps/moltnet-cli/go.mod
+++ b/apps/moltnet-cli/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/XiaoConstantine/dspy-go v0.82.2
 	github.com/getlarge/themoltnet/libs/dspy-adapters v0.9.2
-	github.com/getlarge/themoltnet/libs/moltnet-api-client v1.30.4
+	github.com/getlarge/themoltnet/libs/moltnet-api-client v1.30.4 // release CLI when generated client changes
 	github.com/go-faster/jx v1.2.0
 	github.com/google/uuid v1.6.0
 	github.com/ipfs/go-cid v0.6.0


### PR DESCRIPTION
## Summary

- force a release-please-recognized `apps/moltnet-cli` change
- document that the CLI should be released when the generated Go API client changes
- keep the CLI pinned to `github.com/getlarge/themoltnet/libs/moltnet-api-client v1.30.4`

## Why

`apps/moltnet-cli` already requires the latest generated Go API client (`v1.30.4`) on `main`, but the sync landed as a chore-style change and did not reliably produce a CLI release. This PR adds a tiny CLI-scoped `go.mod` note and uses a `fix(moltnet-cli)` commit so release-please should open a patch release for the CLI linked-version group after merge.

## Validation

- `go test ./...` from `apps/moltnet-cli`

<!-- legreffier-correlation: 5f20ab57-2dc1-4f2a-8633-54d776b2b9a6 -->
