### PR TITLE
fix(release): make Nx dry run tag-compatible

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,7 +301,8 @@ jobs:
           go-version-file: apps/moltnet-cli/go.mod
           cache: true
 
-      - uses: docker/setup-buildx-action@v3
+      - if: ${{ !inputs.dry-run }}
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
         if: ${{ !inputs.dry-run }}
@@ -338,7 +339,7 @@ jobs:
           fi
 
           if [ '${{ inputs.dry-run }}' = 'true' ]; then
-            pnpm exec nx release --dry-run "${RELEASE_ARGS[@]}"
+            NX_DRY_RUN=true pnpm exec nx release --dry-run "${RELEASE_ARGS[@]}"
             exit 0
           fi
 

--- a/docs/contribute/nx-release-workflow.md
+++ b/docs/contribute/nx-release-workflow.md
@@ -27,17 +27,24 @@ updates. Keep the workflow filename as `release.yml` when that cleanup happens.
 
 Configured in `nx.json` under `release.groups`:
 
-- `npm-packages`: independent published TypeScript packages.
+- One group per published TypeScript package, named for its existing public tag
+  prefix (for example, `sdk` owns `@themoltnet/sdk` and creates
+  `sdk-v{version}`).
 - `cli`: fixed-version CLI family, including the Go CLI and npm wrapper
   packages.
 - `go-modules`: independent Go library modules.
 - `github-actions`: independent GitHub Actions distributed from this repo by
   tag.
-- `docker-images`: independent Docker images built from Nx projects with
-  Dockerfiles.
+- One group per Docker image, also named for its public tag prefix (for example,
+  `rest-api` owns `@moltnet/rest-api` and creates `rest-api-v{version}`).
 
-Use groups when invoking release commands. Avoid hand-ordering projects; Nx
-should derive project ordering and dependent updates.
+The one-project groups are intentional. Nx interpolates scoped package names
+literally for `{projectName}`, while the repository's Release Please history
+uses unscoped tag prefixes. `{releaseGroupName}-v{version}` preserves those
+public tags and lets Nx resolve the correct current version from git history.
+
+Use groups when invoking release commands. Nx still derives project ordering
+and dependent updates across the selected groups.
 
 ## Full Rehearsal
 
@@ -281,14 +288,17 @@ git clean -fd
 Use dry-runs only as a fast preflight before the full rehearsal:
 
 ```bash
-pnpm exec nx release version patch --groups npm-packages --dry-run --verbose
+pnpm exec nx release version patch --groups sdk --dry-run --verbose
 pnpm exec nx release version patch --groups go-modules,cli --dry-run --verbose
 pnpm exec nx release version patch --groups github-actions --dry-run --verbose
-NX_DRY_RUN=true pnpm exec nx release version patch --groups docker-images --dry-run --verbose
+NX_DRY_RUN=true pnpm exec nx release version patch --groups rest-api --dry-run --verbose
 ```
 
-The Docker dry-run sets `NX_DRY_RUN=true` because `docker.preVersionCommand`
-would otherwise build images before Nx retags them.
+The Docker dry-run must set `NX_DRY_RUN=true` on the parent Nx process. Nx
+passes dry-run mode to `docker.groupPreVersionCommand`, but the Nx Docker
+version action reads it from the parent environment before deciding whether to
+run `docker tag`. The CI workflow sets this explicitly and skips Buildx setup
+for dry runs.
 
 ## Go Modules
 
@@ -394,15 +404,15 @@ Do not use `pnpm --filter` for action build/test/typecheck tasks.
 
 ## Docker Images
 
-Docker releases use Nx native Docker release support. The `docker-images`
-release group owns the Docker pre-version helper, so image builds only run when
-that group is selected. The helper builds the group before Nx retags images. By
-default it reads the project list from `nx.json`.
+Docker releases use Nx native Docker release support. Each image release group
+owns a Docker pre-version command that passes its exact project to
+`tools/release/docker-preversion.mjs`. Selecting `rest-api`, for example, builds
+only `@moltnet/rest-api` before Nx retags it.
 
 Override the image list only for local debugging:
 
 ```bash
-NX_RELEASE_DOCKER_PROJECTS=@moltnet/rest-api pnpm exec nx release version patch --groups docker-images --dry-run --verbose
+NX_DRY_RUN=true NX_RELEASE_DOCKER_PROJECTS=@moltnet/rest-api pnpm exec nx release version patch --groups rest-api --dry-run --verbose
 ```
 
 ## Expected Operator Flow

