### PR TITLE
fix(pi-extension): resolve built-ins from task cwd

### DIFF
--- a/libs/pi-extension/src/moltnet/task-artifacts.test.ts
+++ b/libs/pi-extension/src/moltnet/task-artifacts.test.ts
@@ -1,4 +1,5 @@
 import {
+  access,
   mkdir,
   mkdtemp,
   readFile,
@@ -12,11 +13,17 @@ import { Readable } from 'node:stream';
 
 import { describe, expect, it, vi } from 'vitest';
 
+import { createGondolinToolDefinitions } from '../runtime/execute-pi-task.js';
 import {
   createMoltNetTools,
   type MoltNetTaskContext,
   type MoltNetToolsConfig,
 } from './tools.js';
+
+const PNG_BYTES = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABmJLR0QA/wD/AP+gvaeTAAABi0lEQVQ4jdWSv0tbYRSGn3MTok1RnCQoRFsKoYNQiktF3DREKHV0cLR7wYJj7VaH0NGhg39EkMQGaQgSpbUaCcErSixB2nQJdSghTc79nPTmxoSAW9/p4/x4zvvCB/+PjBF2Py9zkAi2lq3bV+X4IefHGc6+L3UEJJMBhFX++ndIuBAXUPfHsSSML5DuCJifr+OzphEJMWjFvc2K/YhyUSkVZntGySajZLYa7GyNuQ4cXoGUeDzhuX66Obz2J/X0gwcwE9sGuQTnZWuECCL59mXEvANW70CEIyyJAPgBMOKA8cxUr+o1QRjoryJiarQRMEZcgE9sjIm2jrx4c7W+93HogTHCyOLv9237z8DKuIVfJ+Nc2g3KhTl6KZeOkk01SSfC3sZPe4Ny8YKLYqjr8tcvIXLpEtnUxk3J/QcMroBUQHOc5e86+ZaJYcw+UCHYWHHTeFwcBKn3xVF9jeoP1CmgTQfV56iOovqJZv9bpqZqnQE3Kh2O8c9ZQPUJxoFG00YlweR0uWu8++oaz1SX517RnkIAAAAASUVORK5CYII=',
+  'base64',
+);
 
 interface CapturedUpload {
   path: { taskId: string; attemptN: number };
@@ -47,6 +54,8 @@ function makeConfig(input: {
   captured?: CapturedUpload[];
   capturedDownloads?: CapturedDownloadPath[];
   cwd: string;
+  downloadBody?: Buffer | string;
+  downloadContentType?: string;
   taskCtx?: MoltNetTaskContext | null;
   teamId?: string | null;
   openWorkspaceFileForRead?: MoltNetToolsConfig['openWorkspaceFileForRead'];
@@ -91,9 +100,9 @@ function makeConfig(input: {
             artifactId: 'artifact-1',
             cid: 'bafkreia',
             contentEncoding: null,
-            contentType: 'text/plain',
+            contentType: input.downloadContentType ?? 'text/plain',
             sha256: 'a'.repeat(64),
-            stream: Readable.from(['artifact bytes']),
+            stream: Readable.from([input.downloadBody ?? 'artifact bytes']),
           };
         }),
       },
@@ -386,6 +395,108 @@ describe('moltnet_download_task_artifact', () => {
       await rm(cwd, { force: true, recursive: true });
     }
   });
