### PR TITLE
fix(pi-extension): mount worktree node_modules on resume

### DIFF
--- a/libs/pi-extension/src/runtime/execute-pi-task.ts
+++ b/libs/pi-extension/src/runtime/execute-pi-task.ts
@@ -524,6 +524,7 @@ export async function executePiTask(
         agentName: opts.agentName,
         agentRootDir,
         mountPath,
+        cwdPath,
         workspaceMode: workspace.mode,
         extraAllowedHosts: opts.extraAllowedHosts,
         sandboxConfig,

--- a/libs/pi-extension/src/vm-manager-resume.test.ts
+++ b/libs/pi-extension/src/vm-manager-resume.test.ts
@@ -139,4 +139,56 @@ describe('resumeVm task-context mount', () => {
     expect(resumeOptions.env.MOLTNET_TEST_DO_NOT_FORWARD).toBeUndefined();
     expect(resumeOptions.env.NODE_OPTIONS).toBe('--dns-result-order=ipv4first');
   });
+
+  it('exposes the mounted workspace and active cwd to resume commands', async () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'moltnet-vm-cwd-'));
+    tempRoots.push(root);
+    const workspace = path.join(root, 'workspace');
+    const cwd = path.join(workspace, '.worktrees', 'task-1');
+    const agentDir = path.join(root, '.moltnet', 'legreffier');
+    mkdirSync(cwd, { recursive: true });
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(
+      path.join(agentDir, 'moltnet.json'),
+      JSON.stringify({
+        endpoints: { api: 'https://api.themolt.net' },
+      }),
+      'utf8',
+    );
+    writeFileSync(path.join(agentDir, 'env'), '', 'utf8');
+
+    await resumeVm({
+      checkpointPath: path.join(root, 'checkpoint.qcow2'),
+      agentName: 'legreffier',
+      agentRootDir: root,
+      mountPath: workspace,
+      cwdPath: cwd,
+      workspaceMode: 'dedicated_worktree',
+      sandboxConfig: {
+        resumeCommands: [
+          {
+            run: 'test "$MOLTNET_GUEST_CWD" != "$MOLTNET_GUEST_WORKSPACE"',
+            when: { workspaceMode: ['dedicated_worktree'] },
+          },
+        ],
+      },
+    });
+
+    expect(gondolinMock.resumeCalls).toHaveLength(1);
+    const resumeOptions = gondolinMock.resumeCalls[0] as {
+      env: Record<string, string>;
+    };
+    expect(resumeOptions.env.MOLTNET_GUEST_WORKSPACE).toBe(workspace);
+    expect(resumeOptions.env.MOLTNET_GUEST_CWD).toBe(cwd);
+    expect(gondolinMock.vm.exec).toHaveBeenCalledWith(
+      [
+        'sh',
+        '-c',
+        expect.stringContaining(
+          'test "$MOLTNET_GUEST_CWD" != "$MOLTNET_GUEST_WORKSPACE"',
+        ),
+      ],
+      expect.any(Object),
+    );
+  });
 });

--- a/libs/pi-extension/src/vm-manager.test.ts
+++ b/libs/pi-extension/src/vm-manager.test.ts
@@ -5,6 +5,7 @@
  */
 import { execFileSync } from 'node:child_process';
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -313,6 +314,66 @@ describe('shouldRunResumeCommand', () => {
   });
 });
 