--- a/nx.json
+++ b/nx.json
@@ -181,6 +181,20 @@
       "commitMessage": "chore(release): publish {version} [skip ci]"
     },
     "groups": {
+      "agent-daemon": {
+        "projects": ["@themoltnet/agent-daemon"],
+        "projectsRelationship": "independent",
+        "releaseTag": {
+          "pattern": "{releaseGroupName}-v{version}"
+        }
+      },
+      "agent-runtime": {
+        "projects": ["@themoltnet/agent-runtime"],
+        "projectsRelationship": "independent",
+        "releaseTag": {
+          "pattern": "{releaseGroupName}-v{version}"
+        }
+      },
       "cli": {
         "projects": [
           "moltnet-cli",
@@ -197,21 +211,38 @@
           "pattern": "cli-v{version}"
         }
       },
-      "docker-images": {
+      "console": {
         "docker": {
-          "groupPreVersionCommand": "node tools/release/docker-preversion.mjs"
+          "groupPreVersionCommand": "node tools/release/docker-preversion.mjs --projects=@moltnet/console"
         },
-        "projects": [
-          "@moltnet/console",
-          "@moltnet/database",
-          "@moltnet/landing",
-          "@moltnet/mcp-host",
-          "@moltnet/mcp-server",
-          "@moltnet/rest-api"
-        ],
+        "projects": ["@moltnet/console"],
         "projectsRelationship": "independent",
         "releaseTag": {
-          "pattern": "{projectName}-v{version}"
+          "pattern": "{releaseGroupName}-v{version}"
+        }
+      },
+      "ctap": {
+        "projects": ["@themoltnet/ctap"],
+        "projectsRelationship": "independent",
+        "releaseTag": {
+          "pattern": "{releaseGroupName}-v{version}"
+        }
+      },
+      "db-migrate": {
+        "docker": {
+          "groupPreVersionCommand": "node tools/release/docker-preversion.mjs --projects=@moltnet/database"
+        },
+        "projects": ["@moltnet/database"],
+        "projectsRelationship": "independent",
+        "releaseTag": {
+          "pattern": "{releaseGroupName}-v{version}"
+        }
+      },
+      "design-system": {
+        "projects": ["@themoltnet/design-system"],
+        "projectsRelationship": "independent",
+        "releaseTag": {
+          "pattern": "{releaseGroupName}-v{version}"
         }
       },
       "github-actions": {
@@ -219,6 +250,13 @@
         "projectsRelationship": "independent",
         "releaseTag": {
           "pattern": "agent-daemon-action-v{version}"
+        }
+      },
+      "github-agent": {
+        "projects": ["@themoltnet/github-agent"],
+        "projectsRelationship": "independent",
+        "releaseTag": {
+          "pattern": "{releaseGroupName}-v{version}"
         }
       },
       "go-modules": {
@@ -232,23 +270,86 @@
           "versionActions": "./tools/src/release/go-version-actions.ts"
         }
       },
-      "npm-packages": {
-        "projects": [
-          "@themoltnet/agent-daemon",
-          "@themoltnet/agent-runtime",
-          "@themoltnet/ctap",
-          "@themoltnet/design-system",
-          "@themoltnet/github-agent",
-          "@themoltnet/legreffier",
-          "@themoltnet/node-red-contrib-core",
-          "@themoltnet/node-red-theme",
-          "@themoltnet/pi-extension",
-          "@themoltnet/sdk",
-          "@themoltnet/yubikey-preview-sign"
-        ],
+      "landing": {
+        "docker": {
+          "groupPreVersionCommand": "node tools/release/docker-preversion.mjs --projects=@moltnet/landing"
+        },
+        "projects": ["@moltnet/landing"],
         "projectsRelationship": "independent",
         "releaseTag": {
-          "pattern": "{projectName}-v{version}"
+          "pattern": "{releaseGroupName}-v{version}"
+        }
+      },
+      "legreffier": {
+        "projects": ["@themoltnet/legreffier"],
+        "projectsRelationship": "independent",
+        "releaseTag": {
+          "pattern": "{releaseGroupName}-v{version}"
+        }
+      },
+      "mcp-host": {
+        "docker": {
+          "groupPreVersionCommand": "node tools/release/docker-preversion.mjs --projects=@moltnet/mcp-host"
+        },
+        "projects": ["@moltnet/mcp-host"],
+        "projectsRelationship": "independent",
+        "releaseTag": {
+          "pattern": "{releaseGroupName}-v{version}"
+        }
+      },
+      "mcp-server": {
+        "docker": {
+          "groupPreVersionCommand": "node tools/release/docker-preversion.mjs --projects=@moltnet/mcp-server"
+        },
+        "projects": ["@moltnet/mcp-server"],
+        "projectsRelationship": "independent",
+        "releaseTag": {
+          "pattern": "{releaseGroupName}-v{version}"
+        }
+      },
+      "node-red-contrib-core": {
+        "projects": ["@themoltnet/node-red-contrib-core"],
+        "projectsRelationship": "independent",
+        "releaseTag": {
+          "pattern": "{releaseGroupName}-v{version}"
+        }
+      },
+      "node-red-theme": {
+        "projects": ["@themoltnet/node-red-theme"],
+        "projectsRelationship": "independent",
+        "releaseTag": {
+          "pattern": "{releaseGroupName}-v{version}"
+        }
+      },
+      "pi-extension": {
+        "projects": ["@themoltnet/pi-extension"],
+        "projectsRelationship": "independent",
+        "releaseTag": {
+          "pattern": "{releaseGroupName}-v{version}"
+        }
+      },
+      "rest-api": {
+        "docker": {
+          "groupPreVersionCommand": "node tools/release/docker-preversion.mjs --projects=@moltnet/rest-api"
+        },
+        "projects": ["@moltnet/rest-api"],
+        "projectsRelationship": "independent",
+        "releaseTag": {
+          "pattern": "{releaseGroupName}-v{version}"
+        }
+      },
+      "sdk": {
+        "projects": ["@themoltnet/sdk"],
+        "projectsRelationship": "independent",
+        "releaseTag": {
+          "pattern": "{releaseGroupName}-v{version}"
+        }
+      },
+      "yubikey-preview-sign": {
+        "projects": ["@themoltnet/yubikey-preview-sign"],
+        "projectsRelationship": "independent",
+        "releaseTag": {
+          "pattern": "{releaseGroupName}-v{version}"
         }
       }
     },

--- a/tools/package.json
+++ b/tools/package.json
@@ -15,7 +15,8 @@
     "task:bootstrap-local": "tsx src/tasks/bootstrap-local-agent.ts",
     "bench:ory": "tsx src/bench-ory-connection-reuse.ts",
     "bench:embedding": "tsx src/bench-embedding-warmup.ts",
-    "smtp:test": "tsx src/test-smtp.ts"
+    "smtp:test": "tsx src/test-smtp.ts",
+    "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
     "@dotenvx/dotenvx": "catalog:",

--- a/tools/release/docker-preversion.mjs
+++ b/tools/release/docker-preversion.mjs
@@ -1,50 +1,62 @@
 import { execFileSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
 import process from 'node:process';
+import { parseArgs } from 'node:util';
+
+const { values } = parseArgs({
+  options: {
+    projects: {
+      type: 'string',
+    },
+  },
+  strict: true,
+});
+
+const configuredProjects =
+  values.projects
+    ?.split(',')
+    .map((project) => project.trim())
+    .filter(Boolean) ?? [];
+const overriddenProjects = process.env.NX_RELEASE_DOCKER_PROJECTS?.split(',')
+  .map((project) => project.trim())
+  .filter(Boolean);
+const projects =
+  overriddenProjects && overriddenProjects.length > 0
+    ? overriddenProjects
+    : configuredProjects;
+
+if (projects.length === 0) {
+  throw new Error(
+    'Pass at least one Nx project with --projects=<comma-separated-projects>.',
+  );
+}
 
 if (process.env.NX_DRY_RUN === 'true') {
   process.stdout.write(
-    'Skipping Docker pre-version build during nx release dry-run.\n',
+    `Skipping Docker pre-version build for ${projects.join(
+      ', ',
+    )} during nx release dry-run.\n`,
   );
-  process.exit(0);
-}
+} else {
+  process.stdout.write(
+    `Building Docker release images for ${projects.join(
+      ', ',
+    )} before Nx retags them.\n`,
+  );
 
-const nxConfig = JSON.parse(readFileSync('nx.json', 'utf8'));
-const releaseDockerProjects =
-  nxConfig.release?.groups?.['docker-images']?.projects ?? [];
-if (
-  !Array.isArray(releaseDockerProjects) ||
-  releaseDockerProjects.length === 0
-) {
-  throw new Error(
-    'No projects configured in nx.json release.groups.docker-images',
+  execFileSync(
+    'pnpm',
+    [
+      'exec',
+      'nx',
+      'run-many',
+      '-t',
+      'docker:build',
+      '--projects',
+      projects.join(','),
+    ],
+    {
+      stdio: 'inherit',
+      windowsHide: true,
+    },
   );
 }
-
-const projects =
-  process.env.NX_RELEASE_DOCKER_PROJECTS?.split(',')
-    .map((project) => project.trim())
-    .filter(Boolean) ?? releaseDockerProjects;
-
-process.stdout.write(
-  `Building Docker release images for ${projects.join(
-    ', ',
-  )} before Nx retags them.\n`,
-);
-
-execFileSync(
-  'pnpm',
-  [
-    'exec',
-    'nx',
-    'run-many',
-    '-t',
-    'docker:build',
-    '--projects',
-    projects.join(','),
-  ],
-  {
-    stdio: 'inherit',
-    windowsHide: true,
-  },
-);

--- a/tools/src/release/go-version-actions.test.ts
+++ b/tools/src/release/go-version-actions.test.ts
@@ -354,7 +354,7 @@ go 1.25
         'release',
         'version',
         '--groups',
-        'docker-images',
+        'rest-api',
       ]),
     ).toBe(false);
     expect(
@@ -364,7 +364,7 @@ go 1.25
           goReleaseValidationRoots: ['apps/moltnet-cli'],
           goReleaseValidationGroups: ['go-modules', 'cli'],
         },
