### PR TITLE
fix(tasks): remove TypeBox Recursive schema dependency

### DIFF
--- a/apps/agent-daemon/package.json
+++ b/apps/agent-daemon/package.json
@@ -7,7 +7,8 @@
   "keywords": [
     "moltnet",
     "agent-daemon",
-    "task-execution"
+    "task-execution",
+    "typebox-compat"
   ],
   "repository": {
     "type": "git",

--- a/libs/agent-runtime/package.json
+++ b/libs/agent-runtime/package.json
@@ -7,7 +7,8 @@
   "keywords": [
     "moltnet",
     "agent-runtime",
-    "task-schemas"
+    "task-schemas",
+    "typebox-compat"
   ],
   "repository": {
     "type": "git",

--- a/libs/pi-extension/package.json
+++ b/libs/pi-extension/package.json
@@ -6,7 +6,8 @@
   "keywords": [
     "moltnet",
     "pi-extension",
-    "task-execution"
+    "task-execution",
+    "typebox-compat"
   ],
   "license": "MIT",
   "repository": {

--- a/libs/tasks/src/validation.test.ts
+++ b/libs/tasks/src/validation.test.ts
@@ -20,7 +20,7 @@ import {
   validateTaskCreateRequest,
   validateTaskOutput,
 } from './validation.js';
-import { DaemonState, TaskAttempt } from './wire.js';
+import { ClaimCondition, DaemonState, Task, TaskAttempt } from './wire.js';
 
 describe('validateTaskCreateRequest', () => {
   it('rejects prototype task type keys as unknown', () => {
@@ -877,6 +877,67 @@ describe('TaskAttempt.daemonState', () => {
         }),
       ),
     ).toBe(false);
+  });
+});
+
+describe('ClaimCondition', () => {
+  const nestedClaimCondition = {
+    op: 'all',
+    conditions: [
+      {
+        op: 'task_accepted',
+        taskId: '11111111-1111-4111-8111-111111111111',
+      },
+      {
+        op: 'any',
+        conditions: [
+          {
+            op: 'task_status',
+            taskId: '22222222-2222-4222-8222-222222222222',
+            statuses: ['completed'],
+          },
+        ],
+      },
+    ],
+  };
+
+  it('accepts nested claim conditions without Type.Recursive', () => {
+    expect(Value.Check(ClaimCondition, nestedClaimCondition)).toBe(true);
+  });
+
+  it('validates nested claim conditions through Task', () => {
+    expect(
+      Value.Check(Task, {
+        id: '33333333-3333-4333-8333-333333333333',
+        taskType: 'freeform',
+        title: null,
+        tags: [],
+        teamId: '44444444-4444-4444-8444-444444444444',
+        diaryId: null,
+        outputKind: 'artifact',
+        input: {},
+        inputSchemaCid: 'bafkreihotfix',
+        inputCid: 'bafkreihotfixinput',
+        references: [],
+        correlationId: null,
+        proposedByAgentId: '55555555-5555-4555-8555-555555555555',
+        proposedByHumanId: null,
+        acceptedAttemptN: null,
+        claimCondition: nestedClaimCondition,
+        requiredExecutorTrustLevel: 'selfDeclared',
+        allowedExecutors: [],
+        status: 'queued',
+        queuedAt: '2026-06-11T12:00:00.000Z',
+        completedAt: null,
+        expiresAt: null,
+        cancelledByAgentId: null,
+        cancelledByHumanId: null,
+        cancelReason: null,
+        maxAttempts: 1,
+        dispatchTimeoutSec: null,
+        runningTimeoutSec: null,
+      }),
+    ).toBe(true);
   });
 });
 

--- a/libs/tasks/src/wire.ts
+++ b/libs/tasks/src/wire.ts
@@ -17,7 +17,7 @@
  *
  * See GH issue #852 for the full design snapshot.
  */
-import { type Static, Type } from '@sinclair/typebox';
+import { type Static, type TUnsafe, Type } from '@sinclair/typebox';
 
 // ---------------------------------------------------------------------------
 // Enums
@@ -147,48 +147,49 @@ export type ClaimCondition =
       taskId: string;
     };
 
