### PR TITLE
feat: add GitHub issue lifecycle runner

### DIFF
--- a/apps/issue-lifecycle/package.json
+++ b/apps/issue-lifecycle/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@themoltnet/issue-lifecycle",
+  "version": "0.1.0",
+  "license": "AGPL-3.0-only",
+  "type": "module",
+  "description": "Concrete GitHub issue lifecycle runner using MoltNet freeform continuations.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/getlarge/themoltnet.git",
+    "directory": "apps/issue-lifecycle"
+  },
+  "homepage": "https://themolt.net",
+  "main": "./dist/main.js",
+  "types": "./dist/main.d.ts",
+  "bin": {
+    "moltnet-issue-lifecycle": "./dist/main.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "cli": "tsx src/main.ts",
+    "start": "node dist/main.js",
+    "build": "vite build",
+    "test": "vitest run --passWithNoTests",
+    "typecheck": "tsc -b --emitDeclarationOnly",
+    "lint": "eslint .",
+    "check:pack": "tsx ../../tools/src/check-pack.ts --package ."
+  },
+  "dependencies": {
+    "@themoltnet/sdk": "workspace:*",
+    "absurd-sdk": "catalog:",
+    "pino": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  },
+  "nx": {
+    "tags": [
+      "type:app",
+      "scope:agent",
+      "platform:cli"
+    ]
+  }
+}

--- a/apps/issue-lifecycle/src/absurd.ts
+++ b/apps/issue-lifecycle/src/absurd.ts
@@ -1,0 +1,47 @@
+import { Absurd, type JsonValue, type TaskContext } from 'absurd-sdk';
+
+import type {
+  IssueLifecycleDeps,
+  IssueLifecycleInput,
+  WorkflowContext,
+} from './types.js';
+import { runGithubIssueLifecycle } from './workflow.js';
+
+export const GITHUB_ISSUE_LIFECYCLE_TASK = 'github_issue_lifecycle';
+
+function asWorkflowContext(ctx: TaskContext): WorkflowContext {
+  return {
+    step(name, fn) {
+      return ctx.step(name, fn);
+    },
+    sleepFor(name, seconds) {
+      return ctx.sleepFor(name, seconds);
+    },
+  };
+}
+
+export function createIssueLifecycleAbsurdApp(args: {
+  databaseUrl: string;
+  queueName?: string;
+  deps: IssueLifecycleDeps;
+}): Absurd {
+  const app = new Absurd({
+    db: args.databaseUrl,
+    queueName: args.queueName ?? 'issue-lifecycle',
+  });
+
+  app.registerTask<IssueLifecycleInput, JsonValue>(
+    {
+      name: GITHUB_ISSUE_LIFECYCLE_TASK,
+      defaultMaxAttempts: 3,
+    },
+    async (params, ctx) =>
+      (await runGithubIssueLifecycle(
+        params,
+        args.deps,
+        asWorkflowContext(ctx),
+      )) as unknown as JsonValue,
+  );
+
+  return app;
+}

--- a/apps/issue-lifecycle/src/artifact.test.ts
+++ b/apps/issue-lifecycle/src/artifact.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { isReviewPassed, parseLifecycleStateArtifact } from './artifact.js';
+
+describe('parseLifecycleStateArtifact', () => {
+  it('reads the issue_lifecycle_state freeform artifact', () => {
+    const state = parseLifecycleStateArtifact({
+      summary: 'done',
+      artifacts: [
+        {
+          kind: 'issue_lifecycle_state',
+          title: 'state',
+          body: JSON.stringify({
+            phase: 'plan_generated',
+            decision: 'review_passed',
+            summary: 'Plan is good',
+            findings: [],
+          }),
+        },
+      ],
+    });
+
+    expect(state).toEqual({
+      phase: 'plan_generated',
+      decision: 'review_passed',
+      summary: 'Plan is good',
+      findings: [],
+    });
+    expect(isReviewPassed(state)).toBe(true);
+  });
+
+  it('rejects output without a lifecycle artifact', () => {
+    expect(() => parseLifecycleStateArtifact({ artifacts: [] })).toThrow(
+      /missing an issue_lifecycle_state/,
+    );
+  });
+});

--- a/apps/issue-lifecycle/src/artifact.ts
+++ b/apps/issue-lifecycle/src/artifact.ts
@@ -1,0 +1,100 @@
+import type { LifecyclePhase, LifecycleStateArtifact } from './types.js';
+
+const PHASES = new Set<LifecyclePhase>([
+  'triaging',
+  'classified',
+  'plan_generated',
+  'approved',
+  'implementing',
+  'pr_open',
+  'pr_failed',
+  'releasing',
+  'notify',
+  'done',
+]);
+
+interface FreeformArtifact {
+  kind?: unknown;
+  body?: unknown;
+}
+
+interface FreeformOutput {
+  artifacts?: unknown;
+}
+
+function parseJsonObject(raw: string): Record<string, unknown> {
+  const parsed = JSON.parse(raw) as unknown;
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error(
+      'issue_lifecycle_state artifact body must be a JSON object',
+    );
+  }
+  return parsed as Record<string, unknown>;
+}
+
+export function parseLifecycleStateArtifact(
+  output: unknown,
+): LifecycleStateArtifact {
+  const artifacts =
+    typeof output === 'object' && output !== null
+      ? (output as FreeformOutput).artifacts
+      : undefined;
+  if (!Array.isArray(artifacts)) {
+    throw new Error('freeform output does not contain artifacts[]');
+  }
+
+  const artifact = artifacts.find(
+    (candidate): candidate is FreeformArtifact =>
+      typeof candidate === 'object' &&
+      candidate !== null &&
+      (candidate as FreeformArtifact).kind === 'issue_lifecycle_state',
+  );
+  if (!artifact || typeof artifact.body !== 'string') {
+    throw new Error(
+      'freeform output is missing an issue_lifecycle_state artifact body',
+    );
+  }
+
+  const body = parseJsonObject(artifact.body);
+  const phase = body.phase;
+  const decision = body.decision;
+  const summary = body.summary;
+
+  if (typeof phase !== 'string' || !PHASES.has(phase as LifecyclePhase)) {
+    throw new Error(`invalid issue lifecycle phase: ${String(phase)}`);
+  }
+  if (typeof decision !== 'string' || decision.length === 0) {
+    throw new Error('issue lifecycle artifact decision must be a string');
+  }
+  if (typeof summary !== 'string' || summary.length === 0) {
+    throw new Error('issue lifecycle artifact summary must be a string');
+  }
+
+  const state: LifecycleStateArtifact = {
+    phase: phase as LifecyclePhase,
+    decision,
+    summary,
+  };
+
+  if (Array.isArray(body.findings)) {
+    state.findings = body.findings.filter(
+      (finding): finding is string => typeof finding === 'string',
+    );
+  }
+  if (typeof body.plan === 'string') state.plan = body.plan;
+  if (typeof body.prNumber === 'number') state.prNumber = body.prNumber;
+  if (typeof body.prUrl === 'string') state.prUrl = body.prUrl;
+  if (typeof body.notifySkipped === 'boolean') {
+    state.notifySkipped = body.notifySkipped;
+  }
+
+  return state;
+}
+
+export function isReviewPassed(state: LifecycleStateArtifact): boolean {
+  return (
+    state.phase === 'plan_generated' &&
+    ['review_passed', 'no_findings', 'approve'].includes(state.decision) &&
+    (!state.findings || state.findings.length === 0)
+  );
+}

