### PR TITLE
feat(crypto): dispatch signing verification by method

### DIFF
--- a/apps/rest-api/__tests__/signing-requests.test.ts
+++ b/apps/rest-api/__tests__/signing-requests.test.ts
@@ -6,6 +6,7 @@ import type {
   TokenValidator,
 } from '@moltnet/auth';
 import { buildSigningBytes } from '@moltnet/crypto-service';
+import { DBOS } from '@moltnet/database';
 import type { FastifyInstance } from 'fastify';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -65,6 +66,9 @@ function createMockSigningRequest(
   return {
     id: REQUEST_ID,
     agentId: OWNER_ID,
+    verificationMethod: 'agent-ed25519',
+    requestedBy: null,
+    signerConstraint: null,
     message: 'Hello, world!',
     nonce: 'aaa08400-e29b-41d4-a716-446655440011',
     status: 'pending',
@@ -224,6 +228,7 @@ describe('Signing request routes', () => {
       const body = response.json();
       expect(body.id).toBe(REQUEST_ID);
       expect(body.message).toBe('Hello, world!');
+      expect(body.verificationMethod).toBe('agent-ed25519');
       expect(body.status).toBe('pending');
       expect(body.signingInput).toBe(
         expectedSigningInput(
@@ -235,7 +240,16 @@ describe('Signing request routes', () => {
         expect.objectContaining({
           agentId: OWNER_ID,
           message: 'Hello, world!',
+          verificationMethod: 'agent-ed25519',
         }),
+      );
+      const workflow = vi.mocked(DBOS.startWorkflow).mock.results[0].value;
+      expect(workflow).toHaveBeenCalledWith(
+        REQUEST_ID,
+        OWNER_ID,
+        'Hello, world!',
+        'aaa08400-e29b-41d4-a716-446655440011',
+        'agent-ed25519',
       );
     });
 
@@ -267,6 +281,7 @@ describe('Signing request routes', () => {
       const body = response.json();
       expect(body.items).toHaveLength(1);
       expect(body.total).toBe(1);
+      expect(body.items[0].verificationMethod).toBe('agent-ed25519');
       expect(body.items[0].signingInput).toBe(
         expectedSigningInput(
           'Hello, world!',
@@ -307,6 +322,7 @@ describe('Signing request routes', () => {
       expect(response.statusCode).toBe(200);
       const body = response.json();
       expect(body.id).toBe(REQUEST_ID);
+      expect(body.verificationMethod).toBe('agent-ed25519');
       expect(body.signingInput).toBe(
         expectedSigningInput(
           'Hello, world!',

--- a/apps/rest-api/src/routes/signing-requests.ts
+++ b/apps/rest-api/src/routes/signing-requests.ts
@@ -42,6 +42,7 @@ function toSigningResponse(row: SigningRequest) {
   return {
     id: row.id,
     agentId: row.agentId,
+    verificationMethod: row.verificationMethod,
     message: row.message,
     nonce: row.nonce,
     signingInput: Buffer.from(
@@ -78,6 +79,12 @@ export async function signingRequestRoutes(fastify: FastifyInstance) {
         security: [{ bearerAuth: [] }, { sessionAuth: [] }, { cookieAuth: [] }],
         body: Type.Object({
           message: Type.String({ minLength: 1, maxLength: 100000 }),
+          verificationMethod: Type.Optional(
+            Type.Union([
+              Type.Literal('agent-ed25519'),
+              Type.Literal('human-hardware-previewsign'),
+            ]),
+          ),
         }),
         response: {
           400: Type.Ref(ProblemDetailsSchema.$id),
@@ -88,7 +95,7 @@ export async function signingRequestRoutes(fastify: FastifyInstance) {
       },
     },
     async (request, reply) => {
-      const { message } = request.body;
+      const { message, verificationMethod = 'agent-ed25519' } = request.body;
       const agentId = request.authContext!.identityId;
       const timeoutSeconds = fastify.signingTimeoutSeconds;
       const expiresAt = new Date(Date.now() + timeoutSeconds * 1000);
@@ -98,13 +105,20 @@ export async function signingRequestRoutes(fastify: FastifyInstance) {
         agentId,
         message,
         expiresAt,
+        verificationMethod,
       });
 
       // Start the DBOS workflow (must be outside runTransaction so recv/send work)
       const workflowHandle = await DBOS.startWorkflow(
         signingWorkflows.requestSignature,
         { workflowID: `signing-${created.id}` },
-      )(created.id, agentId, message, created.nonce);
+      )(
+        created.id,
+        agentId,
+        message,
+        created.nonce,
+        created.verificationMethod,
+      );
 
       // Persist the workflow ID for later send() calls
       await fastify.signingRequestRepository.updateStatus(created.id, {

--- a/apps/rest-api/src/routes/signing-requests.ts
+++ b/apps/rest-api/src/routes/signing-requests.ts
@@ -25,6 +25,8 @@ import { DBOS, parseStatusFilter } from '@moltnet/database';
 import {
   ConflictProblemDetailsSchema,
   ProblemDetailsSchema,
+  VERIFICATION_METHOD,
+  VerificationMethodSchema,
 } from '@moltnet/models';
 import { signingWorkflows } from '@moltnet/signing-workflows';
 import type { FastifyInstance } from 'fastify';
@@ -79,12 +81,7 @@ export async function signingRequestRoutes(fastify: FastifyInstance) {
         security: [{ bearerAuth: [] }, { sessionAuth: [] }, { cookieAuth: [] }],
         body: Type.Object({
           message: Type.String({ minLength: 1, maxLength: 100000 }),
-          verificationMethod: Type.Optional(
-            Type.Union([
-              Type.Literal('agent-ed25519'),
-              Type.Literal('human-hardware-previewsign'),
-            ]),
-          ),
+          verificationMethod: Type.Optional(VerificationMethodSchema),
         }),
         response: {
           400: Type.Ref(ProblemDetailsSchema.$id),
@@ -95,7 +92,8 @@ export async function signingRequestRoutes(fastify: FastifyInstance) {
       },
     },
     async (request, reply) => {
-      const { message, verificationMethod = 'agent-ed25519' } = request.body;
+      const { message, verificationMethod = VERIFICATION_METHOD.AgentEd25519 } =
+        request.body;
       const agentId = request.authContext!.identityId;
       const timeoutSeconds = fastify.signingTimeoutSeconds;
       const expiresAt = new Date(Date.now() + timeoutSeconds * 1000);

--- a/apps/rest-api/src/schemas/crypto.ts
+++ b/apps/rest-api/src/schemas/crypto.ts
@@ -26,6 +26,10 @@ export const SigningRequestSchema = Type.Object(
   {
     id: Type.String({ format: 'uuid' }),
     agentId: Type.String({ format: 'uuid' }),
+    verificationMethod: Type.Union([
+      Type.Literal('agent-ed25519'),
+      Type.Literal('human-hardware-previewsign'),
+    ]),
     message: Type.String(),
     nonce: Type.String({ format: 'uuid' }),
     signingInput: Type.String({

--- a/apps/rest-api/src/schemas/crypto.ts
+++ b/apps/rest-api/src/schemas/crypto.ts
@@ -1,3 +1,4 @@
+import { VerificationMethodSchema } from '@moltnet/models';
 import { Type } from 'typebox';
 
 import { DateTime, NullableDateTime } from './atoms.js';
@@ -26,10 +27,7 @@ export const SigningRequestSchema = Type.Object(
   {
     id: Type.String({ format: 'uuid' }),
     agentId: Type.String({ format: 'uuid' }),
-    verificationMethod: Type.Union([
-      Type.Literal('agent-ed25519'),
-      Type.Literal('human-hardware-previewsign'),
-    ]),
+    verificationMethod: VerificationMethodSchema,
     message: Type.String(),
     nonce: Type.String({ format: 'uuid' }),
     signingInput: Type.String({

--- a/libs/database/__tests__/signing-request.repository.test.ts
+++ b/libs/database/__tests__/signing-request.repository.test.ts
@@ -38,6 +38,9 @@ const REQUEST_ID = '770e8400-e29b-41d4-a716-446655440002';
 const mockRequest: SigningRequest = {
   id: REQUEST_ID,
   agentId: AGENT_ID,
+  verificationMethod: 'agent-ed25519',
+  requestedBy: null,
+  signerConstraint: null,
   message: 'Hello, world!',
   nonce: '880e8400-e29b-41d4-a716-446655440003',
   status: 'pending',
@@ -68,7 +71,34 @@ describe('createSigningRequestRepository', () => {
       });
 
       expect(db.insert).toHaveBeenCalled();
+      expect(db._chain.values).toHaveBeenCalledWith(
+        expect.objectContaining({
+          verificationMethod: 'agent-ed25519',
+        }),
+      );
       expect(result).toEqual(mockRequest);
+    });
+
+    it('creates a signing request with an explicit verification method', async () => {
+      db._chain.returning.mockResolvedValueOnce([
+        {
+          ...mockRequest,
+          verificationMethod: 'human-hardware-previewsign',
+        },
+      ]);
+
+      await repo.create({
+        agentId: AGENT_ID,
+        message: 'Hello, world!',
+        expiresAt: new Date(Date.now() + 5 * 60 * 1000),
+        verificationMethod: 'human-hardware-previewsign',
+      });
+
+      expect(db._chain.values).toHaveBeenCalledWith(
+        expect.objectContaining({
+          verificationMethod: 'human-hardware-previewsign',
+        }),
+      );
     });
 
     it('creates a signing request with custom expiry', async () => {

--- a/libs/database/drizzle/0032_yellow_deadpool.sql
+++ b/libs/database/drizzle/0032_yellow_deadpool.sql
@@ -1,0 +1,4 @@
+CREATE TYPE "public"."verification_method" AS ENUM('agent-ed25519', 'human-hardware-previewsign');--> statement-breakpoint
+ALTER TABLE "signing_requests" ADD COLUMN "verification_method" "verification_method" DEFAULT 'agent-ed25519' NOT NULL;--> statement-breakpoint
+ALTER TABLE "signing_requests" ADD COLUMN "requested_by" jsonb;--> statement-breakpoint
+ALTER TABLE "signing_requests" ADD COLUMN "signer_constraint" jsonb;

--- a/libs/database/drizzle/meta/0032_snapshot.json
+++ b/libs/database/drizzle/meta/0032_snapshot.json
@@ -1,0 +1,5769 @@
+{
+  "id": "29e3cdea-c956-4efa-9b93-dd3314f8c6df",
+  "prevId": "e781c42d-bf84-4daf-a5b8-5306bf21a97e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_vouchers": {
+      "name": "agent_vouchers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer_id": {
+          "name": "issuer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeemed_by": {
+          "name": "redeemed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_vouchers_code_idx": {
+          "name": "agent_vouchers_code_idx",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_vouchers_issuer_idx": {
+          "name": "agent_vouchers_issuer_idx",
+          "columns": [
+            {
+              "expression": "issuer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "identity_id": {
+          "name": "identity_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(19)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agents_fingerprint_idx": {
+          "name": "agents_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.context_pack_entries": {
+      "name": "context_pack_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pack_id": {
+          "name": "pack_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_cid_snapshot": {
+          "name": "entry_cid_snapshot",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compression_level": {
+          "name": "compression_level",
+          "type": "compression_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full'"
+        },
+        "original_tokens": {
+          "name": "original_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "packed_tokens": {
+          "name": "packed_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "context_pack_entries_unique_idx": {
+          "name": "context_pack_entries_unique_idx",
+          "columns": [
+            {
+              "expression": "pack_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "context_pack_entries_pack_idx": {
+          "name": "context_pack_entries_pack_idx",
+          "columns": [
+            {
+              "expression": "pack_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "context_pack_entries_entry_idx": {
+          "name": "context_pack_entries_entry_idx",
+          "columns": [
+            {
+              "expression": "entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "context_pack_entries_pack_id_context_packs_id_fk": {
+          "name": "context_pack_entries_pack_id_context_packs_id_fk",
+          "tableFrom": "context_pack_entries",
+          "tableTo": "context_packs",
+          "columnsFrom": [
+            "pack_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "context_pack_entries_entry_id_diary_entries_id_fk": {
+          "name": "context_pack_entries_entry_id_diary_entries_id_fk",
+          "tableFrom": "context_pack_entries",
+          "tableTo": "diary_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.context_packs": {
+      "name": "context_packs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "diary_id": {
+          "name": "diary_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pack_cid": {
+          "name": "pack_cid",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pack_codec": {
+          "name": "pack_codec",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'dag-cbor'"
+        },
+        "pack_type": {
+          "name": "pack_type",
+          "type": "pack_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'custom'"
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "creator_agent_id": {
+          "name": "creator_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_human_id": {
+          "name": "creator_human_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supersedes_pack_id": {
+          "name": "supersedes_pack_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "(now() + interval '7 days')"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "context_packs_pack_cid_unique_idx": {
+          "name": "context_packs_pack_cid_unique_idx",
+          "columns": [
+            {
+              "expression": "pack_cid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "context_packs_diary_idx": {
+          "name": "context_packs_diary_idx",
+          "columns": [
+            {
+              "expression": "diary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "context_packs_pack_type_idx": {
+          "name": "context_packs_pack_type_idx",
+          "columns": [
+            {
+              "expression": "pack_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "context_packs_expires_at_idx": {
+          "name": "context_packs_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "pinned = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "context_packs_pinned_idx": {
+          "name": "context_packs_pinned_idx",
+          "columns": [
+            {
+              "expression": "pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "context_packs_creator_agent_idx": {
+          "name": "context_packs_creator_agent_idx",
+          "columns": [
+            {
+              "expression": "creator_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "creator_agent_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "context_packs_creator_human_idx": {
+          "name": "context_packs_creator_human_idx",
+          "columns": [
+            {
+              "expression": "creator_human_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "creator_human_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "context_packs_diary_id_diaries_id_fk": {
+          "name": "context_packs_diary_id_diaries_id_fk",
+          "tableFrom": "context_packs",
+          "tableTo": "diaries",
+          "columnsFrom": [
+            "diary_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "context_packs_creator_agent_id_agents_identity_id_fk": {
+          "name": "context_packs_creator_agent_id_agents_identity_id_fk",
+          "tableFrom": "context_packs",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "creator_agent_id"
+          ],
+          "columnsTo": [
+            "identity_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "context_packs_creator_human_id_humans_id_fk": {
+          "name": "context_packs_creator_human_id_humans_id_fk",
+          "tableFrom": "context_packs",
+          "tableTo": "humans",
+          "columnsFrom": [
+            "creator_human_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "context_packs_supersedes_pack_id_context_packs_id_fk": {
+          "name": "context_packs_supersedes_pack_id_context_packs_id_fk",
+          "tableFrom": "context_packs",
+          "tableTo": "context_packs",
+          "columnsFrom": [
+            "supersedes_pack_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "context_packs_creator_xor": {
+          "name": "context_packs_creator_xor",
+          "value": "(creator_agent_id IS NOT NULL) <> (creator_human_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.correlation_seals": {
+      "name": "correlation_seals",
+      "schema": "",
+      "columns": {
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sealed_at": {
+          "name": "sealed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sealed_by_task_id": {
+          "name": "sealed_by_task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_by_task_type": {
+          "name": "sealed_by_task_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_by_agent_id": {
+          "name": "sealed_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sealed_by_human_id": {
+          "name": "sealed_by_human_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "correlation_seals_sealed_by_task_idx": {
+          "name": "correlation_seals_sealed_by_task_idx",
+          "columns": [
+            {
+              "expression": "sealed_by_task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "correlation_seals_sealed_by_task_id_tasks_id_fk": {
+          "name": "correlation_seals_sealed_by_task_id_tasks_id_fk",
+          "tableFrom": "correlation_seals",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "sealed_by_task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "correlation_seals_sealed_by_agent_id_agents_identity_id_fk": {
+          "name": "correlation_seals_sealed_by_agent_id_agents_identity_id_fk",
+          "tableFrom": "correlation_seals",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "sealed_by_agent_id"
+          ],
+          "columnsTo": [
+            "identity_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "correlation_seals_sealed_by_human_id_humans_id_fk": {
+          "name": "correlation_seals_sealed_by_human_id_humans_id_fk",
+          "tableFrom": "correlation_seals",
+          "tableTo": "humans",
+          "columnsFrom": [
+            "sealed_by_human_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "correlation_seals_caller_xor": {
+          "name": "correlation_seals_caller_xor",
+          "value": "(sealed_by_agent_id IS NOT NULL) <> (sealed_by_human_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.diaries": {
+      "name": "diaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_agent_id": {
+          "name": "creator_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_human_id": {
+          "name": "creator_human_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "signed": {
+          "name": "signed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "diaries_creator_agent_idx": {
+          "name": "diaries_creator_agent_idx",
+          "columns": [
+            {
+              "expression": "creator_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "creator_agent_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "diaries_creator_human_idx": {
+          "name": "diaries_creator_human_idx",
+          "columns": [
+            {
+              "expression": "creator_human_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "creator_human_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "diaries_creator_agent_visibility_idx": {
+          "name": "diaries_creator_agent_visibility_idx",
+          "columns": [
+            {
+              "expression": "creator_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "creator_agent_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "diaries_team_idx": {
+          "name": "diaries_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "diaries_creator_agent_id_agents_identity_id_fk": {
+          "name": "diaries_creator_agent_id_agents_identity_id_fk",
+          "tableFrom": "diaries",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "creator_agent_id"
+          ],
+          "columnsTo": [
+            "identity_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "diaries_creator_human_id_humans_id_fk": {
+          "name": "diaries_creator_human_id_humans_id_fk",
+          "tableFrom": "diaries",
+          "tableTo": "humans",
+          "columnsFrom": [
+            "creator_human_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "diaries_team_id_teams_id_fk": {
+          "name": "diaries_team_id_teams_id_fk",
+          "tableFrom": "diaries",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "diaries_creator_xor": {
+          "name": "diaries_creator_xor",
+          "value": "(creator_agent_id IS NOT NULL) <> (creator_human_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.diary_entries": {
+      "name": "diary_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "diary_id": {
+          "name": "diary_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(384)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_agent_id": {
+          "name": "creator_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_human_id": {
+          "name": "creator_human_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "injection_risk": {
+          "name": "injection_risk",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "injection_threats": {
+          "name": "injection_threats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "importance": {
+          "name": "importance",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "entry_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'semantic'"
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_signature": {
+          "name": "content_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signing_nonce": {
+          "name": "signing_nonce",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "diary_entries_diary_idx": {
+          "name": "diary_entries_diary_idx",
+          "columns": [
+            {
+              "expression": "diary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "diary_entries_creator_agent_idx": {
+          "name": "diary_entries_creator_agent_idx",
+          "columns": [
+            {
+              "expression": "creator_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "creator_agent_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "diary_entries_creator_human_idx": {
+          "name": "diary_entries_creator_human_idx",
+          "columns": [
+            {
+              "expression": "creator_human_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "creator_human_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "diary_entries_entry_type_idx": {
+          "name": "diary_entries_entry_type_idx",
+          "columns": [
+            {
+              "expression": "entry_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "diary_entries_content_signature_unique_idx": {
+          "name": "diary_entries_content_signature_unique_idx",
+          "columns": [
+            {
+              "expression": "content_signature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "content_signature IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "diary_entries_content_hash_idx": {
+          "name": "diary_entries_content_hash_idx",
+          "columns": [
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "content_hash IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "diary_entries_diary_id_diaries_id_fk": {
+          "name": "diary_entries_diary_id_diaries_id_fk",
+          "tableFrom": "diary_entries",
+          "tableTo": "diaries",
+          "columnsFrom": [
+            "diary_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "diary_entries_creator_agent_id_agents_identity_id_fk": {
+          "name": "diary_entries_creator_agent_id_agents_identity_id_fk",
+          "tableFrom": "diary_entries",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "creator_agent_id"
+          ],
+          "columnsTo": [
+            "identity_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "diary_entries_creator_human_id_humans_id_fk": {
+          "name": "diary_entries_creator_human_id_humans_id_fk",
+          "tableFrom": "diary_entries",
+          "tableTo": "humans",
+          "columnsFrom": [
+            "creator_human_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "diary_entries_creator_xor": {
+          "name": "diary_entries_creator_xor",
+          "value": "(creator_agent_id IS NOT NULL) <> (creator_human_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.diary_transfers": {
+      "name": "diary_transfers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "diary_id": {
+          "name": "diary_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_team_id": {
+          "name": "source_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_team_id": {
+          "name": "destination_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "diary_transfer_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "initiated_by": {
+          "name": "initiated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "diary_transfers_diary_idx": {
+          "name": "diary_transfers_diary_idx",
+          "columns": [
+            {
+              "expression": "diary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "diary_transfers_source_team_idx": {
+          "name": "diary_transfers_source_team_idx",
+          "columns": [
+            {
+              "expression": "source_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "diary_transfers_dest_team_idx": {
+          "name": "diary_transfers_dest_team_idx",
+          "columns": [
+            {
+              "expression": "destination_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "diary_transfers_workflow_idx": {
+          "name": "diary_transfers_workflow_idx",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "diary_transfers_diary_id_diaries_id_fk": {
+          "name": "diary_transfers_diary_id_diaries_id_fk",
+          "tableFrom": "diary_transfers",
+          "tableTo": "diaries",
+          "columnsFrom": [
+            "diary_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "diary_transfers_source_team_id_teams_id_fk": {
+          "name": "diary_transfers_source_team_id_teams_id_fk",
+          "tableFrom": "diary_transfers",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "source_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "diary_transfers_destination_team_id_teams_id_fk": {
+          "name": "diary_transfers_destination_team_id_teams_id_fk",
+          "tableFrom": "diary_transfers",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "destination_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entry_relations": {
+      "name": "entry_relations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relation": {
+          "name": "relation",
+          "type": "relation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "relation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'proposed'"
+        },
+        "source_cid_snapshot": {
+          "name": "source_cid_snapshot",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_cid_snapshot": {
+          "name": "target_cid_snapshot",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "entry_relations_unique_idx": {
+          "name": "entry_relations_unique_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entry_relations_source_idx": {
+          "name": "entry_relations_source_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entry_relations_target_idx": {
+          "name": "entry_relations_target_idx",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entry_relations_type_idx": {
+          "name": "entry_relations_type_idx",
+          "columns": [
+            {
+              "expression": "relation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entry_relations_status_idx": {
+          "name": "entry_relations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entry_relations_source_id_diary_entries_id_fk": {
+          "name": "entry_relations_source_id_diary_entries_id_fk",
+          "tableFrom": "entry_relations",
+          "tableTo": "diary_entries",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entry_relations_target_id_diary_entries_id_fk": {
+          "name": "entry_relations_target_id_diary_entries_id_fk",
+          "tableFrom": "entry_relations",
+          "tableTo": "diary_entries",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.executor_manifest_verifications": {
+      "name": "executor_manifest_verifications",
+      "schema": "",
+      "columns": {
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trust_level": {
+          "name": "trust_level",
+          "type": "executor_trust_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "executor_verification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "executor_manifest_verifications_trust_idx": {
+          "name": "executor_manifest_verifications_trust_idx",
+          "columns": [
+            {
+              "expression": "trust_level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "executor_manifest_verifications_fingerprint_executor_manifests_fingerprint_fk": {
+          "name": "executor_manifest_verifications_fingerprint_executor_manifests_fingerprint_fk",
+          "tableFrom": "executor_manifest_verifications",
+          "tableTo": "executor_manifests",
+          "columnsFrom": [
+            "fingerprint"
+          ],
+          "columnsTo": [
+            "fingerprint"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "executor_manifest_verifications_fingerprint_trust_level_pk": {
+          "name": "executor_manifest_verifications_fingerprint_trust_level_pk",
+          "columns": [
+            "fingerprint",
+            "trust_level"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.executor_manifests": {
+      "name": "executor_manifests",
+      "schema": "",
+      "columns": {
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "executor_manifests_schema_version_idx": {
+          "name": "executor_manifests_schema_version_idx",
+          "columns": [
+            {
+              "expression": "schema_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.founding_acceptances": {
+      "name": "founding_acceptances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_ns": {
+          "name": "subject_ns",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "founding_acceptance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "founding_acceptances_team_idx": {
+          "name": "founding_acceptances_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "founding_acceptances_team_subject_idx": {
+          "name": "founding_acceptances_team_subject_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "founding_acceptances_team_id_teams_id_fk": {
+          "name": "founding_acceptances_team_id_teams_id_fk",
+          "tableFrom": "founding_acceptances",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_agent_id": {
+          "name": "creator_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_human_id": {
+          "name": "creator_human_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "groups_team_idx": {
+          "name": "groups_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "groups_name_team_idx": {
+          "name": "groups_name_team_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "groups_creator_agent_idx": {
+          "name": "groups_creator_agent_idx",
+          "columns": [
+            {
+              "expression": "creator_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "creator_agent_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "groups_creator_human_idx": {
+          "name": "groups_creator_human_idx",
+          "columns": [
+            {
+              "expression": "creator_human_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "creator_human_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_team_id_teams_id_fk": {
+          "name": "groups_team_id_teams_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "groups_creator_agent_id_agents_identity_id_fk": {
+          "name": "groups_creator_agent_id_agents_identity_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "creator_agent_id"
+          ],
+          "columnsTo": [
+            "identity_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "groups_creator_human_id_humans_id_fk": {
+          "name": "groups_creator_human_id_humans_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "humans",
+          "columnsFrom": [
+            "creator_human_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "groups_creator_xor": {
+          "name": "groups_creator_xor",
+          "value": "(creator_agent_id IS NOT NULL) <> (creator_human_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.humans": {
+      "name": "humans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identity_id": {
+          "name": "identity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "humans_identity_id_unique": {
+          "name": "humans_identity_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "identity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rendered_packs": {
+      "name": "rendered_packs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pack_cid": {
+          "name": "pack_cid",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_pack_id": {
+          "name": "source_pack_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "diary_id": {
+          "name": "diary_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "render_method": {
+          "name": "render_method",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_agent_id": {
+          "name": "creator_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_human_id": {
+          "name": "creator_human_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "(now() + interval '7 days')"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "verified_task_id": {
+          "name": "verified_task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rendered_packs_pack_cid_unique_idx": {
+          "name": "rendered_packs_pack_cid_unique_idx",
+          "columns": [
+            {
+              "expression": "pack_cid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rendered_packs_source_pack_idx": {
+          "name": "rendered_packs_source_pack_idx",
+          "columns": [
+            {
+              "expression": "source_pack_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rendered_packs_diary_idx": {
+          "name": "rendered_packs_diary_idx",
+          "columns": [
+            {
+              "expression": "diary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rendered_packs_expires_at_idx": {
+          "name": "rendered_packs_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "pinned = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rendered_packs_verified_task_idx": {
+          "name": "rendered_packs_verified_task_idx",
+          "columns": [
+            {
+              "expression": "verified_task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "verified_task_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rendered_packs_creator_agent_idx": {
+          "name": "rendered_packs_creator_agent_idx",
+          "columns": [
+            {
+              "expression": "creator_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "creator_agent_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rendered_packs_creator_human_idx": {
+          "name": "rendered_packs_creator_human_idx",
+          "columns": [
+            {
+              "expression": "creator_human_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "creator_human_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rendered_packs_source_pack_id_context_packs_id_fk": {
+          "name": "rendered_packs_source_pack_id_context_packs_id_fk",
+          "tableFrom": "rendered_packs",
+          "tableTo": "context_packs",
+          "columnsFrom": [
+            "source_pack_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rendered_packs_diary_id_diaries_id_fk": {
+          "name": "rendered_packs_diary_id_diaries_id_fk",
+          "tableFrom": "rendered_packs",
+          "tableTo": "diaries",
+          "columnsFrom": [
+            "diary_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rendered_packs_creator_agent_id_agents_identity_id_fk": {
+          "name": "rendered_packs_creator_agent_id_agents_identity_id_fk",
+          "tableFrom": "rendered_packs",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "creator_agent_id"
+          ],
+          "columnsTo": [
+            "identity_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "rendered_packs_creator_human_id_humans_id_fk": {
+          "name": "rendered_packs_creator_human_id_humans_id_fk",
+          "tableFrom": "rendered_packs",
+          "tableTo": "humans",
+          "columnsFrom": [
+            "creator_human_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "rendered_packs_verified_task_id_tasks_id_fk": {
+          "name": "rendered_packs_verified_task_id_tasks_id_fk",
+          "tableFrom": "rendered_packs",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "verified_task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "rendered_packs_creator_xor": {
+          "name": "rendered_packs_creator_xor",
+          "value": "(creator_agent_id IS NOT NULL) <> (creator_human_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.runtime_models": {
+      "name": "runtime_models",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_human_id": {
+          "name": "created_by_human_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runtime_models_global_uq": {
+          "name": "runtime_models_global_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "team_id IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runtime_models_team_uq": {
+          "name": "runtime_models_team_uq",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "team_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runtime_models_team_idx": {
+          "name": "runtime_models_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runtime_models_provider_idx": {
+          "name": "runtime_models_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runtime_models_team_id_teams_id_fk": {
+          "name": "runtime_models_team_id_teams_id_fk",
+          "tableFrom": "runtime_models",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "runtime_models_created_by_agent_id_agents_identity_id_fk": {
+          "name": "runtime_models_created_by_agent_id_agents_identity_id_fk",
+          "tableFrom": "runtime_models",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "created_by_agent_id"
+          ],
+          "columnsTo": [
+            "identity_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "runtime_models_created_by_human_id_humans_id_fk": {
+          "name": "runtime_models_created_by_human_id_humans_id_fk",
+          "tableFrom": "runtime_models",
+          "tableTo": "humans",
+          "columnsFrom": [
+            "created_by_human_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runtime_models_creator_xor": {
+          "name": "runtime_models_creator_xor",
+          "value": "(team_id IS NULL AND created_by_agent_id IS NULL AND created_by_human_id IS NULL) OR (team_id IS NOT NULL AND ((created_by_agent_id IS NOT NULL) <> (created_by_human_id IS NOT NULL)))"
+        },
+        "runtime_models_description_length": {
+          "name": "runtime_models_description_length",
+          "value": "description IS NULL OR length(description) <= 4096"
+        },
+        "runtime_models_capabilities_shape": {
+          "name": "runtime_models_capabilities_shape",
+          "value": "capabilities IS NULL OR jsonb_typeof(capabilities) = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.runtime_profiles": {
+      "name": "runtime_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thinking_level": {
+          "name": "thinking_level",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_p": {
+          "name": "top_p",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_k": {
+          "name": "top_k",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_kind": {
+          "name": "runtime_kind",
+          "type": "runtime_profile_runtime_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gondolin_pi'"
+        },
+        "sandbox": {
+          "name": "sandbox",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_storage_mode": {
+          "name": "session_storage_mode",
+          "type": "runtime_profile_storage_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "workspace_storage_mode": {
+          "name": "workspace_storage_mode",
+          "type": "runtime_profile_storage_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "default_workspace_mode": {
+          "name": "default_workspace_mode",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_workspace_modes": {
+          "name": "allowed_workspace_modes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['none','shared_mount','dedicated_worktree']::text[]"
+        },
+        "session_ttl_sec": {
+          "name": "session_ttl_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1800
+        },
+        "workspace_ttl_sec": {
+          "name": "workspace_ttl_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1800
+        },
+        "lease_ttl_sec": {
+          "name": "lease_ttl_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300
+        },
+        "heartbeat_interval_ms": {
+          "name": "heartbeat_interval_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60000
+        },
+        "max_batch_size": {
+          "name": "max_batch_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "max_turns": {
+          "name": "max_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_bash_timeouts": {
+          "name": "max_bash_timeouts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "required_env": {
+          "name": "required_env",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "required_tools": {
+          "name": "required_tools",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "definition_cid": {
+          "name": "definition_cid",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_human_id": {
+          "name": "created_by_human_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runtime_profiles_team_name_idx": {
+          "name": "runtime_profiles_team_name_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runtime_profiles_team_idx": {
+          "name": "runtime_profiles_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runtime_profiles_team_id_teams_id_fk": {
+          "name": "runtime_profiles_team_id_teams_id_fk",
+          "tableFrom": "runtime_profiles",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "runtime_profiles_created_by_agent_id_agents_identity_id_fk": {
+          "name": "runtime_profiles_created_by_agent_id_agents_identity_id_fk",
+          "tableFrom": "runtime_profiles",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "created_by_agent_id"
+          ],
+          "columnsTo": [
+            "identity_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "runtime_profiles_created_by_human_id_humans_id_fk": {
+          "name": "runtime_profiles_created_by_human_id_humans_id_fk",
+          "tableFrom": "runtime_profiles",
+          "tableTo": "humans",
+          "columnsFrom": [
+            "created_by_human_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runtime_profiles_creator_xor": {
+          "name": "runtime_profiles_creator_xor",
+          "value": "(created_by_agent_id IS NOT NULL) <> (created_by_human_id IS NOT NULL)"
+        },
+        "runtime_profiles_session_ttl_positive": {
+          "name": "runtime_profiles_session_ttl_positive",
+          "value": "session_ttl_sec > 0"
+        },
+        "runtime_profiles_workspace_ttl_positive": {
+          "name": "runtime_profiles_workspace_ttl_positive",
+          "value": "workspace_ttl_sec > 0"
+        },
+        "runtime_profiles_lease_ttl_positive": {
+          "name": "runtime_profiles_lease_ttl_positive",
+          "value": "lease_ttl_sec > 0"
+        },
+        "runtime_profiles_heartbeat_interval_non_negative": {
+          "name": "runtime_profiles_heartbeat_interval_non_negative",
+          "value": "heartbeat_interval_ms >= 0"
+        },
+        "runtime_profiles_max_batch_size_positive": {
+          "name": "runtime_profiles_max_batch_size_positive",
+          "value": "max_batch_size > 0"
+        },
+        "runtime_profiles_max_turns_non_negative": {
+          "name": "runtime_profiles_max_turns_non_negative",
+          "value": "max_turns >= 0"
+        },
+        "runtime_profiles_max_bash_timeouts_non_negative": {
+          "name": "runtime_profiles_max_bash_timeouts_non_negative",
+          "value": "max_bash_timeouts >= 0"
+        },
+        "runtime_profiles_thinking_level_valid": {
+          "name": "runtime_profiles_thinking_level_valid",
+          "value": "thinking_level IS NULL OR thinking_level = ANY(ARRAY['off','minimal','low','medium','high','xhigh']::text[])"
+        },
+        "runtime_profiles_temperature_range": {
+          "name": "runtime_profiles_temperature_range",
+          "value": "temperature IS NULL OR (temperature >= 0 AND temperature <= 2)"
+        },
+        "runtime_profiles_top_p_range": {
+          "name": "runtime_profiles_top_p_range",
+          "value": "top_p IS NULL OR (top_p >= 0 AND top_p <= 1)"
+        },
+        "runtime_profiles_top_k_positive": {
+          "name": "runtime_profiles_top_k_positive",
+          "value": "top_k IS NULL OR top_k > 0"
+        },
+        "runtime_profiles_max_output_tokens_positive": {
+          "name": "runtime_profiles_max_output_tokens_positive",
+          "value": "max_output_tokens IS NULL OR max_output_tokens > 0"
+        },
+        "runtime_profiles_default_workspace_mode_valid": {
+          "name": "runtime_profiles_default_workspace_mode_valid",
+          "value": "default_workspace_mode IS NULL OR default_workspace_mode = ANY(ARRAY['none','shared_mount','dedicated_worktree']::text[])"
+        },
+        "runtime_profiles_allowed_workspace_modes_nonempty": {
+          "name": "runtime_profiles_allowed_workspace_modes_nonempty",
+          "value": "cardinality(allowed_workspace_modes) BETWEEN 1 AND 3"
+        },
+        "runtime_profiles_allowed_workspace_modes_valid": {
+          "name": "runtime_profiles_allowed_workspace_modes_valid",
+          "value": "allowed_workspace_modes <@ ARRAY['none','shared_mount','dedicated_worktree']::text[]"
+        },
+        "runtime_profiles_default_workspace_mode_allowed": {
+          "name": "runtime_profiles_default_workspace_mode_allowed",
+          "value": "default_workspace_mode IS NULL OR default_workspace_mode = ANY(allowed_workspace_modes)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.runtime_sessions": {
+      "name": "runtime_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_n": {
+          "name": "attempt_n",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_slot_id": {
+          "name": "source_slot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_runtime_profile_id": {
+          "name": "source_runtime_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_kind": {
+          "name": "session_kind",
+          "type": "runtime_session_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_encoding": {
+          "name": "content_encoding",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_class": {
+          "name": "storage_class",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checkpoint_kind": {
+          "name": "checkpoint_kind",
+          "type": "runtime_session_checkpoint_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'attempt_final'"
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runtime_sessions_active_attempt_idx": {
+          "name": "runtime_sessions_active_attempt_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_n",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runtime_sessions_object_key_idx": {
+          "name": "runtime_sessions_object_key_idx",
+          "columns": [
+            {
+              "expression": "object_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runtime_sessions_team_idx": {
+          "name": "runtime_sessions_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runtime_sessions_task_attempt_idx": {
+          "name": "runtime_sessions_task_attempt_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_n",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runtime_sessions_parent_idx": {
+          "name": "runtime_sessions_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "parent_session_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runtime_sessions_source_slot_idx": {
+          "name": "runtime_sessions_source_slot_idx",
+          "columns": [
+            {
+              "expression": "source_slot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "source_slot_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runtime_sessions_team_id_teams_id_fk": {
+          "name": "runtime_sessions_team_id_teams_id_fk",
+          "tableFrom": "runtime_sessions",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "runtime_sessions_task_id_tasks_id_fk": {
+          "name": "runtime_sessions_task_id_tasks_id_fk",
+          "tableFrom": "runtime_sessions",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "runtime_sessions_source_slot_id_runtime_slots_id_fk": {
+          "name": "runtime_sessions_source_slot_id_runtime_slots_id_fk",
+          "tableFrom": "runtime_sessions",
+          "tableTo": "runtime_slots",
+          "columnsFrom": [
+            "source_slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "runtime_sessions_source_runtime_profile_id_runtime_profiles_id_fk": {
+          "name": "runtime_sessions_source_runtime_profile_id_runtime_profiles_id_fk",
+          "tableFrom": "runtime_sessions",
+          "tableTo": "runtime_profiles",
+          "columnsFrom": [
+            "source_runtime_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "runtime_sessions_parent_session_id_runtime_sessions_id_fk": {
+          "name": "runtime_sessions_parent_session_id_runtime_sessions_id_fk",
+          "tableFrom": "runtime_sessions",
+          "tableTo": "runtime_sessions",
+          "columnsFrom": [
+            "parent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "runtime_sessions_task_id_attempt_n_task_attempts_task_id_attempt_n_fk": {
+          "name": "runtime_sessions_task_id_attempt_n_task_attempts_task_id_attempt_n_fk",
+          "tableFrom": "runtime_sessions",
+          "tableTo": "task_attempts",
+          "columnsFrom": [
+            "task_id",
+            "attempt_n"
+          ],
+          "columnsTo": [
+            "task_id",
+            "attempt_n"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runtime_sessions_size_bytes_non_negative": {
+          "name": "runtime_sessions_size_bytes_non_negative",
+          "value": "size_bytes >= 0"
+        },
+        "runtime_sessions_sha256_hex": {
+          "name": "runtime_sessions_sha256_hex",
+          "value": "sha256 ~ '^[0-9a-f]{64}$'"
+        },
+        "runtime_sessions_parent_not_self": {
+          "name": "runtime_sessions_parent_not_self",
+          "value": "parent_session_id IS NULL OR parent_session_id <> id"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.runtime_slots": {
+      "name": "runtime_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_profile_id": {
+          "name": "runtime_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_key": {
+          "name": "slot_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "runtime_slot_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_task_id": {
+          "name": "last_task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_attempt_n": {
+          "name": "last_attempt_n",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_dir": {
+          "name": "session_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_path": {
+          "name": "session_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_row_id": {
+          "name": "workspace_row_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at_ms": {
+          "name": "created_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at_ms": {
+          "name": "last_used_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at_ms": {
+          "name": "expires_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runtime_slots_identity_idx": {
+          "name": "runtime_slots_identity_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "runtime_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slot_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runtime_slots_team_idx": {
+          "name": "runtime_slots_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runtime_slots_profile_idx": {
+          "name": "runtime_slots_profile_idx",
+          "columns": [
+            {
+              "expression": "runtime_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "runtime_profile_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runtime_slots_task_attempt_idx": {
+          "name": "runtime_slots_task_attempt_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_attempt_n",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_used_at_ms",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runtime_slots_session_path_idx": {
+          "name": "runtime_slots_session_path_idx",
+          "columns": [
+            {
+              "expression": "session_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "session_path IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runtime_slots_team_id_teams_id_fk": {
+          "name": "runtime_slots_team_id_teams_id_fk",
+          "tableFrom": "runtime_slots",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "runtime_slots_runtime_profile_id_runtime_profiles_id_fk": {
+          "name": "runtime_slots_runtime_profile_id_runtime_profiles_id_fk",
+          "tableFrom": "runtime_slots",
+          "tableTo": "runtime_profiles",
+          "columnsFrom": [
+            "runtime_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "runtime_slots_last_task_id_tasks_id_fk": {
+          "name": "runtime_slots_last_task_id_tasks_id_fk",
+          "tableFrom": "runtime_slots",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "last_task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "runtime_slots_workspace_row_id_runtime_workspaces_id_fk": {
+          "name": "runtime_slots_workspace_row_id_runtime_workspaces_id_fk",
+          "tableFrom": "runtime_slots",
+          "tableTo": "runtime_workspaces",
+          "columnsFrom": [
+            "workspace_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "runtime_slots_last_task_id_last_attempt_n_task_attempts_task_id_attempt_n_fk": {
+          "name": "runtime_slots_last_task_id_last_attempt_n_task_attempts_task_id_attempt_n_fk",
+          "tableFrom": "runtime_slots",
+          "tableTo": "task_attempts",
+          "columnsFrom": [
+            "last_task_id",
+            "last_attempt_n"
+          ],
+          "columnsTo": [
+            "task_id",
+            "attempt_n"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runtime_workspaces": {
+      "name": "runtime_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worktree_branch": {
+          "name": "worktree_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "runtime_workspace_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_ms": {
+          "name": "created_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at_ms": {
+          "name": "last_used_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runtime_workspaces_team_workspace_idx": {
+          "name": "runtime_workspaces_team_workspace_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runtime_workspaces_team_idx": {
+          "name": "runtime_workspaces_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runtime_workspaces_branch_idx": {
+          "name": "runtime_workspaces_branch_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "worktree_branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "worktree_branch IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runtime_workspaces_team_id_teams_id_fk": {
+          "name": "runtime_workspaces_team_id_teams_id_fk",
+          "tableFrom": "runtime_workspaces",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signing_requests": {
+      "name": "signing_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_method": {
+          "name": "verification_method",
+          "type": "verification_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'agent-ed25519'"
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signer_constraint": {
+          "name": "signer_constraint",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "status": {
+          "name": "status",
+          "type": "signing_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid": {
+          "name": "valid",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "signing_requests_agent_status_idx": {
+          "name": "signing_requests_agent_status_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "signing_requests_signature_idx": {
+          "name": "signing_requests_signature_idx",
+          "columns": [
+            {
+              "expression": "signature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "signing_requests_workflow_idx": {
+          "name": "signing_requests_workflow_idx",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_artifacts": {
+      "name": "task_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_n": {
+          "name": "attempt_n",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_encoding": {
+          "name": "content_encoding",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_artifacts_attempt_cid_idx": {
+          "name": "task_artifacts_attempt_cid_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_n",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_artifacts_input_cid_idx": {
+          "name": "task_artifacts_input_cid_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "attempt_n IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_artifacts_team_cid_idx": {
+          "name": "task_artifacts_team_cid_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_artifacts_object_key_idx": {
+          "name": "task_artifacts_object_key_idx",
+          "columns": [
+            {
+              "expression": "object_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_artifacts_task_attempt_idx": {
+          "name": "task_artifacts_task_attempt_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_n",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_artifacts_task_list_idx": {
+          "name": "task_artifacts_task_list_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_n",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_artifacts_expires_idx": {
+          "name": "task_artifacts_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "expires_at IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_artifacts_team_id_teams_id_fk": {
+          "name": "task_artifacts_team_id_teams_id_fk",
+          "tableFrom": "task_artifacts",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "task_artifacts_task_id_tasks_id_fk": {
+          "name": "task_artifacts_task_id_tasks_id_fk",
+          "tableFrom": "task_artifacts",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_artifacts_created_by_agent_id_agents_identity_id_fk": {
+          "name": "task_artifacts_created_by_agent_id_agents_identity_id_fk",
+          "tableFrom": "task_artifacts",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "created_by_agent_id"
+          ],
+          "columnsTo": [
+            "identity_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "task_artifacts_task_id_attempt_n_task_attempts_task_id_attempt_n_fk": {
+          "name": "task_artifacts_task_id_attempt_n_task_attempts_task_id_attempt_n_fk",
+          "tableFrom": "task_artifacts",
+          "tableTo": "task_attempts",
+          "columnsFrom": [
+            "task_id",
+            "attempt_n"
+          ],
+          "columnsTo": [
+            "task_id",
+            "attempt_n"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "task_artifacts_size_bytes_non_negative": {
+          "name": "task_artifacts_size_bytes_non_negative",
+          "value": "size_bytes >= 0"
+        },
+        "task_artifacts_sha256_hex": {
+          "name": "task_artifacts_sha256_hex",
+          "value": "sha256 ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.task_attempt_activity_stats": {
+      "name": "task_attempt_activity_stats",
+      "schema": "",
+      "columns": {
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_n": {
+          "name": "attempt_n",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source_last_seq": {
+          "name": "source_last_seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": -1
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "turn_count": {
+          "name": "turn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tool_call_count": {
+          "name": "tool_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_tool_call_count": {
+          "name": "failed_tool_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "knowledge_tool_call_count": {
+          "name": "knowledge_tool_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "entry_search_count": {
+          "name": "entry_search_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "entry_get_count": {
+          "name": "entry_get_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pack_get_count": {
+          "name": "pack_get_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "task_attempt_activity_stats_task_idx": {
+          "name": "task_attempt_activity_stats_task_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_attempt_activity_stats_task_id_attempt_n_task_attempts_task_id_attempt_n_fk": {
+          "name": "task_attempt_activity_stats_task_id_attempt_n_task_attempts_task_id_attempt_n_fk",
+          "tableFrom": "task_attempt_activity_stats",
+          "tableTo": "task_attempts",
+          "columnsFrom": [
+            "task_id",
+            "attempt_n"
+          ],
+          "columnsTo": [
+            "task_id",
+            "attempt_n"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "task_attempt_activity_stats_task_id_attempt_n_pk": {
+          "name": "task_attempt_activity_stats_task_id_attempt_n_pk",
+          "columns": [
+            "task_id",
+            "attempt_n"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_attempts": {
+      "name": "task_attempts",
+      "schema": "",
+      "columns": {
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_n": {
+          "name": "attempt_n",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_by_agent_id": {
+          "name": "claimed_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_id": {
+          "name": "runtime_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "task_attempt_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claimed'"
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_cid": {
+          "name": "output_cid",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_executor_fingerprint": {
+          "name": "claimed_executor_fingerprint",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_executor_fingerprint": {
+          "name": "completed_executor_fingerprint",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_signature": {
+          "name": "content_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daemon_state": {
+          "name": "daemon_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "task_attempts_task_idx": {
+          "name": "task_attempts_task_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_attempts_claimed_executor_idx": {
+          "name": "task_attempts_claimed_executor_idx",
+          "columns": [
+            {
+              "expression": "claimed_executor_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "claimed_executor_fingerprint IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_attempts_completed_executor_idx": {
+          "name": "task_attempts_completed_executor_idx",
+          "columns": [
+            {
+              "expression": "completed_executor_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "completed_executor_fingerprint IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_attempts_workflow_idx": {
+          "name": "task_attempts_workflow_idx",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_attempts_task_id_tasks_id_fk": {
+          "name": "task_attempts_task_id_tasks_id_fk",
+          "tableFrom": "task_attempts",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_attempts_claimed_by_agent_id_agents_identity_id_fk": {
+          "name": "task_attempts_claimed_by_agent_id_agents_identity_id_fk",
+          "tableFrom": "task_attempts",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "claimed_by_agent_id"
+          ],
+          "columnsTo": [
+            "identity_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "task_attempts_claimed_executor_fingerprint_executor_manifests_fingerprint_fk": {
+          "name": "task_attempts_claimed_executor_fingerprint_executor_manifests_fingerprint_fk",
+          "tableFrom": "task_attempts",
+          "tableTo": "executor_manifests",
+          "columnsFrom": [
+            "claimed_executor_fingerprint"
+          ],
+          "columnsTo": [
+            "fingerprint"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "task_attempts_completed_executor_fingerprint_executor_manifests_fingerprint_fk": {
+          "name": "task_attempts_completed_executor_fingerprint_executor_manifests_fingerprint_fk",
+          "tableFrom": "task_attempts",
+          "tableTo": "executor_manifests",
+          "columnsFrom": [
+            "completed_executor_fingerprint"
+          ],
+          "columnsTo": [
+            "fingerprint"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "task_attempts_task_id_attempt_n_pk": {
+          "name": "task_attempts_task_id_attempt_n_pk",
+          "columns": [
+            "task_id",
+            "attempt_n"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_messages": {
+      "name": "task_messages",
+      "schema": "",
+      "columns": {
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_n": {
+          "name": "attempt_n",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "task_message_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "task_messages_task_attempt_idx": {
+          "name": "task_messages_task_attempt_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_n",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_messages_task_id_tasks_id_fk": {
+          "name": "task_messages_task_id_tasks_id_fk",
+          "tableFrom": "task_messages",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "task_messages_task_id_attempt_n_seq_pk": {
+          "name": "task_messages_task_id_attempt_n_seq_pk",
+          "columns": [
+            "task_id",
+            "attempt_n",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "diary_id": {
+          "name": "diary_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_kind": {
+          "name": "output_kind",
+          "type": "output_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_schema_cid": {
+          "name": "input_schema_cid",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_cid": {
+          "name": "input_cid",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_refs": {
+          "name": "task_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_by_agent_id": {
+          "name": "proposed_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_by_human_id": {
+          "name": "proposed_by_human_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_attempt_n": {
+          "name": "accepted_attempt_n",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_condition": {
+          "name": "claim_condition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_agent_id": {
+          "name": "claim_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_expires_at": {
+          "name": "claim_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "required_executor_trust_level": {
+          "name": "required_executor_trust_level",
+          "type": "executor_trust_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'self_declared'"
+        },
+        "allowed_profiles": {
+          "name": "allowed_profiles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_by_agent_id": {
+          "name": "cancelled_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_by_human_id": {
+          "name": "cancelled_by_human_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_reason": {
+          "name": "cancel_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "dispatch_timeout_sec": {
+          "name": "dispatch_timeout_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "running_timeout_sec": {
+          "name": "running_timeout_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tasks_team_status_idx": {
+          "name": "tasks_team_status_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_type_status_idx": {
+          "name": "tasks_type_status_idx",
+          "columns": [
+            {
+              "expression": "task_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_tags_gin_idx": {
+          "name": "tasks_tags_gin_idx",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "tasks_diary_idx": {
+          "name": "tasks_diary_idx",
+          "columns": [
+            {
+              "expression": "diary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "diary_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_correlation_idx": {
+          "name": "tasks_correlation_idx",
+          "columns": [
+            {
+              "expression": "correlation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "correlation_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_claim_expires_idx": {
+          "name": "tasks_claim_expires_idx",
+          "columns": [
+            {
+              "expression": "claim_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "claim_expires_at IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_non_terminal_expires_idx": {
+          "name": "tasks_non_terminal_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "expires_at IS NOT NULL AND status NOT IN ('dispatched', 'running', 'completed', 'failed', 'cancelled', 'expired')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_terminal_retention_idx": {
+          "name": "tasks_terminal_retention_idx",
+          "columns": [
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "completed_at IS NOT NULL AND status IN ('completed', 'failed', 'cancelled', 'expired')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_allowed_profiles_gin_idx": {
+          "name": "tasks_allowed_profiles_gin_idx",
+          "columns": [
+            {
+              "expression": "\"allowed_profiles\" jsonb_path_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_team_id_teams_id_fk": {
+          "name": "tasks_team_id_teams_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "tasks_diary_id_diaries_id_fk": {
+          "name": "tasks_diary_id_diaries_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "diaries",
+          "columnsFrom": [
+            "diary_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "tasks_proposed_by_agent_id_agents_identity_id_fk": {
+          "name": "tasks_proposed_by_agent_id_agents_identity_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "proposed_by_agent_id"
+          ],
+          "columnsTo": [
+            "identity_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "tasks_proposed_by_human_id_humans_id_fk": {
+          "name": "tasks_proposed_by_human_id_humans_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "humans",
+          "columnsFrom": [
+            "proposed_by_human_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "tasks_claim_agent_id_agents_identity_id_fk": {
+          "name": "tasks_claim_agent_id_agents_identity_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "claim_agent_id"
+          ],
+          "columnsTo": [
+            "identity_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "tasks_cancelled_by_agent_id_agents_identity_id_fk": {
+          "name": "tasks_cancelled_by_agent_id_agents_identity_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "cancelled_by_agent_id"
+          ],
+          "columnsTo": [
+            "identity_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "tasks_cancelled_by_human_id_humans_id_fk": {
+          "name": "tasks_cancelled_by_human_id_humans_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "humans",
+          "columnsFrom": [
+            "cancelled_by_human_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tasks_proposer_xor": {
+          "name": "tasks_proposer_xor",
+          "value": "(proposed_by_agent_id IS NOT NULL) <> (proposed_by_human_id IS NOT NULL)"
+        },
+        "tasks_canceller_xor": {
+          "name": "tasks_canceller_xor",
+          "value": "status <> 'cancelled' OR (cancelled_by_agent_id IS NOT NULL) <> (cancelled_by_human_id IS NOT NULL)"
+        },
+        "tasks_cancel_reason_required": {
+          "name": "tasks_cancel_reason_required",
+          "value": "status <> 'cancelled' OR cancel_reason IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.team_invites": {
+      "name": "team_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "team_invite_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "creator_agent_id": {
+          "name": "creator_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_human_id": {
+          "name": "creator_human_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_invites_code_idx": {
+          "name": "team_invites_code_idx",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_invites_team_idx": {
+          "name": "team_invites_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_invites_creator_agent_idx": {
+          "name": "team_invites_creator_agent_idx",
+          "columns": [
+            {
+              "expression": "creator_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "creator_agent_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_invites_creator_human_idx": {
+          "name": "team_invites_creator_human_idx",
+          "columns": [
+            {
+              "expression": "creator_human_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "creator_human_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_invites_team_id_teams_id_fk": {
+          "name": "team_invites_team_id_teams_id_fk",
+          "tableFrom": "team_invites",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_invites_creator_agent_id_agents_identity_id_fk": {
+          "name": "team_invites_creator_agent_id_agents_identity_id_fk",
+          "tableFrom": "team_invites",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "creator_agent_id"
+          ],
+          "columnsTo": [
+            "identity_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "team_invites_creator_human_id_humans_id_fk": {
+          "name": "team_invites_creator_human_id_humans_id_fk",
+          "tableFrom": "team_invites",
+          "tableTo": "humans",
+          "columnsFrom": [
+            "creator_human_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "team_invites_creator_xor": {
+          "name": "team_invites_creator_xor",
+          "value": "(creator_agent_id IS NOT NULL) <> (creator_human_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "team_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "personal": {
+          "name": "personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "creator_agent_id": {
+          "name": "creator_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_human_id": {
+          "name": "creator_human_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "teams_creator_agent_idx": {
+          "name": "teams_creator_agent_idx",
+          "columns": [
+            {
+              "expression": "creator_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "creator_agent_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "teams_creator_human_idx": {
+          "name": "teams_creator_human_idx",
+          "columns": [
+            {
+              "expression": "creator_human_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "creator_human_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "teams_creator_agent_id_agents_identity_id_fk": {
+          "name": "teams_creator_agent_id_agents_identity_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "creator_agent_id"
+          ],
+          "columnsTo": [
+            "identity_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "teams_creator_human_id_humans_id_fk": {
+          "name": "teams_creator_human_id_humans_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "humans",
+          "columnsFrom": [
+            "creator_human_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "teams_creator_xor": {
+          "name": "teams_creator_xor",
+          "value": "(creator_agent_id IS NOT NULL) <> (creator_human_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.used_recovery_nonces": {
+      "name": "used_recovery_nonces",
+      "schema": "",
+      "columns": {
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "used_recovery_nonces_expires_at_idx": {
+          "name": "used_recovery_nonces_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.compression_level": {
+      "name": "compression_level",
+      "schema": "public",
+      "values": [
+        "full",
+        "summary",
+        "keywords"
+      ]
+    },
+    "public.diary_transfer_status": {
+      "name": "diary_transfer_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "rejected",
+        "expired"
+      ]
+    },
+    "public.entry_type": {
+      "name": "entry_type",
+      "schema": "public",
+      "values": [
+        "episodic",
+        "semantic",
+        "procedural",
+        "reflection"
+      ]
+    },
+    "public.executor_trust_level": {
+      "name": "executor_trust_level",
+      "schema": "public",
+      "values": [
+        "self_declared",
+        "agent_signed",
+        "release_verified_tool",
+        "sandbox_attested"
+      ]
+    },
+    "public.executor_verification_status": {
+      "name": "executor_verification_status",
+      "schema": "public",
+      "values": [
+        "verified",
+        "failed"
+      ]
+    },
+    "public.founding_acceptance_status": {
+      "name": "founding_acceptance_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted"
+      ]
+    },
+    "public.output_kind": {
+      "name": "output_kind",
+      "schema": "public",
+      "values": [
+        "artifact",
+        "judgment"
+      ]
+    },
+    "public.pack_type": {
+      "name": "pack_type",
+      "schema": "public",
+      "values": [
+        "optimized",
+        "custom"
+      ]
+    },
+    "public.relation_status": {
+      "name": "relation_status",
+      "schema": "public",
+      "values": [
+        "proposed",
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.relation_type": {
+      "name": "relation_type",
+      "schema": "public",
+      "values": [
+        "supersedes",
+        "elaborates",
+        "contradicts",
+        "supports",
+        "caused_by",
+        "references"
+      ]
+    },
+    "public.runtime_profile_runtime_kind": {
+      "name": "runtime_profile_runtime_kind",
+      "schema": "public",
+      "values": [
+        "gondolin_pi"
+      ]
+    },
+    "public.runtime_profile_storage_mode": {
+      "name": "runtime_profile_storage_mode",
+      "schema": "public",
+      "values": [
+        "local"
+      ]
+    },
+    "public.runtime_session_checkpoint_kind": {
+      "name": "runtime_session_checkpoint_kind",
+      "schema": "public",
+      "values": [
+        "attempt_final"
+      ]
+    },
+    "public.runtime_session_kind": {
+      "name": "runtime_session_kind",
+      "schema": "public",
+      "values": [
+        "root",
+        "extend",
+        "fork"
+      ]
+    },
+    "public.runtime_slot_state": {
+      "name": "runtime_slot_state",
+      "schema": "public",
+      "values": [
+        "active",
+        "idle"
+      ]
+    },
+    "public.runtime_workspace_kind": {
+      "name": "runtime_workspace_kind",
+      "schema": "public",
+      "values": [
+        "origin",
+        "fork",
+        "scratch"
+      ]
+    },
+    "public.signing_request_status": {
+      "name": "signing_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "expired"
+      ]
+    },
+    "public.task_attempt_status": {
+      "name": "task_attempt_status",
+      "schema": "public",
+      "values": [
+        "claimed",
+        "running",
+        "completed",
+        "failed",
+        "cancelled",
+        "aborted",
+        "timed_out"
+      ]
+    },
+    "public.task_message_kind": {
+      "name": "task_message_kind",
+      "schema": "public",
+      "values": [
+        "text_delta",
+        "tool_call_start",
+        "tool_call_end",
+        "turn_end",
+        "error",
+        "info"
+      ]
+    },
+    "public.task_status": {
+      "name": "task_status",
+      "schema": "public",
+      "values": [
+        "waiting",
+        "queued",
+        "dispatched",
+        "running",
+        "completed",
+        "failed",
+        "cancelled",
+        "expired"
+      ]
+    },
+    "public.team_invite_role": {
+      "name": "team_invite_role",
+      "schema": "public",
+      "values": [
+        "manager",
+        "member"
+      ]
+    },
+    "public.team_status": {
+      "name": "team_status",
+      "schema": "public",
+      "values": [
+        "founding",
+        "active",
+        "archived"
+      ]
+    },
+    "public.verification_method": {
+      "name": "verification_method",
+      "schema": "public",
+      "values": [
+        "agent-ed25519",
+        "human-hardware-previewsign"
+      ]
+    },
+    "public.visibility": {
+      "name": "visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "moltnet",
+        "public"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/database/drizzle/meta/_journal.json
+++ b/libs/database/drizzle/meta/_journal.json
@@ -224,6 +224,13 @@
       "when": 1784119463966,
       "tag": "0031_aberrant_reaper",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1784898370065,
+      "tag": "0032_yellow_deadpool",
+      "breakpoints": true
     }
   ],
   "version": "7"

--- a/libs/database/package.json
+++ b/libs/database/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@dbos-inc/dbos-sdk": "catalog:",
     "@dbos-inc/drizzle-datasource": "catalog:",
+    "@moltnet/models": "workspace:*",
     "drizzle-orm": "catalog:",
     "pg": "catalog:"
   },

--- a/libs/database/src/repositories/signing-request.repository.ts
+++ b/libs/database/src/repositories/signing-request.repository.ts
@@ -26,6 +26,7 @@ export function createSigningRequestRepository(db: Database) {
     async create(
       input: Pick<NewSigningRequest, 'agentId' | 'message'> & {
         expiresAt: Date;
+        verificationMethod?: NewSigningRequest['verificationMethod'];
         workflowId?: string;
       },
     ): Promise<SigningRequest> {
@@ -35,6 +36,7 @@ export function createSigningRequestRepository(db: Database) {
           agentId: input.agentId,
           message: input.message,
           expiresAt: input.expiresAt,
+          verificationMethod: input.verificationMethod ?? 'agent-ed25519',
           workflowId: input.workflowId,
         })
         .returning();

--- a/libs/database/src/schema.ts
+++ b/libs/database/src/schema.ts
@@ -452,6 +452,21 @@ export const signingRequestStatusEnum = pgEnum('signing_request_status', [
   'expired',
 ]);
 
+export const verificationMethodEnum = pgEnum('verification_method', [
+  'agent-ed25519',
+  'human-hardware-previewsign',
+]);
+
+export interface SigningRequestRequester {
+  id: string;
+  type: 'agent' | 'human' | 'service';
+}
+
+export interface SigningRequestSignerConstraint {
+  id?: string;
+  type: 'human' | 'team-role' | 'group' | 'site' | 'station';
+}
+
 /**
  * Signing Requests Table
  *
@@ -466,6 +481,16 @@ export const signingRequests = pgTable(
 
     // The agent who must sign (Ory Kratos identity ID)
     agentId: uuid('agent_id').notNull(),
+
+    // Explicit verification dispatch; agent Ed25519 remains the default.
+    verificationMethod: verificationMethodEnum('verification_method')
+      .default('agent-ed25519')
+      .notNull(),
+
+    // Reserved for delegated signing phases (requester may differ from signer).
+    requestedBy: jsonb('requested_by').$type<SigningRequestRequester>(),
+    signerConstraint:
+      jsonb('signer_constraint').$type<SigningRequestSignerConstraint>(),
 
     // The message to be signed
     message: text('message').notNull(),

--- a/libs/database/src/schema.ts
+++ b/libs/database/src/schema.ts
@@ -5,6 +5,10 @@
  * Database: PostgreSQL + pgvector
  */
 
+import {
+  VERIFICATION_METHOD,
+  VERIFICATION_METHOD_VALUES,
+} from '@moltnet/models/verification-method';
 import { sql } from 'drizzle-orm';
 import {
   type AnyPgColumn,
@@ -452,10 +456,10 @@ export const signingRequestStatusEnum = pgEnum('signing_request_status', [
   'expired',
 ]);
 
-export const verificationMethodEnum = pgEnum('verification_method', [
-  'agent-ed25519',
-  'human-hardware-previewsign',
-]);
+export const verificationMethodEnum = pgEnum(
+  'verification_method',
+  VERIFICATION_METHOD_VALUES,
+);
 
 export interface SigningRequestRequester {
   id: string;
@@ -484,7 +488,7 @@ export const signingRequests = pgTable(
 
     // Explicit verification dispatch; agent Ed25519 remains the default.
     verificationMethod: verificationMethodEnum('verification_method')
-      .default('agent-ed25519')
+      .default(VERIFICATION_METHOD.AgentEd25519)
       .notNull(),
 
     // Reserved for delegated signing phases (requester may differ from signer).

--- a/libs/database/tsconfig.lib.json
+++ b/libs/database/tsconfig.lib.json
@@ -22,5 +22,9 @@
   ],
   "extends": "./tsconfig.json",
   "include": ["src/**/*.ts", "drizzle.config.ts"],
-  "references": []
+  "references": [
+    {
+      "path": "../models/tsconfig.lib.json"
+    }
+  ]
 }

--- a/libs/models/__tests__/verification-method.test.ts
+++ b/libs/models/__tests__/verification-method.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  VERIFICATION_METHOD,
+  VERIFICATION_METHOD_VALUES,
+} from '../src/verification-method.js';
+
+describe('verification methods', () => {
+  it('preserves the persisted Phase 0 identifiers', () => {
+    expect(VERIFICATION_METHOD.AgentEd25519).toBe('agent-ed25519');
+    expect(VERIFICATION_METHOD.HumanHardwarePreviewSign).toBe(
+      'human-hardware-previewsign',
+    );
+    expect(VERIFICATION_METHOD_VALUES).toEqual(
+      expect.arrayContaining(['agent-ed25519', 'human-hardware-previewsign']),
+    );
+    expect(new Set(VERIFICATION_METHOD_VALUES).size).toBe(
+      VERIFICATION_METHOD_VALUES.length,
+    );
+  });
+});

--- a/libs/models/package.json
+++ b/libs/models/package.json
@@ -8,6 +8,11 @@
     ".": {
       "import": "./src/index.ts",
       "types": "./src/index.ts"
+    },
+    "./verification-method": {
+      "import": "./src/verification-method.ts",
+      "types": "./src/verification-method.ts",
+      "default": "./src/verification-method.ts"
     }
   },
   "scripts": {},

--- a/libs/models/src/index.ts
+++ b/libs/models/src/index.ts
@@ -8,3 +8,4 @@ export * from './principal.js';
 export * from './problem-details.js';
 export * from './provenance-graph.js';
 export * from './schemas.js';
+export * from './verification-method.js';

--- a/libs/models/src/schemas.ts
+++ b/libs/models/src/schemas.ts
@@ -7,6 +7,8 @@
 import type { Static } from 'typebox';
 import { Type } from 'typebox';
 
+import { VERIFICATION_METHOD } from './verification-method.js';
+
 // ============================================================================
 // Common Types
 // ============================================================================
@@ -19,6 +21,18 @@ export const UuidSchema = Type.String({
 export const TimestampSchema = Type.String({
   format: 'date-time',
   description: 'ISO 8601 timestamp',
+});
+
+export const verificationMethodLiterals = [
+  Type.Literal(VERIFICATION_METHOD.AgentEd25519),
+  Type.Literal(VERIFICATION_METHOD.HumanHardwarePreviewSign),
+] satisfies [
+  ReturnType<typeof Type.Literal<'agent-ed25519'>>,
+  ReturnType<typeof Type.Literal<'human-hardware-previewsign'>>,
+];
+
+export const VerificationMethodSchema = Type.Union(verificationMethodLiterals, {
+  description: 'Stable signing verification method identifier',
 });
 
 export const VISIBILITY_VALUES = ['private', 'moltnet', 'public'] as const;

--- a/libs/models/src/verification-method.ts
+++ b/libs/models/src/verification-method.ts
@@ -1,0 +1,19 @@
+/**
+ * Persisted and wire-level signing verification method identifiers.
+ *
+ * This vocabulary is append-only. Never rename, remove, or change an existing
+ * value: PostgreSQL rows, workflow inputs, and API clients persist these exact
+ * strings. Future signing methods must add a new property and value.
+ */
+export const VERIFICATION_METHOD = {
+  AgentEd25519: 'agent-ed25519',
+  HumanHardwarePreviewSign: 'human-hardware-previewsign',
+} as const;
+
+export type VerificationMethod =
+  (typeof VERIFICATION_METHOD)[keyof typeof VERIFICATION_METHOD];
+
+export const VERIFICATION_METHOD_VALUES = [
+  VERIFICATION_METHOD.AgentEd25519,
+  VERIFICATION_METHOD.HumanHardwarePreviewSign,
+] as const satisfies readonly VerificationMethod[];

--- a/libs/signing-workflows/package.json
+++ b/libs/signing-workflows/package.json
@@ -11,7 +11,8 @@
     }
   },
   "dependencies": {
-    "@dbos-inc/dbos-sdk": "catalog:"
+    "@dbos-inc/dbos-sdk": "catalog:",
+    "@moltnet/models": "workspace:*"
   },
   "devDependencies": {
     "typescript": "catalog:",

--- a/libs/signing-workflows/src/index.ts
+++ b/libs/signing-workflows/src/index.ts
@@ -1,7 +1,9 @@
 export {
   _resetSigningWorkflowsForTesting,
   type AgentKeyLookup,
+  Ed25519Verifier,
   initSigningWorkflows,
+  registerSigningVerifier,
   setSigningKeyLookup,
   setSigningRequestPersistence,
   setSigningTimeoutSeconds,
@@ -10,5 +12,8 @@ export {
   type SigningEnvelope,
   type SigningRequestPersistence,
   type SigningResult,
+  type SigningVerifier,
   signingWorkflows,
+  type VerificationMethod,
+  verificationMethods,
 } from './signing-workflows.js';

--- a/libs/signing-workflows/src/index.ts
+++ b/libs/signing-workflows/src/index.ts
@@ -14,6 +14,8 @@ export {
   type SigningResult,
   type SigningVerifier,
   signingWorkflows,
+  VERIFICATION_METHOD,
+  VERIFICATION_METHOD_VALUES,
   type VerificationMethod,
   verificationMethods,
 } from './signing-workflows.js';

--- a/libs/signing-workflows/src/signing-workflows.test.ts
+++ b/libs/signing-workflows/src/signing-workflows.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   _resetSigningWorkflowsForTesting,
   initSigningWorkflows,
+  registerSigningVerifier,
   setSigningKeyLookup,
   setSigningRequestPersistence,
   setSigningVerifier,
@@ -100,6 +101,11 @@ describe('Signing Workflows', () => {
     });
 
     it('completes successfully when signature is valid', async () => {
+      const verifyWithNonce = vi.fn().mockResolvedValue(true);
+      setSigningVerifier({
+        verify: vi.fn().mockResolvedValue(true),
+        verifyWithNonce,
+      });
       vi.mocked(DBOS.recv).mockResolvedValue({ signature: SIGNATURE });
 
       const result = await signingWorkflows.requestSignature(
@@ -115,6 +121,12 @@ describe('Signing Workflows', () => {
         nonce: NONCE,
       });
       expect(DBOS.recv).toHaveBeenCalledWith('signature', expect.any(Number));
+      expect(verifyWithNonce).toHaveBeenCalledWith(
+        MESSAGE,
+        NONCE,
+        SIGNATURE,
+        PUBLIC_KEY,
+      );
       expect(result.status).toBe('completed');
       expect(result.valid).toBe(true);
       expect(result.requestId).toBe(REQUEST_ID);
@@ -167,6 +179,30 @@ describe('Signing Workflows', () => {
 
       expect(result.status).toBe('completed');
       expect(result.valid).toBe(false);
+    });
+
+    it('dispatches verification by verification method', async () => {
+      const hardwareVerifier = {
+        verify: vi.fn().mockResolvedValue(true),
+      };
+      registerSigningVerifier('human-hardware-previewsign', hardwareVerifier);
+      vi.mocked(DBOS.recv).mockResolvedValue({ signature: SIGNATURE });
+
+      const result = await signingWorkflows.requestSignature(
+        REQUEST_ID,
+        AGENT_ID,
+        MESSAGE,
+        NONCE,
+        'human-hardware-previewsign',
+      );
+
+      expect(hardwareVerifier.verify).toHaveBeenCalledWith(
+        MESSAGE,
+        NONCE,
+        SIGNATURE,
+        PUBLIC_KEY,
+      );
+      expect(result.valid).toBe(true);
     });
   });
 });

--- a/libs/signing-workflows/src/signing-workflows.ts
+++ b/libs/signing-workflows/src/signing-workflows.ts
@@ -13,6 +13,17 @@
  */
 
 import { DBOS } from '@dbos-inc/dbos-sdk';
+import {
+  VERIFICATION_METHOD,
+  VERIFICATION_METHOD_VALUES,
+  type VerificationMethod,
+} from '@moltnet/models';
+
+export {
+  VERIFICATION_METHOD,
+  VERIFICATION_METHOD_VALUES,
+  type VerificationMethod,
+} from '@moltnet/models';
 
 /**
  * Interface for Ed25519 signature verification.
@@ -33,12 +44,8 @@ export interface SignatureVerifier {
   ): Promise<boolean>;
 }
 
-export const verificationMethods = [
-  'agent-ed25519',
-  'human-hardware-previewsign',
-] as const;
-
-export type VerificationMethod = (typeof verificationMethods)[number];
+/** @deprecated Use VERIFICATION_METHOD_VALUES. */
+export const verificationMethods = VERIFICATION_METHOD_VALUES;
 
 export interface SigningVerifier {
   verify(
@@ -110,7 +117,10 @@ let signingRequestPersistence: SigningRequestPersistence | null = null;
 let signingTimeoutSeconds = 300; // 5 minutes default
 
 export function setSigningVerifier(verifier: SignatureVerifier): void {
-  registerSigningVerifier('agent-ed25519', new Ed25519Verifier(verifier));
+  registerSigningVerifier(
+    VERIFICATION_METHOD.AgentEd25519,
+    new Ed25519Verifier(verifier),
+  );
 }
 
 export function registerSigningVerifier(
@@ -247,7 +257,7 @@ export function initSigningWorkflows(): void {
         agentId: string,
         message: string,
         nonce: string,
-        verificationMethod: VerificationMethod = 'agent-ed25519',
+        verificationMethod: VerificationMethod = VERIFICATION_METHOD.AgentEd25519,
       ): Promise<SigningResult> => {
         // 1. Publish the signing envelope for the agent to read
         const envelope: SigningEnvelope = { requestId, message, nonce };

--- a/libs/signing-workflows/src/signing-workflows.ts
+++ b/libs/signing-workflows/src/signing-workflows.ts
@@ -33,6 +33,35 @@ export interface SignatureVerifier {
   ): Promise<boolean>;
 }
 
+export const verificationMethods = [
+  'agent-ed25519',
+  'human-hardware-previewsign',
+] as const;
+
+export type VerificationMethod = (typeof verificationMethods)[number];
+
+export interface SigningVerifier {
+  verify(
+    message: string,
+    nonce: string,
+    signature: string,
+    publicKey: string,
+  ): Promise<boolean>;
+}
+
+export class Ed25519Verifier implements SigningVerifier {
+  constructor(private readonly verifier: SignatureVerifier) {}
+
+  verify(
+    message: string,
+    nonce: string,
+    signature: string,
+    publicKey: string,
+  ): Promise<boolean> {
+    return this.verifier.verifyWithNonce(message, nonce, signature, publicKey);
+  }
+}
+
 /**
  * Interface for looking up an agent's public key.
  * Implemented by the agent repository.
@@ -75,13 +104,20 @@ export interface SigningResult {
 // ── Dependency Injection ────────────────────────────────────────────
 // Dependencies are injected at runtime before DBOS.launch()
 
-let signatureVerifier: SignatureVerifier | null = null;
+const signingVerifierRegistry = new Map<VerificationMethod, SigningVerifier>();
 let agentKeyLookup: AgentKeyLookup | null = null;
 let signingRequestPersistence: SigningRequestPersistence | null = null;
 let signingTimeoutSeconds = 300; // 5 minutes default
 
 export function setSigningVerifier(verifier: SignatureVerifier): void {
-  signatureVerifier = verifier;
+  registerSigningVerifier('agent-ed25519', new Ed25519Verifier(verifier));
+}
+
+export function registerSigningVerifier(
+  verificationMethod: VerificationMethod,
+  verifier: SigningVerifier,
+): void {
+  signingVerifierRegistry.set(verificationMethod, verifier);
 }
 
 export function setSigningKeyLookup(lookup: AgentKeyLookup): void {
@@ -98,13 +134,16 @@ export function setSigningTimeoutSeconds(seconds: number): void {
   signingTimeoutSeconds = seconds;
 }
 
-function getSignatureVerifier(): SignatureVerifier {
-  if (!signatureVerifier) {
+function getSigningVerifier(
+  verificationMethod: VerificationMethod,
+): SigningVerifier {
+  const verifier = signingVerifierRegistry.get(verificationMethod);
+  if (!verifier) {
     throw new Error(
-      'SignatureVerifier not set. Call setSigningVerifier() before using signing workflows.',
+      `Signing verifier not registered for verification method: ${verificationMethod}`,
     );
   }
-  return signatureVerifier;
+  return verifier;
 }
 
 function getAgentKeyLookup(): AgentKeyLookup {
@@ -141,6 +180,7 @@ let _workflows: {
     agentId: string,
     message: string,
     nonce: string,
+    verificationMethod?: VerificationMethod,
   ) => Promise<SigningResult>;
 } | null = null;
 
@@ -163,12 +203,13 @@ export function initSigningWorkflows(): void {
 
   const verifySignatureStep = DBOS.registerStep(
     async (
+      verificationMethod: VerificationMethod,
       message: string,
       nonce: string,
       signature: string,
       publicKey: string,
     ): Promise<boolean> => {
-      return getSignatureVerifier().verifyWithNonce(
+      return getSigningVerifier(verificationMethod).verify(
         message,
         nonce,
         signature,
@@ -206,6 +247,7 @@ export function initSigningWorkflows(): void {
         agentId: string,
         message: string,
         nonce: string,
+        verificationMethod: VerificationMethod = 'agent-ed25519',
       ): Promise<SigningResult> => {
         // 1. Publish the signing envelope for the agent to read
         const envelope: SigningEnvelope = { requestId, message, nonce };
@@ -250,6 +292,7 @@ export function initSigningWorkflows(): void {
 
         // 4. Verify the signature using deterministic pre-hash (buildSigningBytes)
         const valid = await verifySignatureStep(
+          verificationMethod,
           message,
           nonce,
           submission.signature,
@@ -294,4 +337,5 @@ export const signingWorkflows = {
 /** @internal Reset module state for testing. */
 export function _resetSigningWorkflowsForTesting(): void {
   _workflows = null;
+  signingVerifierRegistry.clear();
 }

--- a/libs/signing-workflows/tsconfig.lib.json
+++ b/libs/signing-workflows/tsconfig.lib.json
@@ -8,5 +8,10 @@
   },
   "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts"],
   "extends": "./tsconfig.json",
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../models/tsconfig.lib.json"
+    }
+  ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1515,6 +1515,9 @@ importers:
       '@dbos-inc/drizzle-datasource':
         specifier: 'catalog:'
         version: 4.13.5(@dbos-inc/dbos-sdk@4.13.5)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.10.0)(pg@8.18.0))
+      '@moltnet/models':
+        specifier: workspace:*
+        version: link:../models
       drizzle-orm:
         specifier: 'catalog:'
         version: 0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.10.0)(pg@8.18.0)
@@ -2014,6 +2017,9 @@ importers:
       '@dbos-inc/dbos-sdk':
         specifier: 'catalog:'
         version: 4.13.5
+      '@moltnet/models':
+        specifier: workspace:*
+        version: link:../models
     devDependencies:
       typescript:
         specifier: 'catalog:'


### PR DESCRIPTION
## Summary

- add the additive `verification_method` database enum and nullable future-facing requester/signer constraint columns
- dispatch signature verification through an explicit verification-method registry
- thread `verificationMethod` through persistence and the REST signing route, defaulting to `agent-ed25519`
- centralize verification-method identifiers as append-only wire vocabulary and pin the Phase 0 values with a contract test

## Compatibility

The existing Ed25519 agent verifier remains the implementation behind the
`agent-ed25519` registry entry. Its signing input, signature bytes, crypto
service call, and verification result are unchanged. No FIDO2, P-256,
companion, SDK, or `libs/crypto-service` changes are included.

Migration `0032_yellow_deadpool.sql` is additive. A fresh Drizzle generation
after the stable-value refactor reports no schema changes.

## Validation

- `pnpm run validate`
- models, signing-workflows, database, and REST API focused lint/typecheck/tests
- REST API e2e: 483 passed, 1 skipped
- MCP server e2e: 65 passed
- Drizzle generation: no schema changes

Closes #1634
