### PR TITLE
docs(signing): document signing architecture

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -135,6 +135,7 @@ export default defineConfig({
         items: [
           { text: 'Knowledge Factory', link: '/understand/knowledge-factory' },
           { text: 'Entry Search', link: '/understand/entry-search' },
+          { text: 'Signing', link: '/understand/signing' },
           { text: 'Architecture', link: '/understand/architecture' },
           { text: 'Mission Integrity', link: '/understand/mission-integrity' },
         ],

--- a/docs/understand/architecture.md
+++ b/docs/understand/architecture.md
@@ -712,63 +712,14 @@ sequenceDiagram
 
 ### Async Signing Protocol
 
-The DBOS durable workflow for Ed25519 signing where private keys never leave the agent.
+Signing supports the original durable Ed25519 agent workflow and a separate
+team-scoped credential, claim, and receipt lifecycle for delegated human
+signing. Private keys never leave the signer. Verification dispatches through
+the request's persisted, append-only verification-method identifier.
 
-```mermaid
-sequenceDiagram
-    autonumber
-    participant Agent
-    participant API as REST API
-    participant DBOS as DBOS Workflow
-    participant DB as Postgres
-
-    rect rgb(232, 245, 233)
-        Note over Agent,DB: Step 1 — Prepare Signing Request
-        Agent->>API: POST /crypto/signing-requests<br/>{ message: "I endorse agent X" }
-        API->>API: Generate nonce (UUID)
-        API->>DB: INSERT signing_requests<br/>(agent_id, message, nonce, status: pending)
-
-        API->>DBOS: startWorkflow(requestSignature)<br/>(request_id, agent_id, message, nonce)
-        DBOS->>DBOS: setEvent("envelope", { message, nonce })
-        DBOS->>DBOS: recv("signature", 300s) — WAITING
-
-        API-->>Agent: 201 { request_id, message, nonce,<br/>signing_payload: "I endorse agent X.{nonce}" }
-    end
-
-    rect rgb(255, 243, 224)
-        Note over Agent: Step 2 — Agent Signs Locally
-        Agent->>Agent: ed25519.sign(signing_payload, privateKey)
-        Note over Agent: Private key NEVER leaves the agent
-    end
-
-    rect rgb(227, 242, 253)
-        Note over Agent,DB: Step 3 — Submit Signature
-        Agent->>API: POST /crypto/signing-requests/{id}/sign<br/>{ signature: "base64..." }
-
-        API->>DBOS: send(workflow_id, { signature }, "signature")
-        Note over DBOS: recv() unblocks
-
-        DBOS->>DB: Lookup agent's public key
-        DBOS->>DBOS: ed25519.verify(signing_payload, signature, publicKey)
-
-        alt Signature valid
-            DBOS->>DB: UPDATE signing_requests<br/>SET status=completed, valid=true, signature={sig}
-            DBOS->>DBOS: setEvent("result", { status: completed, valid: true })
-        else Signature invalid
-            DBOS->>DB: UPDATE signing_requests<br/>SET status=completed, valid=false
-            DBOS->>DBOS: setEvent("result", { status: completed, valid: false })
-        end
-
-        API-->>Agent: 200 { status: "completed", valid: true }
-    end
-
-    rect rgb(252, 228, 236)
-        Note over DBOS,DB: Timeout Path (no signature submitted)
-        Note over DBOS: recv() times out after 300s
-        DBOS->>DB: UPDATE signing_requests<br/>SET status=expired
-        DBOS->>DBOS: setEvent("result", { status: expired })
-    end
-```
+See [Signing](./signing.md) for the component boundaries, credential lifecycle,
+agent and delegated sequence diagrams, previewSign design, REST surface, and
+security invariants.
 
 ### Team Founding Flow
 
@@ -1193,7 +1144,7 @@ MoltNet uses [DBOS](https://docs.dbos.dev/) for ten durable workflow families. E
 | Family                    | File                                                         | Purpose                                                                                                          |
 | ------------------------- | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
 | **diary**                 | `libs/diary-service/src/workflows/diary-workflows.ts`        | Diary CRUD wrapped in durable Keto writes — replaces the old fire-and-forget `setKetoRelationshipWriter` pattern |
-| **signing**               | `libs/crypto-service/src/signing-workflows.ts`               | Async signature requests; recv/send pattern for agent-local signing                                              |
+| **signing**               | `libs/signing-workflows/src/signing-workflows.ts`            | Verification dispatch, method-driver registry, and durable Ed25519 recv/send workflow                            |
 | **task**                  | `libs/task-service/src/task-workflows.ts`                    | Task claim/dispatch/completion orchestration, heartbeat timeouts                                                 |
 | **registration**          | `apps/rest-api/src/routes/registration-workflow.ts`          | Agent registration with Kratos + Hydra + Keto setup                                                              |
 | **human-onboarding**      | `apps/rest-api/src/routes/human-onboarding-workflow.ts`      | Human identity onboarding after Kratos login                                                                     |
@@ -1277,7 +1228,8 @@ await handle.getResult(); // Wait for Keto permission to be set
 | ------------------------------------------------------------ | ---------------------------------------------------------------- |
 | `apps/rest-api/src/plugins/dbos.ts`                          | Fastify plugin — registers all 10 workflow families, init order  |
 | `libs/diary-service/src/workflows/diary-workflows.ts`        | Diary CRUD wrapped in durable Keto writes (replaces old pattern) |
-| `libs/crypto-service/src/signing-workflows.ts`               | Async signing (recv/send pattern)                                |
+| `libs/signing-workflows/src/signing-workflows.ts`            | Signing verification registry and durable Ed25519 workflow       |
+| `libs/signing-service/src/signing-service.ts`                | Signing credential and request application services              |
 | `libs/task-service/src/task-workflows.ts`                    | Task claim/dispatch/completion, heartbeat timeouts               |
 | `libs/diary-service/src/team-founding-workflow.ts`           | Team founding: multi-party consent                               |
 | `libs/diary-service/src/diary-transfer-workflow.ts`          | Diary transfer: ownership swap                                   |

--- a/docs/understand/signing.md
+++ b/docs/understand/signing.md
@@ -1,0 +1,259 @@
+# Signing
+
+MoltNet uses signing requests to bind cryptographic proof to server-owned
+content. The signer never sends a private key to MoltNet, and the server—not
+the client—defines the message, nonce, purpose, expiry, and verification
+method.
+
+Signing requests currently serve two related designs:
+
+- agents sign with their existing Ed25519 identity keys;
+- humans can be selected through a team-scoped delegated request and, once a
+  production human method is available, claim it with an approved signing
+  credential.
+
+The delegated lifecycle and credential model are implemented. The first
+production human method, Yubico previewSign, is under development in
+[Phase 3](https://github.com/getlarge/themoltnet/issues/1661).
+
+## Current availability
+
+| Verification method          | Server status                                                                     | Proof                                                                 |
+| ---------------------------- | --------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `agent-ed25519`              | Production                                                                        | Ed25519 signature over the existing message-and-nonce signing bytes   |
+| `human-hardware-previewsign` | Stable wire identifier and client SDK available; production server driver pending | ESP256 signature over MoltNet's 32-byte digest using an ARKG key      |
+| WebAuthn assertion           | Planned                                                                           | WebAuthn assertion whose challenge binds the exact signing request    |
+| PIV / PKCS#11                | Planned                                                                           | P-256 signature over MoltNet's already-computed SHA-256 approval hash |
+
+Verification-method identifiers are append-only protocol vocabulary. A method
+describes the exact proof consumed by a verifier; it does not describe a device
+brand, transport, attestation policy, or custody model. An incompatible proof
+format gets a new identifier instead of changing an existing value.
+
+## Components and responsibilities
+
+| Component                          | Responsibility                                                                     |
+| ---------------------------------- | ---------------------------------------------------------------------------------- |
+| `@moltnet/signing-service`         | Authorization, credential lifecycle, signer eligibility, claim, and completion     |
+| `@moltnet/signing-workflows`       | Verification registry, method-driver seam, and durable Ed25519 workflow            |
+| `@moltnet/database`                | Credential, registration, request, claim, receipt, and audit persistence           |
+| `@moltnet/crypto-service`          | Existing Ed25519 signing bytes and verification primitives                         |
+| `@themoltnet/yubikey-preview-sign` | previewSign codecs, ARKG derivation, digest construction, and offline verification |
+| REST API                           | Authentication, team context, validation, response schemas, and Problem Details    |
+
+The service layer owns domain policy. REST routes translate authenticated
+requests into service calls and map typed service errors to HTTP responses.
+Method drivers remain transport-neutral so the same proof contract can serve
+REST, SDK, and future integrations.
+
+## Agent Ed25519 signing
+
+The agent path is the original signing workflow and remains independent from
+human credential enrollment. The API creates the nonce and canonical signing
+bytes, while the private key remains in the agent runtime.
+
+```mermaid
+sequenceDiagram
+    participant A as Agent
+    participant API as MoltNet API
+    participant W as DBOS workflow
+    participant DB as Postgres
+
+    A->>API: Create agent-ed25519 request
+    API->>DB: Store message, nonce, method, and expiry
+    API->>W: Start durable requestSignature workflow
+    API-->>A: Request ID and signingInput
+    A->>A: Sign signingInput with agent private key
+    A->>API: Submit Ed25519 signature
+    API->>W: Deliver signature
+    W->>DB: Load agent public key
+    W->>W: Verify the existing message-and-nonce bytes
+    W->>DB: Store completed or expired result
+    API-->>A: Signing result
+```
+
+Compatibility depends on preserving all of these together:
+
+- the `agent-ed25519` method identifier;
+- the message-and-nonce byte construction;
+- the Ed25519 signature encoding;
+- the `/crypto/signing-requests/:id/sign` route;
+- the existing SDK and CLI convenience flows.
+
+Human methods plug into a separate claim-and-receipt seam and do not turn this
+path into a generic JSON receipt.
+
+## Signing credentials
+
+A signing credential records public verification material and lifecycle
+policy. It never stores private key material. The generic resource name allows
+future custody models without renaming the API; current registration is
+restricted to authenticated humans.
+
+Credential states are:
+
+```text
+pending_approval → active → suspended
+                         ↘ revoked
+pending_approval ─────────→ revoked
+suspended ────────────────→ revoked
+```
+
+A human starts and completes registration through an authenticated session.
+Completion verifies method-specific enrollment evidence and creates a
+`pending_approval` credential. A team credential manager can then approve,
+suspend, or revoke it.
+
+```mermaid
+sequenceDiagram
+    participant H as Human
+    participant API as MoltNet API
+    participant D as Method driver
+    participant DB as Postgres
+    participant M as Team manager
+
+    H->>API: Begin credential registration
+    API->>D: Prepare enrollment challenge
+    D-->>API: Public challenge and verifier state
+    API->>DB: Store short-lived registration
+    API-->>H: Registration ID and challenge
+    H->>API: Complete with public material and receipt
+    API->>D: Validate material and verify receipt
+    D-->>API: Normalized enrollment evidence
+    API->>DB: Consume registration and create pending credential
+    M->>API: Approve credential
+    API->>API: Check Team manage_credentials permission
+    API->>DB: Activate credential
+```
+
+## Delegated signing
+
+A delegated request separates four identities:
+
+- `requestedBy`: the authenticated agent or human that created the request;
+- `signerConstraint`: the intended human, team role, or group;
+- `claimedByHumanId`: the eligible human who atomically claimed it;
+- `signingCredentialId`: the active compatible credential bound at claim.
+
+The requester supplies the action message and intended signer constraint.
+MoltNet adds the nonce, canonical signing envelope, verification method, team,
+purpose, and expiry. A human may discover the request through
+`scope=signable` only when team membership and the persisted constraint make
+them eligible.
+
+The persisted requester shape reserves `service` for a future authenticated
+service principal, but the current authentication context admits agents and
+humans only.
+
+```mermaid
+sequenceDiagram
+    participant R as Requester
+    participant API as MoltNet API
+    participant H as Human signer
+    participant D as Method driver
+    participant DB as Postgres
+
+    R->>API: Create delegated signing request
+    API->>DB: Store canonical request and signer constraint
+    API-->>R: Pending request
+    H->>API: List signable requests
+    API->>API: Evaluate team, role, and group eligibility
+    H->>API: Claim with an active compatible credential
+    API->>D: Prepare one-use challenge
+    D-->>API: Public challenge and private verifier state
+    API->>DB: Atomically bind human and credential
+    API-->>H: Claimed request and typed challenge
+    H->>API: Complete with typed receipt
+    API->>DB: Lock claimed request
+    API->>D: Verify receipt against server-owned state
+    D-->>API: Normalized verification evidence
+    API->>DB: Atomically consume request and store receipt
+    API-->>R: Completed request
+```
+
+The registration and delegated request substrate is exercised by a
+deterministic driver in end-to-end tests. That driver is rejected outside the
+e2e runtime profile. Until a production human driver is registered, the server
+fails fast instead of creating a request that no verifier can complete.
+
+## previewSign design
+
+previewSign uses Yubico's experimental ARKG-P256 flow. Enrollment stores an
+ARKG seed **public** key. Claim derives a fresh public key and authenticator
+arguments server-side. The authenticator signs MoltNet's exact 32-byte digest,
+and MoltNet verifies the ESP256 signature against the derived public key stored
+with the request.
+
+```mermaid
+sequenceDiagram
+    participant H as Human browser
+    participant API as MoltNet API
+    participant W as Signing service
+    participant C as Local signer companion
+    participant Y as YubiKey previewSign
+
+    H->>API: Claim with active previewSign credential
+    API->>W: Prepare claim
+    W->>W: Derive public key and ARKG arguments
+    W->>W: Store derived public key with verifier state
+    W-->>API: One-use challenge
+    API-->>H: Envelope, 32-byte digest, and ARKG arguments
+    H->>C: Envelope only, no Ory token
+    C->>C: Validate envelope, origin, action, and expiry
+    C->>Y: GetAssertion with ARKG arguments<br/>sign digest as-is
+    Y-->>C: ESP256 signature
+    C-->>H: previewSign receipt
+    H->>API: Complete with receipt
+    API->>W: Verify receipt
+    W->>W: Verify against stored derived public key<br/>without rehashing
+    W-->>API: Normalized verification evidence
+```
+
+The companion receives a short-lived signing envelope, never the human's Ory
+cookies or tokens. The server verifies the already-computed digest with
+prehashing disabled; passing that digest through another SHA-256 operation
+would prove different bytes.
+
+The server method is tracked in
+[issue #1661](https://github.com/getlarge/themoltnet/issues/1661). Console and
+the production companion are later phases in the
+[human-signing epic](https://github.com/getlarge/themoltnet/issues/1629).
+
+## REST surface
+
+| Operation                     | Endpoint                                                      |
+| ----------------------------- | ------------------------------------------------------------- |
+| Create request                | `POST /crypto/signing-requests`                               |
+| List requested or signable    | `GET /crypto/signing-requests?scope=requested\|signable`      |
+| Get request                   | `GET /crypto/signing-requests/:id`                            |
+| Claim delegated request       | `POST /crypto/signing-requests/:id/claim`                     |
+| Complete delegated request    | `POST /crypto/signing-requests/:id/complete`                  |
+| Reject delegated request      | `POST /crypto/signing-requests/:id/reject`                    |
+| Submit legacy agent signature | `POST /crypto/signing-requests/:id/sign`                      |
+| Begin credential registration | `POST /crypto/signing-credentials/registrations`              |
+| Complete registration         | `POST /crypto/signing-credentials/registrations/:id/complete` |
+| List credentials              | `GET /crypto/signing-credentials`                             |
+| Get credential                | `GET /crypto/signing-credentials/:id`                         |
+| Approve, suspend, or revoke   | `POST /crypto/signing-credentials/:id/:action`                |
+
+Delegated and credential operations require the normal MoltNet team header.
+Claim and completion require an authenticated human session. Team credential
+management is authorized separately from request eligibility.
+
+## Security invariants
+
+- Private signing material never crosses the public API or enters Postgres.
+- The server owns the canonical bytes, nonce, purpose, team, expiry, audience,
+  verification method, and verifier state.
+- Claim atomically binds one eligible human and one active compatible
+  credential.
+- Completion is exactly once and rejects method mismatch, expiry, replay,
+  revoked credentials, wrong claimant, and malformed receipts.
+- A signature is accountability evidence. It is not by itself authorization to
+  execute a safety-critical action.
+- Credential and request data must not become public workforce-performance
+  aggregation.
+
+For the broader threat model, see
+[Mission Integrity](./mission-integrity.md). For service boundaries and the
+database model, see [Architecture](./architecture.md).


### PR DESCRIPTION
## Summary

- add one canonical signing architecture page covering current availability, stable verification methods, agent Ed25519 signing, delegated signing credentials/requests, and the planned previewSign integration
- document the REST surface and security invariants while clearly separating production behavior from planned hardware support
- link the canonical page from the docs sidebar and replace the stale Ed25519-only architecture section/file references
- separately repair the invalid previewSign Mermaid source in the #1629 issue body

## Verification

- `pnpm exec nx run @moltnet/docs:lint`
- `pnpm exec nx run @moltnet/docs:typecheck`
- `pnpm exec nx run @moltnet/docs:build --skipNxCache`
- local Mermaid parse validation for all signing diagrams and the corrected #1629 diagram

Diary: `9e2fce33-a951-4752-a390-61499c30d311`