--- a/apps/issue-lifecycle/src/config.ts
+++ b/apps/issue-lifecycle/src/config.ts
@@ -1,0 +1,115 @@
+import { execFileSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { parseArgs, parseEnv } from 'node:util';
+
+import type { IssueLifecycleInput } from './types.js';
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export interface CliConfig {
+  repoRoot: string;
+  agentName: string;
+  agentDir: string;
+  databaseUrl: string;
+  queueName: string;
+  githubToken?: string;
+  githubEnv: NodeJS.ProcessEnv;
+  input: IssueLifecycleInput;
+}
+
+function requireString(value: string | undefined, name: string): string {
+  if (!value) throw new Error(`Missing required ${name}`);
+  return value;
+}
+
+function readAgentEnv(agentDir: string): Record<string, string | undefined> {
+  return parseEnv(readFileSync(join(agentDir, 'env'), 'utf8'));
+}
+
+function getGithubToken(agentDir: string): string {
+  return execFileSync(
+    'moltnet',
+    ['github', 'token', '--credentials', join(agentDir, 'moltnet.json')],
+    { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] },
+  ).trim();
+}
+
+export function parseCliConfig(argv = process.argv.slice(2)): CliConfig {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      repo: { type: 'string' },
+      issue: { type: 'string' },
+      agent: { type: 'string', default: 'legreffier' },
+      'team-id': { type: 'string' },
+      'diary-id': { type: 'string' },
+      'correlation-id': { type: 'string' },
+      'database-url': { type: 'string' },
+      'queue-name': { type: 'string', default: 'issue-lifecycle' },
+      'approval-label': { type: 'string' },
+      'skip-notify-label': { type: 'string' },
+      'poll-interval-sec': { type: 'string' },
+      'dry-run': { type: 'boolean', default: false },
+    },
+  });
+
+  const repoRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+    encoding: 'utf8',
+  }).trim();
+  const agentName = values.agent;
+  const agentDir = join(repoRoot, '.moltnet', agentName);
+  const agentEnv = readAgentEnv(agentDir);
+
+  const issueNumber = Number(values.issue);
+  if (!Number.isInteger(issueNumber) || issueNumber < 1) {
+    throw new Error('--issue must be a positive integer');
+  }
+  if (values['correlation-id'] && !UUID_RE.test(values['correlation-id'])) {
+    throw new Error('--correlation-id must be a UUID');
+  }
+
+  const databaseUrl =
+    values['database-url'] ?? process.env.ISSUE_LIFECYCLE_DATABASE_URL;
+  const githubToken =
+    process.env.GH_TOKEN ||
+    process.env.GITHUB_TOKEN ||
+    getGithubToken(agentDir);
+
+  const correlationId = values['correlation-id'] ?? randomUUID();
+
+  return {
+    repoRoot,
+    agentName,
+    agentDir,
+    databaseUrl: requireString(
+      databaseUrl,
+      '--database-url or ISSUE_LIFECYCLE_DATABASE_URL',
+    ),
+    queueName: values['queue-name'],
+    githubToken,
+    githubEnv: { ...process.env, GH_TOKEN: githubToken },
+    input: {
+      repo: requireString(values.repo, '--repo'),
+      issueNumber,
+      teamId:
+        values['team-id'] ??
+        requireString(agentEnv.MOLTNET_TEAM_ID, 'MOLTNET_TEAM_ID'),
+      diaryId:
+        values['diary-id'] ??
+        requireString(agentEnv.MOLTNET_DIARY_ID, 'MOLTNET_DIARY_ID'),
+      correlationId,
+      ...(values['approval-label']
+        ? { approvalLabel: values['approval-label'] }
+        : {}),
+      ...(values['skip-notify-label']
+        ? { skipNotifyLabel: values['skip-notify-label'] }
+        : {}),
+      ...(values['poll-interval-sec']
+        ? { pollIntervalSec: Number(values['poll-interval-sec']) }
+        : {}),
+    },
+  };
+}