+describe('themoltnet sandbox tmpfs resume command', () => {
+  it('mounts node_modules for both the mounted repo and active worktree cwd', () => {
+    const sandbox = JSON.parse(
+      readFileSync(path.resolve('../..', 'sandbox.json'), 'utf8'),
+    ) as {
+      resumeCommands: { run: string }[];
+    };
+    const command = sandbox.resumeCommands[0]?.run;
+    expect(command).toBeTruthy();
+    expect(command).not.toContain('pnpm m ls');
+    expect(command).toContain('MOLTNET_GUEST_CWD');
+
+    const root = mkdtempSync(path.join(tmpdir(), 'pi-sandbox-root-'));
+    const cwd = path.join(root, '.worktrees', 'task-1');
+    const bin = path.join(root, 'bin');
+    const mountLog = path.join(root, 'mount.log');
+    try {
+      for (const base of [root, cwd]) {
+        mkdirSync(path.join(base, 'apps', 'rest-api'), { recursive: true });
+        mkdirSync(path.join(base, 'libs', 'pi-extension'), {
+          recursive: true,
+        });
+        mkdirSync(path.join(base, 'packages', 'cli'), { recursive: true });
+        mkdirSync(path.join(base, 'tools'), { recursive: true });
+      }
+      mkdirSync(bin, { recursive: true });
+      const fakeMount = path.join(bin, 'mount');
+      writeFileSync(
+        fakeMount,
+        '#!/bin/sh\nprintf "%s\\n" "$*" >> "$MOUNT_LOG"\n',
+        'utf8',
+      );
+      chmodSync(fakeMount, 0o755);
+
+      execFileSync('sh', ['-c', `set -eu\n${command}`], {
+        env: {
+          ...process.env,
+          PATH: `${bin}${path.delimiter}${process.env.PATH ?? ''}`,
+          MOLTNET_GUEST_WORKSPACE: root,
+          MOLTNET_GUEST_CWD: cwd,
+          MOUNT_LOG: mountLog,
+        },
+        stdio: 'pipe',
+      });
+
+      const mounts = readFileSync(mountLog, 'utf8');
+      expect(mounts).toContain(`${root}/node_modules`);
+      expect(mounts).toContain(`${root}/apps/rest-api/node_modules`);
+      expect(mounts).toContain(`${root}/libs/pi-extension/node_modules`);
+      expect(mounts).toContain(`${cwd}/node_modules`);
+      expect(mounts).toContain(`${cwd}/apps/rest-api/node_modules`);
+      expect(mounts).toContain(`${cwd}/libs/pi-extension/node_modules`);
+      expect(mounts).toContain(`${cwd}/packages/cli/node_modules`);
+      expect(mounts).toContain(`${cwd}/tools/node_modules`);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
 // ---------------------------------------------------------------------------
 // loadCredentials — PEM reading (finding 7)
 // ---------------------------------------------------------------------------
@@ -577,6 +638,12 @@ describe('dedicated worktree mount topology', () => {
         worktreeBranch: 'moltnet/correlation-1/demo-task',
         workspaceScope: 'session',
       });
+
+      expect(realpathSync(workspace.mountPath)).toBe(realpathSync(repoRoot));
+      expect(realpathSync(workspace.cwdPath)).toBe(
+        realpathSync(path.join(repoRoot, '.worktrees', 'session-slot-1')),
+      );
+      expect(workspace.cwdPath).not.toBe(workspace.mountPath);
 
       const guestWorkspace = path.resolve(workspace.cwdPath);
       const gitdirPointer = readFileSync(path.join(guestWorkspace, '.git'), {

--- a/libs/pi-extension/src/vm-manager.test.ts
+++ b/libs/pi-extension/src/vm-manager.test.ts
@@ -325,6 +325,9 @@ describe('themoltnet sandbox tmpfs resume command', () => {
     expect(command).toBeTruthy();
     expect(command).not.toContain('pnpm m ls');
     expect(command).toContain('MOLTNET_GUEST_CWD');
+    expect(sandbox.resumeCommands[1]?.run).toContain(
+      'cd "${MOLTNET_GUEST_CWD:-${MOLTNET_GUEST_WORKSPACE}}"',
+    );
 
     const root = mkdtempSync(path.join(tmpdir(), 'pi-sandbox-root-'));
     const cwd = path.join(root, '.worktrees', 'task-1');

--- a/libs/pi-extension/src/vm-manager.ts
+++ b/libs/pi-extension/src/vm-manager.ts
@@ -54,6 +54,15 @@ export interface VmConfig {
   agentRootDir?: string;
   /** Host directory to mount into the VM. */
   mountPath: string;
+  /**
+   * Host working directory where the agent session will start.
+   *
+   * For dedicated worktree tasks this differs from `mountPath`: the VM mounts
+   * the main repository root, while the agent starts under `.worktrees/<id>`.
+   * Resume commands need this path to prepare the active checkout before the
+   * session starts.
+   */
+  cwdPath?: string;
   /** Effective workspace shape selected by the caller. */
   workspaceMode?: 'shared_mount' | 'dedicated_worktree' | 'scratch_mount';
   /** Additional hosts to allow in egress policy. */
@@ -305,6 +314,7 @@ export async function resumeVm(config: VmConfig): Promise<ManagedVm> {
   throwIfAborted(config.signal, 'VM resume');
   const agentDir = resolveVmAgentDir(config);
   const guestWorkspace = path.resolve(config.mountPath);
+  const guestCwd = path.resolve(config.cwdPath ?? config.mountPath);
 
   if (!existsSync(agentDir)) {
     throw new Error(
@@ -378,6 +388,7 @@ export async function resumeVm(config: VmConfig): Promise<ManagedVm> {
     NODE_EXTRA_CA_CERTS: '/etc/ssl/certs/ca-certificates.crt',
     ...envOverrides,
     MOLTNET_GUEST_WORKSPACE: guestWorkspace,
+    MOLTNET_GUEST_CWD: guestCwd,
   };
 
   const resources = config.sandboxConfig?.resources;

--- a/sandbox.json
+++ b/sandbox.json
@@ -49,7 +49,7 @@
     {
       "retries": 3,
       "retryBackoffMs": 5000,
-      "run": "cd \"${MOLTNET_GUEST_WORKSPACE}\" && pnpm install --frozen-lockfile --fetch-retries=8 --fetch-retry-mintimeout=2000 --fetch-retry-maxtimeout=30000 --network-concurrency=8",
+      "run": "cd \"${MOLTNET_GUEST_CWD:-${MOLTNET_GUEST_WORKSPACE}}\" && pnpm install --frozen-lockfile --fetch-retries=8 --fetch-retry-mintimeout=2000 --fetch-retry-maxtimeout=30000 --network-concurrency=8",
       "when": {
         "workspaceMode": ["shared_mount", "dedicated_worktree"]
       }

--- a/sandbox.json
+++ b/sandbox.json
@@ -41,7 +41,7 @@
   },
   "resumeCommands": [
     {
-      "run": "cd \"${MOLTNET_GUEST_WORKSPACE}\" && pnpm m ls --depth -1 --parseable | while read d; do [ -d \"$d\" ] || continue; mkdir -p \"$d/node_modules\"; if [ \"$d\" = \"${MOLTNET_GUEST_WORKSPACE}\" ]; then sz=6G; else sz=64M; fi; mount -t tmpfs -o size=$sz,mode=0755,uid=501,gid=501 tmpfs \"$d/node_modules\"; done",
+      "run": "mount_node_modules_tmpfs() { root=\"$1\"; [ -d \"$root\" ] || return 0; for d in \"$root\" \"$root\"/apps/* \"$root\"/libs/* \"$root\"/packages/* \"$root\"/tools \"$root\"/docs; do [ -d \"$d\" ] || continue; nm=\"$d/node_modules\"; mkdir -p \"$nm\"; if [ \"$d\" = \"$root\" ]; then sz=6G; else sz=64M; fi; mount -t tmpfs -o size=$sz,mode=0755,uid=501,gid=501 tmpfs \"$nm\" 2>/dev/null || true; done; }; mount_node_modules_tmpfs \"${MOLTNET_GUEST_WORKSPACE}\"; if [ \"${MOLTNET_GUEST_CWD:-${MOLTNET_GUEST_WORKSPACE}}\" != \"${MOLTNET_GUEST_WORKSPACE}\" ]; then mount_node_modules_tmpfs \"${MOLTNET_GUEST_CWD}\"; fi",
       "when": {
         "workspaceMode": ["shared_mount", "dedicated_worktree"]
       }


### PR DESCRIPTION
## Summary

Fixes #1392 by making runtime-profile resume commands aware of the active task checkout, not only the VM mount root.

- expose the prepared task cwd to VM resume commands as `MOLTNET_GUEST_CWD`
- pass `cwdPath` from `executePiTask` into `resumeVm`
- replace the repo tmpfs mount command with a pnpm-free loop that covers both `MOLTNET_GUEST_WORKSPACE` and a distinct worktree cwd
- add regression tests proving the actual sandbox command mounts both main and worktree `node_modules` paths

## Root Cause

After runtime profiles, dedicated task worktrees are prepared before VM resume, but the VM still mounts the main repository root. The existing resume command only knew about `MOLTNET_GUEST_WORKSPACE`, so it could prepare the main checkout while missing the worktree where the agent session actually starts.

## Validation

- `pnpm exec nx run @themoltnet/pi-extension:test-ci--src/vm-manager.test.ts`
- `pnpm exec nx run @themoltnet/pi-extension:test-ci--src/vm-manager-resume.test.ts`
- `pnpm exec nx run @themoltnet/pi-extension:typecheck`
- `pnpm exec nx run @themoltnet/pi-extension:lint` (passes with existing warnings)

MoltNet-Diary: 8be3b73e-c322-4fa6-9800-2eb23514b745