-        ['nx', 'release', 'version', '--groups=docker-images'],
+        ['nx', 'release', 'version', '--groups=rest-api'],
       ),
     ).toEqual([]);
   });

--- a/tools/src/release/nx-release-config.test.ts
+++ b/tools/src/release/nx-release-config.test.ts
@@ -1,0 +1,118 @@
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const workspaceRoot = fileURLToPath(new URL('../../../', import.meta.url));
+const nxConfig = JSON.parse(
+  readFileSync(new URL('../../../nx.json', import.meta.url), 'utf8'),
+);
+const workflow = readFileSync(
+  new URL('../../../.github/workflows/release.yml', import.meta.url),
+  'utf8',
+);
+
+const npmReleaseGroups = {
+  'agent-daemon': '@themoltnet/agent-daemon',
+  'agent-runtime': '@themoltnet/agent-runtime',
+  ctap: '@themoltnet/ctap',
+  'design-system': '@themoltnet/design-system',
+  'github-agent': '@themoltnet/github-agent',
+  legreffier: '@themoltnet/legreffier',
+  'node-red-contrib-core': '@themoltnet/node-red-contrib-core',
+  'node-red-theme': '@themoltnet/node-red-theme',
+  'pi-extension': '@themoltnet/pi-extension',
+  sdk: '@themoltnet/sdk',
+  'yubikey-preview-sign': '@themoltnet/yubikey-preview-sign',
+};
+
+const dockerReleaseGroups = {
+  console: '@moltnet/console',
+  'db-migrate': '@moltnet/database',
+  landing: '@moltnet/landing',
+  'mcp-host': '@moltnet/mcp-host',
+  'mcp-server': '@moltnet/mcp-server',
+  'rest-api': '@moltnet/rest-api',
+};
+
+describe('Nx release configuration', () => {
+  it('preserves the existing public npm tag prefixes', () => {
+    for (const [groupName, projectName] of Object.entries(npmReleaseGroups)) {
+      expect(nxConfig.release.groups[groupName]).toMatchObject({
+        projects: [projectName],
+        projectsRelationship: 'independent',
+        releaseTag: {
+          pattern: '{releaseGroupName}-v{version}',
+        },
+      });
+    }
+  });
+
+  it('maps every Docker tag prefix to one explicit project build', () => {
+    for (const [groupName, projectName] of Object.entries(
+      dockerReleaseGroups,
+    )) {
+      expect(nxConfig.release.groups[groupName]).toMatchObject({
+        docker: {
+          groupPreVersionCommand: `node tools/release/docker-preversion.mjs --projects=${projectName}`,
+        },
+        projects: [projectName],
+        projectsRelationship: 'independent',
+        releaseTag: {
+          pattern: '{releaseGroupName}-v{version}',
+        },
+      });
+    }
+  });
+
+  it('does not derive public tags from scoped project names', () => {
+    const scopedGroups = [
+      ...Object.keys(npmReleaseGroups),
+      ...Object.keys(dockerReleaseGroups),
+    ];
+
+    for (const groupName of scopedGroups) {
+      expect(
+        nxConfig.release.groups[groupName].releaseTag.pattern,
+      ).not.toContain('{projectName}');
+    }
+
+    expect(nxConfig.release.groups['npm-packages']).toBeUndefined();
+    expect(nxConfig.release.groups['docker-images']).toBeUndefined();
+  });
+
+  it('propagates dry-run mode to Docker release actions in CI', () => {
+    expect(workflow).toContain(
+      '- if: ${{ !inputs.dry-run }}\n        uses: docker/setup-buildx-action@v3',
+    );
+    expect(workflow).toContain(
+      'NX_DRY_RUN=true pnpm exec nx release --dry-run',
+    );
+  });
+
+  it('keeps the Docker pre-version helper side-effect free in dry-run mode', () => {
+    const childEnv = {
+      ...process.env,
+      NX_DRY_RUN: 'true',
+    };
+    delete childEnv.FORCE_COLOR;
+    delete childEnv.NO_COLOR;
+
+    const result = spawnSync(
+      process.execPath,
+      ['tools/release/docker-preversion.mjs', '--projects=@moltnet/rest-api'],
+      {
+        cwd: workspaceRoot,
+        encoding: 'utf8',
+        env: childEnv,
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toBe(
+      'Skipping Docker pre-version build for @moltnet/rest-api during nx release dry-run.\n',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- propagate `NX_DRY_RUN=true` to the parent Nx release process and skip Buildx setup during CI dry runs
- preserve the existing unscoped npm and Docker tag history with explicit one-project release groups
- make Docker pre-version project selection explicit and side-effect-free during dry runs
- add regression coverage and update the Nx release operator runbook

## Root cause

The first Nx release CI dry run failed because Nx 22.7 only passed `NX_DRY_RUN` to the pre-version subprocess, while the Docker release action checked the parent process environment and still executed `docker tag`. The release groups also used `{projectName}` with scoped project names, which did not match the repository's established Release Please tags such as `sdk-v0.124.0` and `rest-api-v0.32.0`; Nx therefore fell back to package versions and replayed too much git history.

## Impact

Dry runs no longer require Docker images or Buildx and do not execute Docker build/tag operations. Existing public tag prefixes remain stable, while newly released Docker artifacts receive explicit tag prefixes derived from their release-group names. Release Please remains the default release engine during the Nx proving period.

## Validation

- `pnpm exec nx run @moltnet/tools:test` — 37 tests passed
- `pnpm exec nx run @moltnet/tools:lint`
- `pnpm exec nx run @moltnet/tools:typecheck`
- `pnpm run check:actionlint`
- Prettier and `git diff --check`
- `NX_DRY_RUN=true NX_LOAD_DOT_ENV_FILES=false pnpm exec nx release --dry-run --skip-publish --verbose` against current remote tags

The full dry run resolved existing tag history, skipped all six Docker pre-version builds, and only previewed Docker image tags.