--- a/apps/issue-lifecycle/src/github-cli.ts
+++ b/apps/issue-lifecycle/src/github-cli.ts
@@ -1,0 +1,121 @@
+import { execFileSync } from 'node:child_process';
+
+import type { GithubClient, GithubIssue, PullRequestStatus } from './types.js';
+
+interface GhIssueJson {
+  number: number;
+  title: string;
+  body?: string;
+  labels?: Array<{ name: string }>;
+}
+
+interface GhPrJson {
+  number: number;
+  url: string;
+  merged: boolean;
+  statusCheckRollup?: Array<{ conclusion?: string | null; status?: string }>;
+}
+
+function runGhJson<T>(
+  args: string[],
+  options: { token?: string; cwd?: string; env?: NodeJS.ProcessEnv },
+): T {
+  const raw = execFileSync('gh', args, {
+    encoding: 'utf8',
+    cwd: options.cwd,
+    env: {
+      ...(options.env ?? {}),
+      ...(options.token ? { GH_TOKEN: options.token } : {}),
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  return JSON.parse(raw) as T;
+}
+
+function checksConclusion(pr: GhPrJson): PullRequestStatus['checks'] {
+  const checks = pr.statusCheckRollup ?? [];
+  if (checks.length === 0) return 'pending';
+  if (
+    checks.some(
+      (check) =>
+        check.conclusion === 'FAILURE' ||
+        check.conclusion === 'TIMED_OUT' ||
+        check.conclusion === 'CANCELLED' ||
+        check.conclusion === 'ACTION_REQUIRED',
+    )
+  ) {
+    return 'failure';
+  }
+  if (
+    checks.every(
+      (check) =>
+        check.conclusion === 'SUCCESS' ||
+        check.conclusion === 'NEUTRAL' ||
+        check.conclusion === 'SKIPPED',
+    )
+  ) {
+    return 'success';
+  }
+  return 'pending';
+}
+
+export class GhCliGithubClient implements GithubClient {
+  constructor(
+    private readonly options: {
+      token?: string;
+      cwd?: string;
+      env?: NodeJS.ProcessEnv;
+    } = {},
+  ) {}
+
+  getIssue(repo: string, issueNumber: number): Promise<GithubIssue> {
+    const issue = runGhJson<GhIssueJson>(
+      [
+        'issue',
+        'view',
+        String(issueNumber),
+        '--repo',
+        repo,
+        '--json',
+        'number,title,body,labels',
+      ],
+      this.options,
+    );
+    return Promise.resolve({
+      number: issue.number,
+      title: issue.title,
+      body: issue.body ?? '',
+      labels: (issue.labels ?? []).map((label) => label.name),
+    });
+  }
+
+  async hasIssueLabel(
+    repo: string,
+    issueNumber: number,
+    label: string,
+  ): Promise<boolean> {
+    const issue = await this.getIssue(repo, issueNumber);
+    return issue.labels.includes(label);
+  }
+
+  getPullRequest(repo: string, prNumber: number): Promise<PullRequestStatus> {
+    const pr = runGhJson<GhPrJson>(
+      [
+        'pr',
+        'view',
+        String(prNumber),
+        '--repo',
+        repo,
+        '--json',
+        'number,url,merged,statusCheckRollup',
+      ],
+      this.options,
+    );
+    return Promise.resolve({
+      number: pr.number,
+      url: pr.url,
+      merged: pr.merged,
+      checks: checksConclusion(pr),
+    });
+  }
+}

--- a/apps/issue-lifecycle/src/main.ts
+++ b/apps/issue-lifecycle/src/main.ts
@@ -1,0 +1,63 @@
+import { connect } from '@themoltnet/sdk';
+import pino from 'pino';
+
+import {
+  createIssueLifecycleAbsurdApp,
+  GITHUB_ISSUE_LIFECYCLE_TASK,
+} from './absurd.js';
+import { parseCliConfig } from './config.js';
+import { GhCliGithubClient } from './github-cli.js';
+import { createSdkTaskClient } from './sdk-task-client.js';
+
+async function main(): Promise<number> {
+  const cfg = parseCliConfig();
+  const logger = pino({ name: 'issue-lifecycle' });
+  const agent = await connect({ configDir: cfg.agentDir });
+  const app = createIssueLifecycleAbsurdApp({
+    databaseUrl: cfg.databaseUrl,
+    queueName: cfg.queueName,
+    deps: {
+      tasks: createSdkTaskClient(agent),
+      github: new GhCliGithubClient({
+        token: cfg.githubToken,
+        cwd: cfg.repoRoot,
+        env: cfg.githubEnv,
+      }),
+      logger,
+    },
+  });
+
+  await app.createQueue(cfg.queueName);
+  const spawned = await app.spawn(GITHUB_ISSUE_LIFECYCLE_TASK, cfg.input, {
+    queue: cfg.queueName,
+    idempotencyKey: `github-issue-lifecycle:${cfg.input.repo}:${cfg.input.issueNumber}:${cfg.input.correlationId ?? 'new'}`,
+  });
+  logger.info(
+    {
+      taskID: spawned.taskID,
+      runID: spawned.runID,
+      repo: cfg.input.repo,
+      issueNumber: cfg.input.issueNumber,
+    },
+    'issue_lifecycle.spawned',
+  );
+
+  const worker = await app.startWorker({ concurrency: 1 });
+  const result = await app.awaitTaskResult(spawned.taskID);
+  await worker.close();
+  await app.close();
+
+  // eslint-disable-next-line no-console
+  console.log(JSON.stringify(result, null, 2));
+  return result.state === 'completed' ? 0 : 1;
+}
+
+main()
+  .then((code) => {
+    process.exitCode = code;
+  })
+  .catch((err) => {
+    // eslint-disable-next-line no-console
+    console.error('[fatal]', err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  });

--- a/apps/issue-lifecycle/src/sdk-task-client.ts
+++ b/apps/issue-lifecycle/src/sdk-task-client.ts
@@ -1,0 +1,17 @@
+import type { Agent } from '@themoltnet/sdk';
+
+import type { TaskClient } from './types.js';
+
+export function createSdkTaskClient(agent: Agent): TaskClient {
+  return {
+    createTask(body) {
+      return agent.tasks.create(body);
+    },
+    getTask(id) {
+      return agent.tasks.get(id);
+    },
+    listAttempts(id) {
+      return agent.tasks.listAttempts(id);
+    },
+  };
+}

--- a/apps/issue-lifecycle/src/task-factory.ts
+++ b/apps/issue-lifecycle/src/task-factory.ts
@@ -1,0 +1,212 @@
+import { randomUUID } from 'node:crypto';
+
+import type {
+  GithubIssue,
+  IssueLifecycleInput,
+  SdkTaskAttempt,
+  TaskClient,
+} from './types.js';
+
+const DEFAULT_APPROVAL_LABEL = 'moltnet:plan-approved';
+const DEFAULT_SKIP_NOTIFY_LABEL = 'moltnet:skip-notify';
+
+export interface LifecycleDefaults {
+  correlationId: string;
+  approvalLabel: string;
+  skipNotifyLabel: string;
+  pollIntervalSec: number;
+  maxReviewRounds: number;
+  maxImplementationRetries: number;
+}
+
+export function normalizeLifecycleInput(
+  input: IssueLifecycleInput,
+): IssueLifecycleInput & LifecycleDefaults {
+  return {
+    ...input,
+    correlationId: input.correlationId ?? randomUUID(),
+    approvalLabel: input.approvalLabel ?? DEFAULT_APPROVAL_LABEL,
+    skipNotifyLabel: input.skipNotifyLabel ?? DEFAULT_SKIP_NOTIFY_LABEL,
+    pollIntervalSec: input.pollIntervalSec ?? 30,
+    maxReviewRounds: input.maxReviewRounds ?? 5,
+    maxImplementationRetries: input.maxImplementationRetries ?? 3,
+  };
+}
+
+function issueReference(issue: GithubIssue) {
+  return {
+    taskId: null,
+    outputCid: `gh:issue:${issue.number}`,
+    role: 'context' as const,
+    external: {
+      kind: 'github_issue' as const,
+      issue: issue.number,
+    },
+  };
+}
+
+function taskReference(taskId: string, attempt: SdkTaskAttempt) {
+  return {
+    taskId,
+    outputCid:
+      attempt.outputCid ?? `task:${taskId}:attempt:${attempt.attemptN}`,
+    role: 'context' as const,
+  };
+}
+
+function baseBody(
+  input: IssueLifecycleInput & LifecycleDefaults,
+  title: string,
+  brief: string,
+  issue: GithubIssue,
+) {
+  return {
+    taskType: 'freeform',
+    title,
+    teamId: input.teamId,
+    diaryId: input.diaryId,
+    correlationId: input.correlationId,
+    input: {
+      brief,
+      expectedOutput:
+        'Return normal freeform output plus an artifact with kind issue_lifecycle_state and a JSON body.',
+      suggestedTaskType: 'github_issue_lifecycle',
+      successCriteria: { version: 1 },
+    },
+    references: [issueReference(issue)],
+    ...(input.allowedExecutors
+      ? { allowedExecutors: input.allowedExecutors }
+      : {}),
+    ...(input.requiredExecutorTrustLevel
+      ? { requiredExecutorTrustLevel: input.requiredExecutorTrustLevel }
+      : {}),
+  } satisfies Parameters<TaskClient['createTask']>[0];
+}
+
+export function buildTriageTask(
+  input: IssueLifecycleInput & LifecycleDefaults,
+  issue: GithubIssue,
+): Parameters<TaskClient['createTask']>[0] {
+  const brief = [
+    `Triage GitHub issue ${input.repo}#${issue.number}: ${issue.title}`,
+    '',
+    issue.body || '_No issue body provided._',
+    '',
+    'Read repository instructions, design docs, and relevant skills before classifying.',
+    'Classify the issue with useful tags such as feature, security, docs, or bug.',
+    'If the issue is planning-ready, emit phase "classified" and decision "plan".',
+    'If it needs clarification, emit phase "classified" and decision "needs_triage" with a concise summary.',
+    '',
+    'Required artifact body shape:',
+    '{"phase":"classified","decision":"plan","summary":"..."}',
+  ].join('\n');
+
+  return {
+    ...baseBody(input, `Triage issue #${issue.number}`, brief, issue),
+    input: {
+      ...baseBody(input, `Triage issue #${issue.number}`, brief, issue).input,
+      execution: { workspace: 'dedicated_worktree' },
+    },
+  };
+}
+
+export function buildContinuationTask(args: {
+  input: IssueLifecycleInput & LifecycleDefaults;
+  issue: GithubIssue;
+  parentTaskId: string;
+  parentAttempt: SdkTaskAttempt;
+  title: string;
+  brief: string;
+}): Parameters<TaskClient['createTask']>[0] {
+  return {
+    ...baseBody(args.input, args.title, args.brief, args.issue),
+    input: {
+      ...baseBody(args.input, args.title, args.brief, args.issue).input,
+      continueFrom: {
+        taskId: args.parentTaskId,
+        attemptN: args.parentAttempt.attemptN,
+        mode: 'extend',
+      },
+    },
+    references: [
+      issueReference(args.issue),
+      taskReference(args.parentTaskId, args.parentAttempt),
+    ],
+    claimCondition: {
+      op: 'task_status',
+      taskId: args.parentTaskId,
+      statuses: ['completed'],
+    },
+  };
+}
+
+export function planBrief(issue: GithubIssue): string {
+  return [
+    `Generate an implementation plan for issue #${issue.number}: ${issue.title}.`,
+    'Use the current session and worktree context from triage.',
+    'Do not implement yet.',
+    'Produce a concrete plan with risks, tests, and acceptance criteria.',
+    'Required artifact body shape:',
+    '{"phase":"plan_generated","decision":"ready_for_review","summary":"...","plan":"..."}',
+  ].join('\n');
+}
+
+export function reviewBrief(): string {
+  return [
+    'Review the current plan critically.',
+    'If it is ready for human approval, emit decision "review_passed" and no findings.',
+    'If it needs work, emit decision "findings" and include findings[].',
+    'Do not implement code.',
+    'Required artifact body shape:',
+    '{"phase":"plan_generated","decision":"review_passed","summary":"...","findings":[]}',
+  ].join('\n');
+}
+
+export function revisePlanBrief(findings: string[]): string {
+  return [
+    'Revise the implementation plan to resolve the review findings below.',
+    '',
+    ...findings.map((finding) => `- ${finding}`),
+    '',
+    'Do not implement yet.',
+    'Required artifact body shape:',
+    '{"phase":"plan_generated","decision":"ready_for_review","summary":"...","plan":"..."}',
+  ].join('\n');
+}
+
+export function implementationBrief(issue: GithubIssue): string {
+  return [
+    `Implement the approved plan for issue #${issue.number}: ${issue.title}.`,
+    'Stay within repository instructions and LeGreffier accountable commit workflow.',
+    'Open or link the PR when done.',
+    'Required artifact body shape:',
+    '{"phase":"pr_open","decision":"link_pr","summary":"...","prNumber":123,"prUrl":"https://github.com/..."}',
+  ].join('\n');
+}
+
+export function implementationRetryBrief(): string {
+  return [
+    'The linked PR failed CI or merge gates.',
+    'Inspect the PR/check failures, fix them, and update the same PR.',
+    'Required artifact body shape:',
+    '{"phase":"pr_open","decision":"link_pr","summary":"...","prNumber":123,"prUrl":"https://github.com/..."}',
+  ].join('\n');
+}
+
+export function releaseBrief(prNumber: number): string {
+  return [
+    `The PR #${prNumber} merged. Perform any release bookkeeping that applies.`,
+    'If no release action is needed, state that clearly.',
+    'Required artifact body shape:',
+    '{"phase":"releasing","decision":"ship","summary":"..."}',
+  ].join('\n');
+}
+
+export function notifyBrief(issue: GithubIssue): string {
+  return [
+    `Notify participants that issue #${issue.number} is done.`,
+    'Thank the contributor if applicable.',
+    'Required artifact body shape:',
+    '{"phase":"done","decision":"notify","summary":"...","notifySkipped":false}',
+  ].join('\n');
+}

--- a/apps/issue-lifecycle/src/test-fakes.ts
+++ b/apps/issue-lifecycle/src/test-fakes.ts
@@ -1,0 +1,153 @@
+import type {
+  GithubClient,
+  IssueLifecycleDeps,
+  PullRequestStatus,
+  SdkTask,
+  SdkTaskAttempt,
+  TaskClient,
+} from './types.js';
+
+export function outputState(body: Record<string, unknown>) {
+  const summary = typeof body.summary === 'string' ? body.summary : 'summary';
+  return {
+    summary,
+    artifacts: [
+      {
+        kind: 'issue_lifecycle_state',
+        title: 'state',
+        body: JSON.stringify(body),
+      },
+    ],
+  };
+}
+
+export class FakeTasks implements TaskClient {
+  readonly created: Array<Parameters<TaskClient['createTask']>[0]> = [];
+  private readonly tasks = new Map<string, SdkTask>();
+  private readonly attempts = new Map<string, SdkTaskAttempt>();
+  private next = 1;
+
+  constructor(private readonly outputs: Array<Record<string, unknown>>) {}
+
+  createTask(body: Parameters<TaskClient['createTask']>[0]): Promise<SdkTask> {
+    const id = `00000000-0000-4000-8000-${String(this.next).padStart(12, '0')}`;
+    this.next += 1;
+    const output = this.outputs.shift();
+    if (!output) throw new Error('test exhausted fake outputs');
+    const task = {
+      id,
+      taskType: body.taskType,
+      title: body.title ?? null,
+      tags: [],
+      teamId: body.teamId,
+      diaryId: body.diaryId,
+      outputKind: 'artifact',
+      input: body.input,
+      inputSchemaCid: 'cid',
+      inputCid: 'cid',
+      references: body.references ?? [],
+      correlationId: body.correlationId ?? null,
+      proposedByAgentId: 'agent',
+      proposedByHumanId: null,
+      acceptedAttemptN: 1,
+      claimCondition: body.claimCondition ?? null,
+      requiredExecutorTrustLevel:
+        body.requiredExecutorTrustLevel ?? 'selfDeclared',
+      allowedExecutors: body.allowedExecutors ?? [],
+      status: 'completed',
+      queuedAt: new Date().toISOString(),
+      completedAt: new Date().toISOString(),
+      expiresAt: null,
+      cancelledByAgentId: null,
+      cancelledByHumanId: null,
+      cancelReason: null,
+      maxAttempts: body.maxAttempts ?? 1,
+      dispatchTimeoutSec: body.dispatchTimeoutSec ?? null,
+      runningTimeoutSec: body.runningTimeoutSec ?? null,
+    } as SdkTask;
+    const attempt = {
+      taskId: id,
+      attemptN: 1,
+      claimedByAgentId: 'agent',
+      runtimeId: null,
+      claimedAt: new Date().toISOString(),
+      startedAt: new Date().toISOString(),
+      completedAt: new Date().toISOString(),
+      status: 'completed',
+      output: outputState(output),
+      outputCid: `cid-${id}`,
+      claimedExecutorFingerprint: null,
+      claimedExecutorManifest: null,
+      completedExecutorFingerprint: null,
+      completedExecutorManifest: null,
+      error: null,
+      usage: null,
+      contentSignature: null,
+      signedAt: null,
+      daemonState: {
+        reportedAt: new Date().toISOString(),
+        slotResumableUntil: new Date(Date.now() + 60_000).toISOString(),
+      },
+    } as SdkTaskAttempt;
+    this.created.push(body);
+    this.tasks.set(id, task);
+    this.attempts.set(id, attempt);
+    return Promise.resolve(task);
+  }
+
+  getTask(id: string): Promise<SdkTask> {
+    const task = this.tasks.get(id);
+    if (!task) throw new Error(`missing task ${id}`);
+    return Promise.resolve(task);
+  }
+
+  listAttempts(id: string): Promise<SdkTaskAttempt[]> {
+    const attempt = this.attempts.get(id);
+    if (!attempt) throw new Error(`missing attempt ${id}`);
+    return Promise.resolve([attempt]);
+  }
+}
+
+export class FakeGithub implements GithubClient {
+  approval = true;
+  skipNotify = false;
+  approvalResponses: boolean[] = [];
+  prResponses: PullRequestStatus[] = [];
+  prStatus: PullRequestStatus = {
+    number: 42,
+    url: 'https://github.com/getlarge/themoltnet/pull/42',
+    merged: true,
+    checks: 'success',
+  };
+
+  getIssue() {
+    return Promise.resolve({
+      number: 1327,
+      title: 'Build lifecycle app',
+      body: 'body',
+      labels: [],
+    });
+  }
+
+  hasIssueLabel(_repo: string, _issueNumber: number, label: string) {
+    if (label === 'moltnet:skip-notify') {
+      return Promise.resolve(this.skipNotify);
+    }
+    const next = this.approvalResponses.shift();
+    return Promise.resolve(next ?? this.approval);
+  }
+
+  getPullRequest() {
+    return Promise.resolve(this.prResponses.shift() ?? this.prStatus);
+  }
+}
+
+export function fakeDeps(outputs: Array<Record<string, unknown>>): {
+  deps: IssueLifecycleDeps;
+  tasks: FakeTasks;
+  github: FakeGithub;
+} {
+  const tasks = new FakeTasks(outputs);
+  const github = new FakeGithub();
+  return { deps: { tasks, github }, tasks, github };
+}

--- a/apps/issue-lifecycle/src/types.ts
+++ b/apps/issue-lifecycle/src/types.ts
@@ -1,0 +1,95 @@
+import type { Agent } from '@themoltnet/sdk';
+
+export type SdkTask = Awaited<ReturnType<Agent['tasks']['get']>>;
+export type SdkTaskAttempt = Awaited<
+  ReturnType<Agent['tasks']['listAttempts']>
+>[number];
+
+export type LifecyclePhase =
+  | 'triaging'
+  | 'classified'
+  | 'plan_generated'
+  | 'approved'
+  | 'implementing'
+  | 'pr_open'
+  | 'pr_failed'
+  | 'releasing'
+  | 'notify'
+  | 'done';
+
+export interface IssueLifecycleInput {
+  repo: string;
+  issueNumber: number;
+  teamId: string;
+  diaryId: string;
+  correlationId?: string;
+  approvalLabel?: string;
+  skipNotifyLabel?: string;
+  allowedExecutors?: Array<{ provider: string; model: string }>;
+  requiredExecutorTrustLevel?:
+    | 'selfDeclared'
+    | 'agentSigned'
+    | 'releaseVerifiedTool'
+    | 'sandboxAttested';
+  pollIntervalSec?: number;
+  maxReviewRounds?: number;
+  maxImplementationRetries?: number;
+}
+
+export interface GithubIssue {
+  number: number;
+  title: string;
+  body: string;
+  labels: string[];
+}
+
+export interface PullRequestStatus {
+  number: number;
+  url: string;
+  merged: boolean;
+  checks: 'pending' | 'success' | 'failure';
+}
+
+export interface GithubClient {
+  getIssue(repo: string, issueNumber: number): Promise<GithubIssue>;
+  hasIssueLabel(
+    repo: string,
+    issueNumber: number,
+    label: string,
+  ): Promise<boolean>;
+  getPullRequest(repo: string, prNumber: number): Promise<PullRequestStatus>;
+}
+
+export interface TaskClient {
+  createTask(body: Parameters<Agent['tasks']['create']>[0]): Promise<SdkTask>;
+  getTask(id: string): Promise<SdkTask>;
+  listAttempts(id: string): Promise<SdkTaskAttempt[]>;
+}
+
+export interface WorkflowContext {
+  step<T>(name: string, fn: () => Promise<T>): Promise<T>;
+  sleepFor(name: string, seconds: number): Promise<void>;
+}
+
+export interface IssueLifecycleDeps {
+  tasks: TaskClient;
+  github: GithubClient;
+  logger?: Pick<Console, 'info' | 'warn' | 'error'>;
+}
+
+export interface LifecycleStateArtifact {
+  phase: LifecyclePhase;
+  decision: string;
+  summary: string;
+  findings?: string[];
+  plan?: string;
+  prNumber?: number;
+  prUrl?: string;
+  notifySkipped?: boolean;
+}
+
+export interface AcceptedTaskResult {
+  task: SdkTask;
+  attempt: SdkTaskAttempt;
+  state: LifecycleStateArtifact;
+}

--- a/apps/issue-lifecycle/src/workflow.integration.test.ts
+++ b/apps/issue-lifecycle/src/workflow.integration.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest';
+
+import { fakeDeps } from './test-fakes.js';
+import type { IssueLifecycleInput, WorkflowContext } from './types.js';
+import { runGithubIssueLifecycle } from './workflow.js';
+
+const BASE_INPUT: IssueLifecycleInput = {
+  repo: 'getlarge/themoltnet',
+  issueNumber: 1327,
+  teamId: 'team',
+  diaryId: 'diary',
+  correlationId: '00000000-0000-4000-8000-000000000999',
+  pollIntervalSec: 1,
+};
+
+function successfulOutputs() {
+  return [
+    { phase: 'classified', decision: 'plan', summary: 'classified' },
+    {
+      phase: 'plan_generated',
+      decision: 'ready_for_review',
+      summary: 'planned',
+      plan: 'plan',
+    },
+    {
+      phase: 'plan_generated',
+      decision: 'review_passed',
+      summary: 'reviewed',
+      findings: [],
+    },
+    {
+      phase: 'pr_open',
+      decision: 'link_pr',
+      summary: 'implemented',
+      prNumber: 42,
+      prUrl: 'https://github.com/getlarge/themoltnet/pull/42',
+    },
+    { phase: 'releasing', decision: 'ship', summary: 'released' },
+    {
+      phase: 'done',
+      decision: 'notify',
+      summary: 'notified',
+      notifySkipped: false,
+    },
+  ];
+}
+
+function recordingContext(sleeps: string[]): WorkflowContext {
+  return {
+    step(_name, fn) {
+      return fn();
+    },
+    sleepFor(name) {
+      sleeps.push(name);
+      return Promise.resolve();
+    },
+  };
+}
+
+describe('GitHub issue lifecycle integration', () => {
+  it('waits for explicit human approval before implementation', async () => {
+    const { deps, github, tasks } = fakeDeps(successfulOutputs());
+    const sleeps: string[] = [];
+    github.approvalResponses = [false, false, true];
+
+    const result = await runGithubIssueLifecycle(
+      BASE_INPUT,
+      deps,
+      recordingContext(sleeps),
+    );
+
+    expect(result.status).toBe('done');
+    expect(sleeps).toEqual([
+      'wait-plan-approval-label',
+      'wait-plan-approval-label',
+    ]);
+    expect(tasks.created.map((task) => task.title)).toEqual([
+      'Triage issue #1327',
+      'Plan issue #1327',
+      'Review plan for issue #1327',
+      'Implement issue #1327',
+      'Release issue #1327',
+      'Notify issue #1327',
+    ]);
+  });
+
+  it('creates an implementation retry when the linked PR fails checks', async () => {
+    const { deps, github, tasks } = fakeDeps([
+      ...successfulOutputs().slice(0, 4),
+      {
+        phase: 'pr_open',
+        decision: 'link_pr',
+        summary: 'fixed failed checks',
+        prNumber: 42,
+        prUrl: 'https://github.com/getlarge/themoltnet/pull/42',
+      },
+      ...successfulOutputs().slice(4),
+    ]);
+    github.prResponses = [
+      {
+        number: 42,
+        url: 'https://github.com/getlarge/themoltnet/pull/42',
+        merged: false,
+        checks: 'failure',
+      },
+      {
+        number: 42,
+        url: 'https://github.com/getlarge/themoltnet/pull/42',
+        merged: false,
+        checks: 'failure',
+      },
+      {
+        number: 42,
+        url: 'https://github.com/getlarge/themoltnet/pull/42',
+        merged: true,
+        checks: 'success',
+      },
+    ];
+
+    const result = await runGithubIssueLifecycle(BASE_INPUT, deps);
+
+    expect(result.prNumber).toBe(42);
+    expect(
+      tasks.created.filter((task) => task.title === 'Implement issue #1327'),
+    ).toHaveLength(2);
+    expect(tasks.created.map((task) => task.title)).toContain(
+      'Release issue #1327',
+    );
+  });
+
+  it('fails when review findings cannot be resolved within the review budget', async () => {
+    const { deps, tasks } = fakeDeps([
+      { phase: 'classified', decision: 'plan', summary: 'classified' },
+      {
+        phase: 'plan_generated',
+        decision: 'ready_for_review',
+        summary: 'planned',
+        plan: 'plan',
+      },
+      {
+        phase: 'plan_generated',
+        decision: 'findings',
+        summary: 'needs work',
+        findings: ['missing test plan'],
+      },
+      {
+        phase: 'plan_generated',
+        decision: 'ready_for_review',
+        summary: 'revised',
+        plan: 'plan v2',
+      },
+    ]);
+
+    await expect(
+      runGithubIssueLifecycle(
+        {
+          ...BASE_INPUT,
+          maxReviewRounds: 1,
+        },
+        deps,
+      ),
+    ).rejects.toThrow('plan review did not pass within 1 rounds');
+    expect(tasks.created.map((task) => task.title)).toEqual([
+      'Triage issue #1327',
+      'Plan issue #1327',
+      'Review plan for issue #1327',
+      'Revise plan for issue #1327',
+    ]);
+  });
+});

--- a/apps/issue-lifecycle/src/workflow.test.ts
+++ b/apps/issue-lifecycle/src/workflow.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+
+import type { FakeGithub } from './test-fakes.js';
+import { fakeDeps } from './test-fakes.js';
+import { runGithubIssueLifecycle } from './workflow.js';
+
+describe('runGithubIssueLifecycle', () => {
+  it('creates a freeform continuation chain through notify', async () => {
+    const { deps: d, tasks } = fakeDeps([
+      { phase: 'classified', decision: 'plan', summary: 'classified' },
+      {
+        phase: 'plan_generated',
+        decision: 'ready_for_review',
+        summary: 'planned',
+        plan: 'plan',
+      },
+      {
+        phase: 'plan_generated',
+        decision: 'review_passed',
+        summary: 'reviewed',
+        findings: [],
+      },
+      {
+        phase: 'pr_open',
+        decision: 'link_pr',
+        summary: 'implemented',
+        prNumber: 42,
+        prUrl: 'https://github.com/getlarge/themoltnet/pull/42',
+      },
+      { phase: 'releasing', decision: 'ship', summary: 'released' },
+      {
+        phase: 'done',
+        decision: 'notify',
+        summary: 'notified',
+        notifySkipped: false,
+      },
+    ]);
+
+    const result = await runGithubIssueLifecycle(
+      {
+        repo: 'getlarge/themoltnet',
+        issueNumber: 1327,
+        teamId: 'team',
+        diaryId: 'diary',
+        correlationId: '00000000-0000-4000-8000-000000000999',
+        pollIntervalSec: 1,
+      },
+      d,
+    );
+
+    expect(result).toMatchObject({ status: 'done', prNumber: 42 });
+    expect(tasks.created).toHaveLength(6);
+    expect(tasks.created[0]?.taskType).toBe('freeform');
+    expect(tasks.created[0]?.input).toMatchObject({
+      execution: { workspace: 'dedicated_worktree' },
+    });
+    const secondInput = tasks.created[1]?.input as
+      | {
+          continueFrom?: {
+            taskId?: unknown;
+            attemptN?: unknown;
+            mode?: unknown;
+          };
+        }
+      | undefined;
+    expect(typeof secondInput?.continueFrom?.taskId).toBe('string');
+    expect(secondInput?.continueFrom).toMatchObject({
+      attemptN: 1,
+      mode: 'extend',
+    });
+    expect(tasks.created.slice(1).every((task) => task.claimCondition)).toBe(
+      true,
+    );
+  });
+
+  it('creates a plan revision when review returns findings', async () => {
+    const { deps: d, tasks } = fakeDeps([
+      { phase: 'classified', decision: 'plan', summary: 'classified' },
+      {
+        phase: 'plan_generated',
+        decision: 'ready_for_review',
+        summary: 'planned',
+        plan: 'plan',
+      },
+      {
+        phase: 'plan_generated',
+        decision: 'findings',
+        summary: 'needs work',
+        findings: ['tighten tests'],
+      },
+      {
+        phase: 'plan_generated',
+        decision: 'ready_for_review',
+        summary: 'revised',
+        plan: 'plan v2',
+      },
+      {
+        phase: 'plan_generated',
+        decision: 'review_passed',
+        summary: 'reviewed',
+        findings: [],
+      },
+      {
+        phase: 'pr_open',
+        decision: 'link_pr',
+        summary: 'implemented',
+        prNumber: 42,
+      },
+      { phase: 'releasing', decision: 'ship', summary: 'released' },
+    ]);
+    (d.github as FakeGithub).skipNotify = true;
+
+    await runGithubIssueLifecycle(
+      {
+        repo: 'getlarge/themoltnet',
+        issueNumber: 1327,
+        teamId: 'team',
+        diaryId: 'diary',
+        correlationId: '00000000-0000-4000-8000-000000000999',
+        pollIntervalSec: 1,
+      },
+      d,
+    );
+
+    expect(tasks.created.map((task) => task.title)).toContain(
+      'Revise plan for issue #1327',
+    );
+  });
+});

--- a/apps/issue-lifecycle/src/workflow.ts
+++ b/apps/issue-lifecycle/src/workflow.ts
@@ -1,0 +1,276 @@
+import { isReviewPassed, parseLifecycleStateArtifact } from './artifact.js';
+import {
+  buildContinuationTask,
+  buildTriageTask,
+  implementationBrief,
+  implementationRetryBrief,
+  normalizeLifecycleInput,
+  notifyBrief,
+  planBrief,
+  releaseBrief,
+  reviewBrief,
+  revisePlanBrief,
+} from './task-factory.js';
+import type {
+  AcceptedTaskResult,
+  IssueLifecycleDeps,
+  IssueLifecycleInput,
+  TaskClient,
+  WorkflowContext,
+} from './types.js';
+
+const inlineContext: WorkflowContext = {
+  step(_name, fn) {
+    return fn();
+  },
+  sleepFor() {
+    return Promise.resolve();
+  },
+};
+
+async function waitForAcceptedTask(
+  taskId: string,
+  tasks: TaskClient,
+  ctx: WorkflowContext,
+  pollIntervalSec: number,
+): Promise<AcceptedTaskResult> {
+  for (;;) {
+    const task = await tasks.getTask(taskId);
+    if (task.status === 'failed' || task.status === 'cancelled') {
+      throw new Error(`task ${taskId} ended with status ${task.status}`);
+    }
+    if (task.status === 'completed' && task.acceptedAttemptN !== null) {
+      const attempts = await tasks.listAttempts(taskId);
+      const attempt = attempts.find(
+        (candidate) => candidate.attemptN === task.acceptedAttemptN,
+      );
+      if (!attempt || attempt.status !== 'completed') {
+        throw new Error(`task ${taskId} accepted attempt is not completed`);
+      }
+      return {
+        task,
+        attempt,
+        state: parseLifecycleStateArtifact(attempt.output),
+      };
+    }
+    await ctx.sleepFor(`wait-task:${taskId}`, pollIntervalSec);
+  }
+}
+
+async function waitForApprovalLabel(
+  input: ReturnType<typeof normalizeLifecycleInput>,
+  deps: IssueLifecycleDeps,
+  ctx: WorkflowContext,
+): Promise<void> {
+  for (;;) {
+    const approved = await deps.github.hasIssueLabel(
+      input.repo,
+      input.issueNumber,
+      input.approvalLabel,
+    );
+    if (approved) return;
+    await ctx.sleepFor('wait-plan-approval-label', input.pollIntervalSec);
+  }
+}
+
+export async function runGithubIssueLifecycle(
+  rawInput: IssueLifecycleInput,
+  deps: IssueLifecycleDeps,
+  ctx: WorkflowContext = inlineContext,
+): Promise<{ status: 'done'; correlationId: string; prNumber: number }> {
+  const input = normalizeLifecycleInput(rawInput);
+  const issue = await ctx.step('github.issue.get', () =>
+    deps.github.getIssue(input.repo, input.issueNumber),
+  );
+
+  const triageTask = await ctx.step('task.triage.create', () =>
+    deps.tasks.createTask(buildTriageTask(input, issue)),
+  );
+  const triage = await waitForAcceptedTask(
+    triageTask.id,
+    deps.tasks,
+    ctx,
+    input.pollIntervalSec,
+  );
+  if (triage.state.phase !== 'classified') {
+    throw new Error(`triage produced unexpected phase ${triage.state.phase}`);
+  }
+
+  const planTask = await ctx.step('task.plan.create', () =>
+    deps.tasks.createTask(
+      buildContinuationTask({
+        input,
+        issue,
+        parentTaskId: triage.task.id,
+        parentAttempt: triage.attempt,
+        title: `Plan issue #${issue.number}`,
+        brief: planBrief(issue),
+      }),
+    ),
+  );
+  let latestPlan = await waitForAcceptedTask(
+    planTask.id,
+    deps.tasks,
+    ctx,
+    input.pollIntervalSec,
+  );
+
+  let reviewPassed = false;
+  for (let round = 1; round <= input.maxReviewRounds; round += 1) {
+    const reviewTask = await ctx.step(`task.plan-review.${round}.create`, () =>
+      deps.tasks.createTask(
+        buildContinuationTask({
+          input,
+          issue,
+          parentTaskId: latestPlan.task.id,
+          parentAttempt: latestPlan.attempt,
+          title: `Review plan for issue #${issue.number}`,
+          brief: reviewBrief(),
+        }),
+      ),
+    );
+    const review = await waitForAcceptedTask(
+      reviewTask.id,
+      deps.tasks,
+      ctx,
+      input.pollIntervalSec,
+    );
+    if (isReviewPassed(review.state)) {
+      reviewPassed = true;
+      break;
+    }
+
+    const findings = review.state.findings ?? [];
+    if (findings.length === 0) {
+      throw new Error('plan review did not pass and produced no findings');
+    }
+    const revisionTask = await ctx.step(
+      `task.plan-revision.${round}.create`,
+      () =>
+        deps.tasks.createTask(
+          buildContinuationTask({
+            input,
+            issue,
+            parentTaskId: review.task.id,
+            parentAttempt: review.attempt,
+            title: `Revise plan for issue #${issue.number}`,
+            brief: revisePlanBrief(findings),
+          }),
+        ),
+    );
+    latestPlan = await waitForAcceptedTask(
+      revisionTask.id,
+      deps.tasks,
+      ctx,
+      input.pollIntervalSec,
+    );
+  }
+  if (!reviewPassed) {
+    throw new Error(
+      `plan review did not pass within ${input.maxReviewRounds} rounds`,
+    );
+  }
+
+  await ctx.step('approval.label.wait', () =>
+    waitForApprovalLabel(input, deps, ctx),
+  );
+
+  let implementationParent = latestPlan;
+  let prNumber: number | null = null;
+  for (
+    let attempt = 0;
+    attempt <= input.maxImplementationRetries;
+    attempt += 1
+  ) {
+    const implTask = await ctx.step(`task.implement.${attempt}.create`, () =>
+      deps.tasks.createTask(
+        buildContinuationTask({
+          input,
+          issue,
+          parentTaskId: implementationParent.task.id,
+          parentAttempt: implementationParent.attempt,
+          title: `Implement issue #${issue.number}`,
+          brief:
+            attempt === 0
+              ? implementationBrief(issue)
+              : implementationRetryBrief(),
+        }),
+      ),
+    );
+    const impl = await waitForAcceptedTask(
+      implTask.id,
+      deps.tasks,
+      ctx,
+      input.pollIntervalSec,
+    );
+    if (impl.state.phase !== 'pr_open' || !impl.state.prNumber) {
+      throw new Error('implementation did not produce a linked PR');
+    }
+    prNumber = impl.state.prNumber;
+    implementationParent = impl;
+
+    for (;;) {
+      const pr = await deps.github.getPullRequest(input.repo, prNumber);
+      if (pr.merged) break;
+      if (pr.checks === 'failure') {
+        if (attempt === input.maxImplementationRetries) {
+          throw new Error(`PR #${prNumber} failed after retry budget`);
+        }
+        break;
+      }
+      await ctx.sleepFor(`wait-pr:${prNumber}`, input.pollIntervalSec);
+    }
+
+    const pr = await deps.github.getPullRequest(input.repo, prNumber);
+    if (pr.merged) break;
+  }
+
+  if (prNumber === null) throw new Error('implementation did not open a PR');
+
+  const releaseTask = await ctx.step('task.release.create', () =>
+    deps.tasks.createTask(
+      buildContinuationTask({
+        input,
+        issue,
+        parentTaskId: implementationParent.task.id,
+        parentAttempt: implementationParent.attempt,
+        title: `Release issue #${issue.number}`,
+        brief: releaseBrief(prNumber),
+      }),
+    ),
+  );
+  const release = await waitForAcceptedTask(
+    releaseTask.id,
+    deps.tasks,
+    ctx,
+    input.pollIntervalSec,
+  );
+
+  const skipNotify = await deps.github.hasIssueLabel(
+    input.repo,
+    input.issueNumber,
+    input.skipNotifyLabel,
+  );
+  if (!skipNotify) {
+    const notifyTask = await ctx.step('task.notify.create', () =>
+      deps.tasks.createTask(
+        buildContinuationTask({
+          input,
+          issue,
+          parentTaskId: release.task.id,
+          parentAttempt: release.attempt,
+          title: `Notify issue #${issue.number}`,
+          brief: notifyBrief(issue),
+        }),
+      ),
+    );
+    await waitForAcceptedTask(
+      notifyTask.id,
+      deps.tasks,
+      ctx,
+      input.pollIntervalSec,
+    );
+  }
+
+  return { status: 'done', correlationId: input.correlationId, prNumber };
+}

--- a/apps/issue-lifecycle/tsconfig.json
+++ b/apps/issue-lifecycle/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/apps/issue-lifecycle/tsconfig.lib.json
+++ b/apps/issue-lifecycle/tsconfig.lib.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./out-tsc",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./out-tsc/tsconfig.tsbuildinfo"
+  },
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/*.spec.ts"],
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts", "src/**/*.d.ts"],
+  "references": [
+    {
+      "path": "../../libs/sdk/tsconfig.lib.json"
+    }
+  ]
+}

--- a/apps/issue-lifecycle/tsconfig.spec.json
+++ b/apps/issue-lifecycle/tsconfig.spec.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./out-tsc/spec",
+    "rootDir": ".",
+    "tsBuildInfoFile": "./out-tsc/tsconfig.spec.tsbuildinfo",
+    "types": ["vitest/globals", "vitest", "node"]
+  },
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts", "src/**/*.d.ts"],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/apps/issue-lifecycle/vite.config.ts
+++ b/apps/issue-lifecycle/vite.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    ssr: 'src/main.ts',
+    outDir: 'dist',
+    rollupOptions: {
+      output: {
+        banner: '#!/usr/bin/env node',
+      },
+    },
+  },
+  ssr: {
+    external: ['@themoltnet/sdk', 'absurd-sdk', 'pino'],
+  },
+  test: {
+    exclude: ['node_modules/**', 'dist/**'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,6 +213,9 @@ catalogs:
     '@vitest/ui':
       specifier: ^3.0.0
       version: 3.2.4
+    absurd-sdk:
+      specifier: ^0.4.0
+      version: 0.4.0
     citty:
       specifier: ^0.2.2
       version: 0.2.2
@@ -649,6 +652,34 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 3.2.4(@types/debug@4.1.13)(@types/node@25.1.0)(@vitest/ui@3.2.4)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
+
+  apps/issue-lifecycle:
+    dependencies:
+      '@themoltnet/sdk':
+        specifier: workspace:*
+        version: link:../../libs/sdk
+      absurd-sdk:
+        specifier: 'catalog:'
+        version: 0.4.0(pg@8.18.0)
+      pino:
+        specifier: 'catalog:'
+        version: 10.3.1
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.19
+      tsx:
+        specifier: 'catalog:'
+        version: 4.21.0
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.3(@types/node@22.19.19)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.19)(@vitest/ui@3.2.4)(jiti@2.7.0)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
 
   apps/landing:
     dependencies:
@@ -5889,6 +5920,12 @@ packages:
 
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
+
+  absurd-sdk@0.4.0:
+    resolution: {integrity: sha512-vUqaC8HaLi/LMNDzRDveyaiBJF6owt3VfY90jhbD/E29ec4p9GeDRNe6ZQJ5Jc7eJcQV7+2bC0V+FkAImrW8Dw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      pg: ^8.0.0
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -14974,6 +15011,10 @@ snapshots:
       event-target-shim: 5.0.1
 
   abstract-logging@2.0.1: {}
+
+  absurd-sdk@0.4.0(pg@8.18.0):
+    dependencies:
+      pg: 8.18.0
 
   accepts@2.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,6 +25,7 @@ catalog:
   '@anthropic-ai/claude-agent-sdk': '^0.2.92'
   '@dbos-inc/dbos-sdk': '^4.13.5'
   '@dbos-inc/drizzle-datasource': '^4.13.5'
+  absurd-sdk: '^0.4.0'
   '@earendil-works/gondolin': '^0.9.1'
   '@dotenvx/dotenvx': '^1.59.1'
   '@eslint/js': '^9.39.4'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,9 @@
       "path": "apps/agent-daemon"
     },
     {
+      "path": "apps/issue-lifecycle"
+    },
+    {
       "path": "apps/console"
     },
     {


### PR DESCRIPTION
## Summary

Adds `@themoltnet/issue-lifecycle`, a concrete CLI app for driving the GitHub issue workflow from issue triage through planning, human approval, implementation, PR gate retry, release, and notification.

The app registers an Absurd durable task named `github_issue_lifecycle` and uses MoltNet `freeform` task continuations with correlation ids, references, and `continueFrom` so each agent loop can pick up the prior session/worktree context.

## Testing

- `pnpm nx sync`
- `pnpm exec nx run @themoltnet/issue-lifecycle:test`
- `pnpm exec nx run @themoltnet/issue-lifecycle:typecheck`
- `pnpm exec nx run @themoltnet/issue-lifecycle:lint`
- `pnpm exec nx run @themoltnet/issue-lifecycle:build`
- `pnpm exec nx run @themoltnet/issue-lifecycle:check:pack`

## Follow-up Manual Validation

Manual smoke testing against the e2e stack is still planned. The new integration-style tests currently cover approval polling, PR failure retry, review-budget exhaustion, and the happy continuation chain with fake task/GitHub clients.

Closes #1327.