+
+  it.each([
+    { name: 'shared mount', worktree: false },
+    { name: 'dedicated worktree', worktree: true },
+  ])(
+    'makes a bound image input readable from the active $name cwd',
+    async ({ worktree }) => {
+      const mountPath = await mkdtemp(
+        path.join(tmpdir(), 'moltnet-pi-artifact-'),
+      );
+      const cwdPath = worktree
+        ? path.join(mountPath, '.worktrees', 'task-1624')
+        : mountPath;
+      const artifactPath = path.join(cwdPath, 'inputs', 'inspection.png');
+      const capturedDownloads: CapturedDownloadPath[] = [];
+      const vmAccess = vi.fn((filePath: string) => access(filePath));
+      const vmReadFile = vi.fn((filePath: string) => readFile(filePath));
+      const vmExec = vi.fn(() =>
+        Promise.resolve({
+          exitCode: 0,
+          ok: true,
+          stderr: '',
+          stdout: 'image/png\n',
+        }),
+      );
+      const vm = {
+        exec: vmExec,
+        fs: {
+          access: vmAccess,
+          readFile: vmReadFile,
+        },
+      };
+
+      try {
+        await mkdir(path.dirname(artifactPath), { recursive: true });
+        const downloadTool = findTool(
+          makeConfig({
+            capturedDownloads,
+            cwd: cwdPath,
+            downloadBody: PNG_BYTES,
+            downloadContentType: 'image/png',
+          }),
+          'moltnet_download_task_artifact',
+        );
+
+        await callTool(downloadTool, {
+          cid: 'bafkreiinput',
+          outputPath: 'inputs/inspection.png',
+        });
+
+        const toolConfig = {
+          vm: vm as never,
+          cwdPath,
+          guestWorkspace: mountPath,
+        };
+        const readTool = createGondolinToolDefinitions(toolConfig).find(
+          (tool) => tool.name === 'read',
+        );
+        if (!readTool) throw new Error('read tool not registered');
+
+        const result = await readTool.execute(
+          'call-id',
+          { path: 'inputs/inspection.png' },
+          new AbortController().signal,
+          () => {},
+          null as never,
+        );
+
+        await expect(readFile(artifactPath)).resolves.toEqual(PNG_BYTES);
+        expect(capturedDownloads).toEqual([
+          { taskId: 'task-123', cid: 'bafkreiinput' },
+        ]);
+        expect(vmAccess).toHaveBeenCalledWith(artifactPath);
+        expect(vmReadFile).toHaveBeenCalledWith(artifactPath);
+        expect(vmExec).toHaveBeenCalled();
+        expect(result.content).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              text: expect.stringContaining('Read image file [image/png]'),
+              type: 'text',
+            }),
+            expect.objectContaining({
+              data: expect.stringMatching(/.+/),
+              mimeType: 'image/png',
+              type: 'image',
+            }),
+          ]),
+        );
+        if (worktree) {
+          const lossyMountPath = path.join(
+            mountPath,
+            'inputs',
+            'inspection.png',
+          );
+          expect(vmAccess).not.toHaveBeenCalledWith(lossyMountPath);
+          expect(vmReadFile).not.toHaveBeenCalledWith(lossyMountPath);
+        }
+      } finally {
+        await rm(mountPath, { force: true, recursive: true });
+      }
+    },
+  );
 
   it('rejects download paths escaping the workspace', async () => {
     const cwd = await mkdtemp(path.join(tmpdir(), 'moltnet-pi-artifact-'));

--- a/libs/pi-extension/src/runtime/execute-pi-task.test.ts
+++ b/libs/pi-extension/src/runtime/execute-pi-task.test.ts
@@ -123,7 +123,7 @@ describe('createGondolinToolDefinitions', () => {
   it('registers the full VM-routed built-in tool surface', () => {
     const tools = createGondolinToolDefinitions({
       vm: {} as never,
-      mountPath: '/Users/ed/project',
+      cwdPath: '/Users/ed/project',
       guestWorkspace: '/workspace',
     });
 

--- a/libs/pi-extension/src/runtime/execute-pi-task.ts
+++ b/libs/pi-extension/src/runtime/execute-pi-task.ts
@@ -172,29 +172,29 @@ export async function openVmWorkspaceFileForRead(config: {
 
 export function createGondolinToolDefinitions(config: {
   vm: VM;
-  mountPath: string;
+  cwdPath: string;
   guestWorkspace: string;
 }): ToolDefinition[] {
-  const { vm, mountPath, guestWorkspace } = config;
-  const grepTool = createGrepToolDefinition(mountPath);
+  const { vm, cwdPath, guestWorkspace } = config;
+  const grepTool = createGrepToolDefinition(cwdPath);
   return [
-    createReadToolDefinition(mountPath, {
-      operations: createGondolinReadOps(vm, mountPath, guestWorkspace),
+    createReadToolDefinition(cwdPath, {
+      operations: createGondolinReadOps(vm, cwdPath, guestWorkspace),
     }),
-    createWriteToolDefinition(mountPath, {
-      operations: createGondolinWriteOps(vm, mountPath, guestWorkspace),
+    createWriteToolDefinition(cwdPath, {
+      operations: createGondolinWriteOps(vm, cwdPath, guestWorkspace),
     }),
-    createEditToolDefinition(mountPath, {
-      operations: createGondolinEditOps(vm, mountPath, guestWorkspace),
+    createEditToolDefinition(cwdPath, {
+      operations: createGondolinEditOps(vm, cwdPath, guestWorkspace),
     }),
-    createBashToolDefinition(mountPath, {
-      operations: createGondolinBashOps(vm, mountPath, guestWorkspace),
+    createBashToolDefinition(cwdPath, {
+      operations: createGondolinBashOps(vm, cwdPath, guestWorkspace),
     }),
-    createLsToolDefinition(mountPath, {
-      operations: createGondolinLsOps(vm, mountPath, guestWorkspace),
+    createLsToolDefinition(cwdPath, {
+      operations: createGondolinLsOps(vm, cwdPath, guestWorkspace),
     }),
-    createFindToolDefinition(mountPath, {
-      operations: createGondolinFindOps(vm, mountPath, guestWorkspace),
+    createFindToolDefinition(cwdPath, {
+      operations: createGondolinFindOps(vm, cwdPath, guestWorkspace),
     }),
     {
       ...grepTool,
@@ -202,13 +202,7 @@ export function createGondolinToolDefinitions(config: {
         ...args: Parameters<typeof grepTool.execute>
       ): ReturnType<typeof grepTool.execute> {
         const [_id, params, signal] = args;
-        return executeGondolinGrep(
-          vm,
-          mountPath,
-          guestWorkspace,
-          params,
-          signal,
-        );
+        return executeGondolinGrep(vm, cwdPath, guestWorkspace, params, signal);
       },
     },
   ] as unknown as ToolDefinition[];
@@ -774,7 +768,7 @@ export async function executePiTask(
     // default by name at definition-registry merge time (AgentSession._refreshToolRegistry).
     const gondolinCustomTools = createGondolinToolDefinitions({
       vm: managed.vm,
-      mountPath,
+      cwdPath,
       guestWorkspace: managed.guestWorkspace,
     });
 


### PR DESCRIPTION
## Summary

- resolve every Gondolin-routed Pi built-in from the active task `cwdPath`
- keep the repository mount as `guestWorkspace` for sandbox path containment
- add a CID download → PNG → real Pi `Read` regression covering shared and dedicated worktrees

## Root cause

`createGondolinToolDefinitions` captured `mountPath` as Pi's working directory. Pi resolves relative paths before invoking the Gondolin operations, so a dedicated-worktree path such as `.worktrees/task-1624/inputs/inspection.png` was irreversibly reduced to the repository-root `inputs/inspection.png` path.

The fix applies `cwdPath` consistently to read, write, edit, bash, ls, find, and grep. Shared and scratch workspaces retain their existing behavior because their cwd already equals the mount root.

## Red/green proof

Before the runtime change, the new table-driven regression produced:

- shared mount: passed
- dedicated worktree: failed with `ENOENT` at `<mountPath>/inputs/inspection.png`, omitting `.worktrees/task-1624`

After the change, both cases pass. The test downloads a valid PNG exclusively from the mocked bound-input CID, writes it beneath `cwdPath`, invokes the real Pi `Read("inputs/inspection.png")`, and asserts image output plus the absence of mount-root fallback reads.

## Validation

- Pi extension: 308 tests passed; 2 existing guarded integration tests skipped
- Pi extension typecheck and lint passed
- Pi extension build, tarball validation, loader bundle check, and Pi loader smoke passed
- Agent daemon build passed
- Agent daemon tarball install and packaged CLI smoke passed
- post-commit focused artifact regression: 12 tests passed

## Release

Tracks #1624. Keep the issue open until release-please publishes both the Pi extension patch and the downstream agent daemon release.