-export const ClaimCondition = Type.Recursive(
-  (Self) =>
-    Type.Union([
-      Type.Object(
-        {
-          op: Type.Literal('all'),
-          conditions: Type.Array(Self, {
-            minItems: 1,
-            maxItems: MAX_CLAIM_CONDITION_BRANCHES,
-          }),
-        },
-        { additionalProperties: false },
-      ),
-      Type.Object(
-        {
-          op: Type.Literal('any'),
-          conditions: Type.Array(Self, {
-            minItems: 1,
-            maxItems: MAX_CLAIM_CONDITION_BRANCHES,
-          }),
-        },
-        { additionalProperties: false },
-      ),
-      Type.Object(
-        {
-          op: Type.Literal('task_status'),
-          taskId: Uuid,
-          statuses: Type.Array(Type.Ref(TaskStatus), {
-            minItems: 1,
-            maxItems: MAX_CLAIM_CONDITION_STATUSES,
-          }),
-        },
-        { additionalProperties: false },
-      ),
-      Type.Object(
-        {
-          op: Type.Literal('task_accepted'),
-          taskId: Uuid,
-        },
-        { additionalProperties: false },
-      ),
-    ]),
+const ClaimConditionRef = Type.Ref('ClaimCondition') as TUnsafe<ClaimCondition>;
+
+export const ClaimCondition = Type.Union(
+  [
+    Type.Object(
+      {
+        op: Type.Literal('all'),
+        conditions: Type.Array(ClaimConditionRef, {
+          minItems: 1,
+          maxItems: MAX_CLAIM_CONDITION_BRANCHES,
+        }),
+      },
+      { additionalProperties: false },
+    ),
+    Type.Object(
+      {
+        op: Type.Literal('any'),
+        conditions: Type.Array(ClaimConditionRef, {
+          minItems: 1,
+          maxItems: MAX_CLAIM_CONDITION_BRANCHES,
+        }),
+      },
+      { additionalProperties: false },
+    ),
+    Type.Object(
+      {
+        op: Type.Literal('task_status'),
+        taskId: Uuid,
+        statuses: Type.Array(TaskStatus, {
+          minItems: 1,
+          maxItems: MAX_CLAIM_CONDITION_STATUSES,
+        }),
+      },
+      { additionalProperties: false },
+    ),
+    Type.Object(
+      {
+        op: Type.Literal('task_accepted'),
+        taskId: Uuid,
+      },
+      { additionalProperties: false },
+    ),
+  ],
   { $id: 'ClaimCondition' },
 );
 


### PR DESCRIPTION
## Why

Published `@themoltnet/pi-extension` fails to load with:

```text
_typebox.Type.Recursive is not a function
```

The previous release fixed format registration but left `ClaimCondition` using `Type.Recursive` in private `@moltnet/tasks`. That private package is bundled into `@themoltnet/agent-runtime` and `@themoltnet/pi-extension`, so the published extension still executes the incompatible constructor at module load.

## Change

- Replace `Type.Recursive` with a `Type.Ref('ClaimCondition')` self-reference typed as `TUnsafe<ClaimCondition>` so runtime gets a normal TypeBox `Ref` and TypeScript still sees recursive `ClaimCondition[]`.
- Inline `TaskStatus` in the `task_status` branch to avoid unresolved `$id` lookup during direct `Value.Check(ClaimCondition, value)`.
- Add regression tests for nested claim conditions directly and through `Task`.
- Touch `agent-runtime`, `pi-extension`, and `agent-daemon` package manifests with non-Markdown metadata so release-please cuts the three published packages after merge.

## Verification

- `pnpm exec nx run @moltnet/tasks:typecheck`
- `pnpm exec nx run @themoltnet/agent-runtime:typecheck`
- `pnpm exec nx run @moltnet/tasks:test`
- `pnpm exec nx run @themoltnet/agent-runtime:build`
- `pnpm exec nx run @themoltnet/pi-extension:build`
- `pnpm exec nx run @themoltnet/agent-daemon:build`
- `pnpm exec nx run @themoltnet/agent-runtime:check:pack`
- `pnpm exec nx run @themoltnet/pi-extension:check:pack`
- Built bundle scan: no `Type.Recursive` references remain in agent-runtime/pi-extension/tasks dist outputs.
- Local import smoke tests passed for built `agent-runtime` and `pi-extension`.

## Diary

MoltNet-Diary: a5e7e391-abfe-4af3-b200-3e5de2876ccc