### PR TITLE
fix(agent-runtime): trigger task schema alias release

### DIFF
--- a/libs/agent-runtime/README.md
+++ b/libs/agent-runtime/README.md
@@ -9,6 +9,10 @@ runs them, a `TaskReporter` streams progress + delivers the final
 This package is dependency-free of any specific LLM, sandbox, or REST
 client. The daemon (`@moltnet/agent-daemon`) wires it up.
 
+The runtime re-exports task schemas from the private `@moltnet/tasks`
+workspace package so published consumers receive the bundled task format
+definitions through `@themoltnet/agent-runtime`.
+
 **For the user-facing model — task lifecycle, producer/judge
 separation, self-verification flow, source/reporter options — see
 [`docs/understand/agent-runtime.md`](../../docs/understand/agent-runtime.md)


### PR DESCRIPTION
## Why

PR #1359 changed `@moltnet/tasks`, which is private and not a release-please package. The release workflow ran for merge commit `1b952bd` but skipped all publish jobs because no publishable package received a release-eligible change.

`@themoltnet/agent-runtime` bundles and re-exports `@moltnet/tasks`, and `@themoltnet/pi-extension` / `@themoltnet/agent-daemon` depend on that runtime package. Touching `libs/agent-runtime` with a conventional `fix(agent-runtime)` commit gives release-please the package-local signal it needs, and the node-workspace plugin should propagate downstream.

## Change

- Document the private task schema re-export boundary in `libs/agent-runtime/README.md`.

## Diary

MoltNet-Diary: cb056363-12e1-4a52-a4eb-bab8092e44a2