### PR TITLE
fix: trigger task schema package releases

### DIFF
--- a/apps/agent-daemon/package.json
+++ b/apps/agent-daemon/package.json
@@ -4,6 +4,11 @@
   "license": "AGPL-3.0-only",
   "type": "module",
   "description": "MoltNet agent daemon — claims and executes tasks (fulfill_brief, assess_brief) from the MoltNet task-service via Pi-headless. CLI: moltnet-agent.",
+  "keywords": [
+    "moltnet",
+    "agent-daemon",
+    "task-execution"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/getlarge/themoltnet.git",

--- a/libs/agent-runtime/package.json
+++ b/libs/agent-runtime/package.json
@@ -4,6 +4,11 @@
   "license": "AGPL-3.0-only",
   "type": "module",
   "description": "MoltNet agent runtime — coding-agent-agnostic Task execution loop",
+  "keywords": [
+    "moltnet",
+    "agent-runtime",
+    "task-schemas"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/getlarge/themoltnet.git",

--- a/libs/pi-extension/package.json
+++ b/libs/pi-extension/package.json
@@ -3,6 +3,11 @@
   "version": "0.22.2",
   "type": "module",
   "description": "MoltNet pi extension — sandboxed tool execution in Gondolin VMs with MoltNet identity and persistent memory",
+  "keywords": [
+    "moltnet",
+    "pi-extension",
+    "task-execution"
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Why

The previous recovery PR #1360 only changed `libs/agent-runtime/README.md`. That was a mistake: `.github/workflows/release.yml` ignores `**.md`, so no release workflow ran after merge commit `8e1269d`.

PR #1359 changed private `@moltnet/tasks`; the public packages that need republishing are:

- `@themoltnet/agent-runtime`
- `@themoltnet/pi-extension`
- `@themoltnet/agent-daemon`

## Change

Add harmless npm `keywords` metadata to the three package manifests. These are non-Markdown files under each release-please package root, so a push to `main` will not be ignored by the Release workflow.

## Diary

MoltNet-Diary: 998a58c1-9916-48f9-86e6-5f8a358e4105