### PR TITLE
refactor: centralize security-sensitive runtime contracts

### DIFF
--- a/apps/rest-api/__tests__/require-keto-subject.test.ts
+++ b/apps/rest-api/__tests__/require-keto-subject.test.ts
@@ -1,0 +1,49 @@
+import { type AuthContext, KetoNamespace } from '@moltnet/auth';
+import { describe, expect, it } from 'vitest';
+
+import { requireKetoSubject } from '../src/utils/require-keto-subject.js';
+
+function authContext(subjectType: AuthContext['subjectType']): AuthContext {
+  const base = {
+    identityId: `${subjectType}-identity`,
+    scopes: [],
+    currentTeamId: null,
+  };
+
+  return subjectType === 'human'
+    ? {
+        ...base,
+        subjectType,
+        clientId: null,
+        humanId: 'human-id',
+      }
+    : {
+        ...base,
+        subjectType,
+        clientId: 'agent-client',
+        publicKey: 'public-key',
+        fingerprint: 'fingerprint',
+      };
+}
+
+describe('requireKetoSubject', () => {
+  it.each([
+    ['agent', KetoNamespace.Agent],
+    ['human', KetoNamespace.Human],
+  ] as const)('maps a %s caller to its Keto namespace', (type, namespace) => {
+    expect(requireKetoSubject({ authContext: authContext(type) })).toEqual({
+      identityId: `${type}-identity`,
+      subjectType: type,
+      subjectNs: namespace,
+    });
+  });
+
+  it('rejects a request without an authentication context', () => {
+    expect(() => requireKetoSubject({})).toThrow(
+      expect.objectContaining({
+        statusCode: 401,
+        detail: 'Authentication context missing',
+      }),
+    );
+  });
+});

--- a/apps/rest-api/public/openapi.json
+++ b/apps/rest-api/public/openapi.json
@@ -2354,7 +2354,8 @@
                 ],
                 "type": "string"
               }
-            ]
+            ],
+            "description": "Runtime tool-policy enforcement mode: off (inert), watch (audit only), enforce (block disallowed tools, fail-closed)."
           },
           "topK": {
             "anyOf": [
@@ -8702,7 +8703,8 @@
                 ],
                 "type": "string"
               }
-            ]
+            ],
+            "description": "Runtime tool-policy enforcement mode: off (inert), watch (audit only), enforce (block disallowed tools, fail-closed)."
           },
           "topK": {
             "anyOf": [
@@ -9367,7 +9369,8 @@
                       ],
                       "type": "string"
                     }
-                  ]
+                  ],
+                  "description": "Runtime tool-policy enforcement mode: off (inert), watch (audit only), enforce (block disallowed tools, fail-closed)."
                 },
                 "topK": {
                   "anyOf": [
@@ -13957,7 +13960,8 @@
                 ],
                 "type": "string"
               }
-            ]
+            ],
+            "description": "Runtime tool-policy enforcement mode: off (inert), watch (audit only), enforce (block disallowed tools, fail-closed)."
           },
           "topK": {
             "anyOf": [

--- a/apps/rest-api/src/routes/agent-keys.ts
+++ b/apps/rest-api/src/routes/agent-keys.ts
@@ -3,7 +3,7 @@ import {
   type AgentKeySubject,
   createAgentKeyService,
 } from '@moltnet/agent-key-service';
-import { KetoNamespace, requireAuth } from '@moltnet/auth';
+import { requireAuth } from '@moltnet/auth';
 import {
   ProblemDetailsSchema,
   TeamHeaderRequiredSchema,
@@ -24,6 +24,7 @@ import {
 } from '../schemas.js';
 import { requestAbortSignal } from '../utils/request-abort-signal.js';
 import { requireCurrentTeamId } from '../utils/require-current-team-id.js';
+import { requireKetoSubject } from '../utils/require-keto-subject.js';
 
 interface AgentKeyRoutesOptions {
   talosApi?: Pick<
@@ -40,13 +41,10 @@ function authSubject(request: FastifyRequest): AgentKeySubject {
   const auth = request.authContext;
   if (!auth) throw createProblem('unauthorized');
   return {
-    identityId: auth.identityId,
+    ...requireKetoSubject(request),
     ...(auth.subjectType === 'agent' && auth.credentialBinding
       ? { credentialKeyId: auth.credentialBinding.keyId }
       : {}),
-    subjectType: auth.subjectType,
-    subjectNs:
-      auth.subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent,
   };
 }
 

--- a/apps/rest-api/src/routes/diary-entries.ts
+++ b/apps/rest-api/src/routes/diary-entries.ts
@@ -3,7 +3,7 @@
  */
 
 import type { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
-import { KetoNamespace, requireAuth } from '@moltnet/auth';
+import { type KetoNamespace, requireAuth } from '@moltnet/auth';
 import { computeContentCid } from '@moltnet/crypto-service';
 import type { RelationAtDepth } from '@moltnet/database';
 import type { ListInput, ListTagsInput } from '@moltnet/diary-service';
@@ -42,6 +42,7 @@ import {
   batchInflateRowsWithCreator,
   rowToResponseWithCreator,
 } from '../utils/auth-principal.js';
+import { requireKetoSubject } from '../utils/require-keto-subject.js';
 
 const queryTagSchema = Type.String({
   minLength: 1,
@@ -152,9 +153,7 @@ export async function diaryEntryRoutes(fastify: FastifyInstance) {
         contentHash,
         signingRequestId,
       } = request.body;
-      const { identityId: agentId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId: agentId, subjectNs } = requireKetoSubject(request);
 
       try {
         let contentSignature: string | undefined;
@@ -317,9 +316,7 @@ export async function diaryEntryRoutes(fastify: FastifyInstance) {
       const { diaryId } = request.params;
       const { limit, offset, ids, tags, excludeTags, entryType } =
         request.query;
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       let diary: Awaited<ReturnType<typeof fastify.diaryService.findDiary>>;
       try {
@@ -397,9 +394,7 @@ export async function diaryEntryRoutes(fastify: FastifyInstance) {
     async (request) => {
       const { diaryId } = request.params;
       const { prefix, minCount, entryTypes } = request.query;
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       try {
         const tags = await fastify.diaryService.listTags(
@@ -604,9 +599,7 @@ export async function diaryEntryRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
       const entry = await getEntry(
         request.params.entryId,
         identityId,
@@ -660,9 +653,7 @@ export async function diaryEntryRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
       return verifyEntry(request.params.entryId, identityId, subjectNs);
     },
   );
@@ -690,9 +681,7 @@ export async function diaryEntryRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       // Defense in depth: Ajv's removeAdditional can strip unknown keys
       // before minProperties is evaluated, so guard explicitly against a
@@ -740,9 +729,7 @@ export async function diaryEntryRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
       return fastify.diaryService.deleteEntries(
         request.body.ids,
         identityId,
@@ -772,9 +759,7 @@ export async function diaryEntryRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
       return deleteEntry(request.params.entryId, identityId, subjectNs);
     },
   );
@@ -846,9 +831,7 @@ export async function diaryEntryRoutes(fastify: FastifyInstance) {
         excludeSuperseded,
       } = request.body;
 
-      const { identityId: agentId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId: agentId, subjectNs } = requireKetoSubject(request);
       const searchInput = {
         diaryId,
         query,

--- a/apps/rest-api/src/routes/diary.ts
+++ b/apps/rest-api/src/routes/diary.ts
@@ -46,6 +46,7 @@ import {
   inflateCreator,
   rowToResponseWithCreator,
 } from '../utils/auth-principal.js';
+import { requireKetoSubject } from '../utils/require-keto-subject.js';
 import {
   diaryTransferWorkflow,
   TRANSFER_DECISION_EVENT,
@@ -107,9 +108,7 @@ export async function diaryRoutes(fastify: FastifyInstance) {
       },
     },
     async (request, reply) => {
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
       const { name, visibility } = request.body;
 
       const teamId = request.authContext!.currentTeamId;
@@ -210,9 +209,7 @@ export async function diaryRoutes(fastify: FastifyInstance) {
     },
     async (request) => {
       const { id } = request.params;
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
       try {
         const diary = await fastify.diaryService.findDiary(
           id,
@@ -261,9 +258,7 @@ export async function diaryRoutes(fastify: FastifyInstance) {
     },
     async (request) => {
       const { id } = request.params;
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       // Defense in depth: Ajv's removeAdditional can strip unknown keys
       // before minProperties is evaluated, so guard explicitly against a
@@ -321,9 +316,7 @@ export async function diaryRoutes(fastify: FastifyInstance) {
     },
     async (request) => {
       const { id } = request.params;
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       try {
         const deleted = await fastify.diaryService.deleteDiary(
@@ -368,9 +361,7 @@ export async function diaryRoutes(fastify: FastifyInstance) {
     },
     async (request, reply) => {
       const { id } = request.params;
-      const { identityId, subjectType } = request.authContext!;
-      const callerNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs: callerNs } = requireKetoSubject(request);
 
       const canManage = await fastify.permissionChecker.canManageDiary(
         id,
@@ -453,9 +444,7 @@ export async function diaryRoutes(fastify: FastifyInstance) {
     },
     async (request) => {
       const { id } = request.params;
-      const { identityId, subjectType } = request.authContext!;
-      const callerNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs: callerNs } = requireKetoSubject(request);
 
       const canRead = await fastify.permissionChecker.canReadDiary(
         id,
@@ -499,9 +488,7 @@ export async function diaryRoutes(fastify: FastifyInstance) {
     },
     async (request) => {
       const { id } = request.params;
-      const { identityId, subjectType } = request.authContext!;
-      const callerNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs: callerNs } = requireKetoSubject(request);
 
       const canManage = await fastify.permissionChecker.canManageDiary(
         id,
@@ -560,9 +547,7 @@ export async function diaryRoutes(fastify: FastifyInstance) {
     },
     async (request, reply) => {
       const { id } = request.params;
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       // Must have diary manage permission
       const canManage = await fastify.permissionChecker.canManageDiary(
@@ -710,9 +695,7 @@ export async function diaryRoutes(fastify: FastifyInstance) {
     },
     async (request, reply) => {
       const { transferId } = request.params;
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       const transfer =
         await fastify.diaryTransferRepository.findById(transferId);
@@ -773,9 +756,7 @@ export async function diaryRoutes(fastify: FastifyInstance) {
     },
     async (request, reply) => {
       const { transferId } = request.params;
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       const transfer =
         await fastify.diaryTransferRepository.findById(transferId);

--- a/apps/rest-api/src/routes/entry-relations.ts
+++ b/apps/rest-api/src/routes/entry-relations.ts
@@ -8,7 +8,7 @@
  */
 
 import type { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
-import { KetoNamespace, requireAuth } from '@moltnet/auth';
+import { requireAuth } from '@moltnet/auth';
 import type { EntryRelation } from '@moltnet/database';
 import { EntryParamsSchema, ProblemDetailsSchema } from '@moltnet/models';
 import type { FastifyInstance } from 'fastify';
@@ -23,6 +23,7 @@ import {
   type RelationType,
   RelationTypeSchema,
 } from '../schemas.js';
+import { requireKetoSubject } from '../utils/require-keto-subject.js';
 
 /**
  * Map a DB EntryRelation row to the API response shape.
@@ -118,9 +119,7 @@ export async function entryRelationRoutes(fastify: FastifyInstance) {
       },
     },
     async (request, reply) => {
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
       const { entryId } = request.params;
       const { targetId, relation, status = 'proposed' } = request.body;
 
@@ -205,9 +204,7 @@ export async function entryRelationRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
       const { entryId } = request.params;
       const {
         relation,
@@ -288,9 +285,7 @@ export async function entryRelationRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
       const { id } = request.params;
       const { status } = request.body;
 
@@ -344,9 +339,7 @@ export async function entryRelationRoutes(fastify: FastifyInstance) {
       },
     },
     async (request, reply) => {
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
       const { id } = request.params;
 
       const relation = await fastify.entryRelationRepository.findById(id);

--- a/apps/rest-api/src/routes/groups.ts
+++ b/apps/rest-api/src/routes/groups.ts
@@ -28,6 +28,7 @@ import { Type } from 'typebox';
 
 import { createConflictProblem, createProblem } from '../problems/index.js';
 import { authContextToCreator } from '../utils/auth-principal.js';
+import { requireKetoSubject } from '../utils/require-keto-subject.js';
 
 // ── Routes ─────────────────────────────────────────────────────
 
@@ -59,9 +60,7 @@ export async function groupRoutes(fastify: FastifyInstance) {
     },
     async (request, reply) => {
       const { id } = request.params;
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       const canManageMembers =
         await fastify.permissionChecker.canManageTeamMembers(
@@ -150,9 +149,7 @@ export async function groupRoutes(fastify: FastifyInstance) {
     },
     async (request) => {
       const { id } = request.params;
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       const canAccess = await fastify.permissionChecker.canAccessTeam(
         id,
@@ -194,9 +191,7 @@ export async function groupRoutes(fastify: FastifyInstance) {
     },
     async (request) => {
       const { groupId } = request.params;
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       const group = await fastify.groupRepository.findById(groupId);
       if (!group) throw createProblem('not-found');
@@ -245,9 +240,7 @@ export async function groupRoutes(fastify: FastifyInstance) {
     },
     async (request, reply) => {
       const { groupId } = request.params;
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       const group = await fastify.groupRepository.findById(groupId);
       if (!group) throw createProblem('not-found');
@@ -297,9 +290,7 @@ export async function groupRoutes(fastify: FastifyInstance) {
     },
     async (request, reply) => {
       const { groupId } = request.params;
-      const { identityId, subjectType } = request.authContext!;
-      const callerNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs: callerNs } = requireKetoSubject(request);
 
       const group = await fastify.groupRepository.findById(groupId);
       if (!group) throw createProblem('not-found');
@@ -362,9 +353,7 @@ export async function groupRoutes(fastify: FastifyInstance) {
     },
     async (request) => {
       const { groupId } = request.params;
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       const group = await fastify.groupRepository.findById(groupId);
       if (!group) throw createProblem('not-found');
@@ -409,9 +398,7 @@ export async function groupRoutes(fastify: FastifyInstance) {
     },
     async (request, reply) => {
       const { groupId, subjectId } = request.params;
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       const group = await fastify.groupRepository.findById(groupId);
       if (!group) throw createProblem('not-found');

--- a/apps/rest-api/src/routes/packs.ts
+++ b/apps/rest-api/src/routes/packs.ts
@@ -1,5 +1,5 @@
 import type { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
-import { KetoNamespace, requireAuth } from '@moltnet/auth';
+import { requireAuth } from '@moltnet/auth';
 import {
   compress,
   type CompressionLevel,
@@ -38,6 +38,7 @@ import {
   PackUpdateBodySchema,
 } from '../schemas.js';
 import { authContextToCreator } from '../utils/auth-principal.js';
+import { requireKetoSubject } from '../utils/require-keto-subject.js';
 import { buildPackProvenanceGraph } from './pack-provenance.js';
 
 interface SelectedEntry {
@@ -344,16 +345,13 @@ export async function packRoutes(fastify: FastifyInstance) {
     },
     persist: boolean,
   ) => {
-    const subjectNs =
-      request.authContext.subjectType === 'human'
-        ? KetoNamespace.Human
-        : KetoNamespace.Agent;
+    const { identityId, subjectNs } = requireKetoSubject(request);
 
     let diary: Awaited<ReturnType<typeof fastify.diaryService.findDiary>>;
     try {
       diary = await fastify.diaryService.findDiary(
         request.params.id,
-        request.authContext.identityId,
+        identityId,
         subjectNs,
       );
     } catch (err) {
@@ -521,9 +519,7 @@ export async function packRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       let pack;
       try {
@@ -581,9 +577,7 @@ export async function packRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       let pack;
       try {
@@ -640,9 +634,7 @@ export async function packRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       try {
         return await fastify.contextPackService.diffPacks({
@@ -680,9 +672,7 @@ export async function packRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       try {
         return await fastify.contextPackService.diffPacks({
@@ -720,9 +710,7 @@ export async function packRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       if (request.query.diaryId && request.query.containsEntry) {
         throw createProblem(
@@ -825,9 +813,7 @@ export async function packRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       try {
         return await fastify.contextPackService.getPackById({
@@ -937,9 +923,7 @@ export async function packRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       try {
         return await fastify.contextPackService.listPacksByDiary({
@@ -982,9 +966,7 @@ export async function packRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       const pack = await fastify.contextPackRepository.findById(
         request.params.id,

--- a/apps/rest-api/src/routes/rendered-packs.ts
+++ b/apps/rest-api/src/routes/rendered-packs.ts
@@ -1,5 +1,5 @@
 import type { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
-import { KetoNamespace, requireAuth } from '@moltnet/auth';
+import { requireAuth } from '@moltnet/auth';
 import { PackServiceError } from '@moltnet/context-pack-service';
 import {
   ConflictProblemDetailsSchema,
@@ -22,6 +22,7 @@ import {
   RenderPackPreviewBodySchema,
 } from '../schemas.js';
 import { authContextToCreator } from '../utils/auth-principal.js';
+import { requireKetoSubject } from '../utils/require-keto-subject.js';
 
 function translatePackServiceError(err: PackServiceError): never {
   switch (err.code) {
@@ -76,9 +77,7 @@ export async function renderedPackRoutes(fastify: FastifyInstance) {
           ? request.body.renderedMarkdown
           : undefined;
 
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       try {
         const canRead = await fastify.permissionChecker.canReadPack(
@@ -146,9 +145,7 @@ export async function renderedPackRoutes(fastify: FastifyInstance) {
           ? request.body.renderedMarkdown
           : undefined;
 
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       try {
         const canWrite = await fastify.permissionChecker.canWritePack(
@@ -212,9 +209,7 @@ export async function renderedPackRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       try {
         return await fastify.contextPackService.getLatestRenderedPack({
@@ -264,9 +259,7 @@ export async function renderedPackRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       try {
         return await fastify.contextPackService.listRenderedPacksByDiary({
@@ -307,9 +300,7 @@ export async function renderedPackRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       try {
         return await fastify.contextPackService.getRenderedPackById({
@@ -357,9 +348,7 @@ export async function renderedPackRoutes(fastify: FastifyInstance) {
       }
 
       // Permission check via source pack
-      const { identityId, subjectType } = request.authContext!;
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
       const allowed = await fastify.permissionChecker.canManagePack(
         rendered.sourcePackId,
         identityId,

--- a/apps/rest-api/src/routes/runtime-models.ts
+++ b/apps/rest-api/src/routes/runtime-models.ts
@@ -1,5 +1,5 @@
 import { type TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
-import { KetoNamespace, requireAuth, TEAM_HEADER } from '@moltnet/auth';
+import { requireAuth, TEAM_HEADER } from '@moltnet/auth';
 import type { RuntimeModel } from '@moltnet/database';
 import { UniqueViolationError } from '@moltnet/database';
 import {
@@ -19,23 +19,7 @@ import {
   UpdateRuntimeModelBodySchema,
 } from '../schemas.js';
 import { authContextToCreator } from '../utils/auth-principal.js';
-
-function authSubject(request: {
-  authContext: {
-    identityId: string;
-    subjectType: 'agent' | 'human';
-    currentTeamId: string | null;
-  } | null;
-}) {
-  const auth = request.authContext;
-  if (!auth)
-    throw createProblem('unauthorized', 'Authentication context missing');
-  return {
-    identityId: auth.identityId,
-    subjectNs:
-      auth.subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent,
-  };
-}
+import { requireKetoSubject } from '../utils/require-keto-subject.js';
 
 /**
  * `x-moltnet-team-id` is optional for the catalog: without it, only global
@@ -140,7 +124,7 @@ export async function runtimeModelRoutes(fastify: FastifyInstance) {
           `${TEAM_HEADER} header is required: runtime model creation is team-scoped`,
         );
       }
-      const { identityId, subjectNs } = authSubject(request);
+      const { identityId, subjectNs } = requireKetoSubject(request);
       const canManage = await fastify.permissionChecker.canManageTeamRuntime(
         teamId,
         identityId,
@@ -204,7 +188,7 @@ export async function runtimeModelRoutes(fastify: FastifyInstance) {
       // Team-scoped entries: caller must be able to access the team.
       // Global entries: any authenticated caller can read.
       if (row.teamId) {
-        const { identityId, subjectNs } = authSubject(request);
+        const { identityId, subjectNs } = requireKetoSubject(request);
         const canAccess = await fastify.permissionChecker.canAccessTeam(
           row.teamId,
           identityId,
@@ -248,7 +232,7 @@ export async function runtimeModelRoutes(fastify: FastifyInstance) {
           'Global catalog entries are not modifiable via the public API',
         );
       }
-      const { identityId, subjectNs } = authSubject(request);
+      const { identityId, subjectNs } = requireKetoSubject(request);
       const canManage = await fastify.permissionChecker.canManageTeamRuntime(
         existing.teamId,
         identityId,
@@ -325,7 +309,7 @@ export async function runtimeModelRoutes(fastify: FastifyInstance) {
           'Global catalog entries are not deletable via the public API',
         );
       }
-      const { identityId, subjectNs } = authSubject(request);
+      const { identityId, subjectNs } = requireKetoSubject(request);
       const canManage = await fastify.permissionChecker.canManageTeamRuntime(
         existing.teamId,
         identityId,

--- a/apps/rest-api/src/routes/runtime-policies.ts
+++ b/apps/rest-api/src/routes/runtime-policies.ts
@@ -1,5 +1,5 @@
 import { type TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
-import { KetoNamespace, requireAuth } from '@moltnet/auth';
+import { requireAuth } from '@moltnet/auth';
 import { UniqueViolationError } from '@moltnet/database';
 import {
   ConflictProblemDetailsSchema,
@@ -7,14 +7,11 @@ import {
   TeamHeaderRequiredSchema,
   ValidationProblemDetailsSchema,
 } from '@moltnet/models';
-import {
-  createRuntimePolicyService,
-  type RuntimePolicySubject,
-} from '@moltnet/runtime-policy-service';
-import type { FastifyInstance, FastifyRequest } from 'fastify';
+import { createRuntimePolicyService } from '@moltnet/runtime-policy-service';
+import type { FastifyInstance } from 'fastify';
 import { type Static, Type } from 'typebox';
 
-import { createConflictProblem, createProblem } from '../problems/index.js';
+import { createConflictProblem } from '../problems/index.js';
 import {
   AllowedToolsResponseSchema,
   CreateRuntimePolicyBodySchema,
@@ -25,6 +22,7 @@ import {
   UpdateRuntimePolicyBodySchema,
 } from '../schemas.js';
 import { requireCurrentTeamId } from '../utils/require-current-team-id.js';
+import { requireKetoSubject } from '../utils/require-keto-subject.js';
 
 const PolicyParamsSchema = Type.Object(
   { policyId: Type.String({ format: 'uuid' }) },
@@ -41,17 +39,6 @@ const SECURITY: Array<Record<string, string[]>> = [
   { sessionAuth: [] },
   { cookieAuth: [] },
 ];
-
-function authSubject(request: FastifyRequest): RuntimePolicySubject {
-  const auth = request.authContext;
-  if (!auth) throw createProblem('unauthorized');
-  return {
-    identityId: auth.identityId,
-    subjectType: auth.subjectType,
-    subjectNs:
-      auth.subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent,
-  };
-}
 
 export async function runtimePolicyRoutes(fastify: FastifyInstance) {
   const server = fastify.withTypeProvider<TypeBoxTypeProvider>();
@@ -94,7 +81,7 @@ export async function runtimePolicyRoutes(fastify: FastifyInstance) {
           name: body.name,
           description: body.description,
           tools: body.tools ?? [],
-          subject: authSubject(request),
+          subject: requireKetoSubject(request),
         });
         return await reply.status(201).send(policy);
       } catch (err) {
@@ -133,7 +120,7 @@ export async function runtimePolicyRoutes(fastify: FastifyInstance) {
       const teamId = requireCurrentTeamId(request, 'runtime policies');
       const items = await policies.list({
         teamId,
-        subject: authSubject(request),
+        subject: requireKetoSubject(request),
       });
       return { items };
     },
@@ -165,7 +152,7 @@ export async function runtimePolicyRoutes(fastify: FastifyInstance) {
       const teamId = requireCurrentTeamId(request, 'runtime policies');
       return policies.get(request.params.policyId, {
         teamId,
-        subject: authSubject(request),
+        subject: requireKetoSubject(request),
       });
     },
   );
@@ -198,7 +185,7 @@ export async function runtimePolicyRoutes(fastify: FastifyInstance) {
       try {
         return await policies.update(request.params.policyId, body, {
           teamId,
-          subject: authSubject(request),
+          subject: requireKetoSubject(request),
         });
       } catch (err) {
         if (err instanceof UniqueViolationError) {
@@ -235,7 +222,7 @@ export async function runtimePolicyRoutes(fastify: FastifyInstance) {
       const teamId = requireCurrentTeamId(request, 'runtime policies');
       await policies.delete(request.params.policyId, {
         teamId,
-        subject: authSubject(request),
+        subject: requireKetoSubject(request),
       });
       return reply.status(204).send(null);
     },
@@ -267,7 +254,7 @@ export async function runtimePolicyRoutes(fastify: FastifyInstance) {
       const teamId = requireCurrentTeamId(request, 'runtime policies');
       return policies.getProfilePolicies(request.params.profileId, {
         teamId,
-        subject: authSubject(request),
+        subject: requireKetoSubject(request),
       });
     },
   );
@@ -300,7 +287,7 @@ export async function runtimePolicyRoutes(fastify: FastifyInstance) {
       await policies.setProfilePolicies(
         request.params.profileId,
         body.policyIds,
-        { teamId, subject: authSubject(request) },
+        { teamId, subject: requireKetoSubject(request) },
       );
       return reply.status(204).send(null);
     },

--- a/apps/rest-api/src/routes/runtime-profiles.ts
+++ b/apps/rest-api/src/routes/runtime-profiles.ts
@@ -1,5 +1,5 @@
 import { type TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
-import { KetoNamespace, requireAuth } from '@moltnet/auth';
+import { requireAuth } from '@moltnet/auth';
 import { computeJsonCid } from '@moltnet/crypto-service';
 import type { RuntimeProfile as RuntimeProfile } from '@moltnet/database';
 import { UniqueViolationError } from '@moltnet/database';
@@ -29,28 +29,12 @@ import {
 } from '../schemas.js';
 import { authContextToCreator } from '../utils/auth-principal.js';
 import { requireCurrentTeamId } from '../utils/require-current-team-id.js';
+import { requireKetoSubject } from '../utils/require-keto-subject.js';
 
 const ProfileParamsSchema = Type.Object(
   { profileId: Type.String({ format: 'uuid' }) },
   { $id: 'RuntimeProfileParams' },
 );
-
-function authSubject(request: {
-  authContext: {
-    identityId: string;
-    subjectType: 'agent' | 'human';
-    currentTeamId: string | null;
-  } | null;
-}) {
-  const auth = request.authContext;
-  if (!auth)
-    throw createProblem('unauthorized', 'Authentication context missing');
-  return {
-    identityId: auth.identityId,
-    subjectNs:
-      auth.subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent,
-  };
-}
 
 function normalizeList(values: readonly string[] | undefined): string[] {
   return [...new Set((values ?? []).map((v) => v.trim()).filter(Boolean))];
@@ -297,7 +281,7 @@ export async function runtimeProfileRoutes(fastify: FastifyInstance) {
     },
     async (request) => {
       const teamId = requireCurrentTeamId(request, 'runtime profiles');
-      const { identityId, subjectNs } = authSubject(request);
+      const { identityId, subjectNs } = requireKetoSubject(request);
       const canAccess = await fastify.permissionChecker.canAccessTeam(
         teamId,
         identityId,
@@ -333,7 +317,7 @@ export async function runtimeProfileRoutes(fastify: FastifyInstance) {
     },
     async (request, reply) => {
       const teamId = requireCurrentTeamId(request, 'runtime profiles');
-      const { identityId, subjectNs } = authSubject(request);
+      const { identityId, subjectNs } = requireKetoSubject(request);
       const canManage = await fastify.permissionChecker.canManageTeamRuntime(
         teamId,
         identityId,
@@ -425,7 +409,7 @@ export async function runtimeProfileRoutes(fastify: FastifyInstance) {
         request.params.profileId,
       );
       if (!row) throw createProblem('not-found');
-      const { identityId, subjectNs } = authSubject(request);
+      const { identityId, subjectNs } = requireKetoSubject(request);
       const canAccess = await fastify.permissionChecker.canAccessTeam(
         row.teamId,
         identityId,
@@ -462,7 +446,7 @@ export async function runtimeProfileRoutes(fastify: FastifyInstance) {
         request.params.profileId,
       );
       if (!existing) throw createProblem('not-found');
-      const { identityId, subjectNs } = authSubject(request);
+      const { identityId, subjectNs } = requireKetoSubject(request);
       const canManage = await fastify.permissionChecker.canManageTeamRuntime(
         existing.teamId,
         identityId,
@@ -577,7 +561,7 @@ export async function runtimeProfileRoutes(fastify: FastifyInstance) {
         request.params.profileId,
       );
       if (!row) throw createProblem('not-found');
-      const { identityId, subjectNs } = authSubject(request);
+      const { identityId, subjectNs } = requireKetoSubject(request);
       const canManage = await fastify.permissionChecker.canManageTeamRuntime(
         row.teamId,
         identityId,

--- a/apps/rest-api/src/routes/runtime-sessions.ts
+++ b/apps/rest-api/src/routes/runtime-sessions.ts
@@ -1,5 +1,5 @@
 import { type TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
-import { KetoNamespace, requireAuth } from '@moltnet/auth';
+import { requireAuth } from '@moltnet/auth';
 import {
   ProblemDetailsSchema,
   TeamHeaderRequiredSchema,
@@ -19,25 +19,7 @@ import type { FastifyInstance } from 'fastify';
 
 import { createProblem } from '../problems/index.js';
 import { requireCurrentTeamId } from '../utils/require-current-team-id.js';
-
-function authSubject(request: {
-  authContext: {
-    identityId: string;
-    subjectType: 'agent' | 'human';
-    currentTeamId: string | null;
-  } | null;
-}) {
-  const auth = request.authContext;
-  if (!auth) {
-    throw createProblem('unauthorized', 'Authentication context missing');
-  }
-  return {
-    identityId: auth.identityId,
-    subjectNs:
-      auth.subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent,
-    subjectType: auth.subjectType,
-  };
-}
+import { requireKetoSubject } from '../utils/require-keto-subject.js';
 
 export async function runtimeSessionRoutes(fastify: FastifyInstance) {
   const server = fastify.withTypeProvider<TypeBoxTypeProvider>();
@@ -95,7 +77,8 @@ export async function runtimeSessionRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectNs, subjectType } = authSubject(request);
+      const { identityId, subjectNs, subjectType } =
+        requireKetoSubject(request);
       if (subjectType !== 'agent') {
         throw createProblem(
           'forbidden',
@@ -141,7 +124,7 @@ export async function runtimeSessionRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectNs } = authSubject(request);
+      const { identityId, subjectNs } = requireKetoSubject(request);
       const session = await runtimeSessions.getMetadata({
         attemptN: request.params.attemptN,
         identityId,
@@ -186,7 +169,7 @@ export async function runtimeSessionRoutes(fastify: FastifyInstance) {
       },
     },
     async (request, reply) => {
-      const { identityId, subjectNs } = authSubject(request);
+      const { identityId, subjectNs } = requireKetoSubject(request);
       const { object, session, stream } = await runtimeSessions.download({
         attemptN: request.params.attemptN,
         identityId,

--- a/apps/rest-api/src/routes/runtime-slots.ts
+++ b/apps/rest-api/src/routes/runtime-slots.ts
@@ -1,5 +1,5 @@
 import { type TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
-import { KetoNamespace, requireAuth } from '@moltnet/auth';
+import { requireAuth } from '@moltnet/auth';
 import {
   ConflictProblemDetailsSchema,
   ProblemDetailsSchema,
@@ -24,25 +24,7 @@ import {
   serializeRuntimeSlot,
 } from '../services/runtime-slots.js';
 import { requireCurrentTeamId } from '../utils/require-current-team-id.js';
-
-function authSubject(request: {
-  authContext: {
-    identityId: string;
-    subjectType: 'agent' | 'human';
-    currentTeamId: string | null;
-  } | null;
-}) {
-  const auth = request.authContext;
-  if (!auth) {
-    throw createProblem('unauthorized', 'Authentication context missing');
-  }
-  return {
-    identityId: auth.identityId,
-    subjectNs:
-      auth.subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent,
-    subjectType: auth.subjectType,
-  };
-}
+import { requireKetoSubject } from '../utils/require-keto-subject.js';
 
 export async function runtimeSlotRoutes(fastify: FastifyInstance) {
   const server = fastify.withTypeProvider<TypeBoxTypeProvider>();
@@ -78,7 +60,8 @@ export async function runtimeSlotRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectNs, subjectType } = authSubject(request);
+      const { identityId, subjectNs, subjectType } =
+        requireKetoSubject(request);
       if (subjectType !== 'agent') {
         throw createProblem(
           'forbidden',
@@ -120,7 +103,8 @@ export async function runtimeSlotRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectNs, subjectType } = authSubject(request);
+      const { identityId, subjectNs, subjectType } =
+        requireKetoSubject(request);
       if (subjectType !== 'agent') {
         throw createProblem(
           'forbidden',
@@ -163,7 +147,7 @@ export async function runtimeSlotRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectNs } = authSubject(request);
+      const { identityId, subjectNs } = requireKetoSubject(request);
       const teamId = requireCurrentTeamId(request, 'runtime slots');
       const items = await runtimeSlots.list({
         identityId,
@@ -200,7 +184,7 @@ export async function runtimeSlotRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectNs } = authSubject(request);
+      const { identityId, subjectNs } = requireKetoSubject(request);
       const teamId = requireCurrentTeamId(request, 'runtime slots');
       const resolved = await runtimeSlots.findLatest({
         identityId,

--- a/apps/rest-api/src/routes/task-artifacts.ts
+++ b/apps/rest-api/src/routes/task-artifacts.ts
@@ -1,5 +1,5 @@
 import { type TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
-import { KetoNamespace, requireAuth } from '@moltnet/auth';
+import { requireAuth } from '@moltnet/auth';
 import {
   ConflictProblemDetailsSchema,
   ProblemDetailsSchema,
@@ -33,25 +33,7 @@ import {
   createValidationProblem,
 } from '../problems/index.js';
 import { requireCurrentTeamId } from '../utils/require-current-team-id.js';
-
-function authSubject(request: {
-  authContext: {
-    identityId: string;
-    subjectType: 'agent' | 'human';
-    currentTeamId: string | null;
-  } | null;
-}) {
-  const auth = request.authContext;
-  if (!auth) {
-    throw createProblem('unauthorized', 'Authentication context missing');
-  }
-  return {
-    identityId: auth.identityId,
-    subjectNs:
-      auth.subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent,
-    subjectType: auth.subjectType,
-  };
-}
+import { requireKetoSubject } from '../utils/require-keto-subject.js';
 
 function toArtifactProblem(
   error: TaskArtifactServiceError,
@@ -148,7 +130,8 @@ export async function taskArtifactRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectNs, subjectType } = authSubject(request);
+      const { identityId, subjectNs, subjectType } =
+        requireKetoSubject(request);
       if (subjectType !== 'agent') {
         throw createProblem(
           'forbidden',
@@ -221,7 +204,7 @@ export async function taskArtifactRoutes(fastify: FastifyInstance) {
     async (request) => {
       // Unlike attempt-output uploads, staging is open to humans: task
       // proposers (Diary write) may be human and attach inputs via the API.
-      const { identityId, subjectNs } = authSubject(request);
+      const { identityId, subjectNs } = requireKetoSubject(request);
       try {
         return await taskArtifacts.stageUpload({
           body: request.body,
@@ -268,7 +251,7 @@ export async function taskArtifactRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectNs } = authSubject(request);
+      const { identityId, subjectNs } = requireKetoSubject(request);
       try {
         const result = await taskArtifacts.listForTask({
           cursor: request.query.cursor,
@@ -345,7 +328,7 @@ export async function taskArtifactRoutes(fastify: FastifyInstance) {
       },
     },
     async (request, reply) => {
-      const { identityId, subjectNs } = authSubject(request);
+      const { identityId, subjectNs } = requireKetoSubject(request);
       try {
         const { artifact, stream } = await taskArtifacts.downloadForTask({
           cid: request.params.cid,
@@ -424,7 +407,7 @@ export async function taskArtifactRoutes(fastify: FastifyInstance) {
       },
     },
     async (request, reply) => {
-      const { identityId, subjectNs } = authSubject(request);
+      const { identityId, subjectNs } = requireKetoSubject(request);
       try {
         const { artifact, stream } = await taskArtifacts.download({
           attemptN: request.params.attemptN,

--- a/apps/rest-api/src/routes/tasks.ts
+++ b/apps/rest-api/src/routes/tasks.ts
@@ -53,6 +53,7 @@ import {
 import { TaskServiceError } from '../services/task.service.js';
 import { authContextToCreator } from '../utils/auth-principal.js';
 import { requireCurrentTeamId } from '../utils/require-current-team-id.js';
+import { requireKetoSubject } from '../utils/require-keto-subject.js';
 import { startTaskDeletionWorkflow } from '../workflows/index.js';
 
 type BatchDeleteTasksBody = Static<typeof BatchDeleteTasksBodySchema>;
@@ -104,19 +105,6 @@ function toTaskAnalyticsProblem(error: TaskAnalyticsServiceError) {
         error.message,
       );
   }
-}
-
-function getAuthContext(request: {
-  authContext: {
-    identityId: string;
-    subjectType: 'agent' | 'human';
-  } | null;
-}) {
-  const authContext = request.authContext;
-  if (!authContext) {
-    throw createProblem('unauthorized', 'Authentication context missing');
-  }
-  return authContext;
 }
 
 function rate(numerator: number, denominator: number): number {
@@ -351,10 +339,12 @@ export function taskRoutes(fastify: FastifyInstance) {
       },
     },
     async (request, reply) => {
-      const { identityId, subjectType } = getAuthContext(request);
+      const {
+        identityId,
+        subjectNs: callerNs,
+        subjectType,
+      } = requireKetoSubject(request);
       const teamId = requireCurrentTeamId(request, 'tasks');
-      const callerNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
       try {
         const normalised = normalizeTaskCreateRequest(request.body);
         await validateAllowedProfiles(
@@ -418,10 +408,8 @@ export function taskRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectType } = getAuthContext(request);
+      const { identityId, subjectNs: callerNs } = requireKetoSubject(request);
       const teamId = requireCurrentTeamId(request, 'tasks');
-      const callerNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
       try {
         return await fastify.taskService.list({
           teamId,
@@ -475,9 +463,11 @@ export function taskRoutes(fastify: FastifyInstance) {
       },
     },
     async (request, reply) => {
-      const { identityId, subjectType } = getAuthContext(request);
-      const callerNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const {
+        identityId,
+        subjectNs: callerNs,
+        subjectType,
+      } = requireKetoSubject(request);
       try {
         const force = request.body.force ?? false;
         const plan = await fastify.taskService.planDeleteMany({
@@ -629,10 +619,8 @@ export function taskRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectType } = getAuthContext(request);
+      const { identityId, subjectNs: callerNs } = requireKetoSubject(request);
       const teamId = requireCurrentTeamId(request, 'task analytics');
-      const callerNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
       const completedBefore = request.query.completedBefore
         ? new Date(request.query.completedBefore)
         : new Date();
@@ -686,9 +674,7 @@ export function taskRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectType } = getAuthContext(request);
-      const callerNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs: callerNs } = requireKetoSubject(request);
       try {
         return await fastify.taskService.get(
           request.params.id,
@@ -724,9 +710,7 @@ export function taskRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectType } = getAuthContext(request);
-      const callerNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs: callerNs } = requireKetoSubject(request);
       try {
         return await fastify.taskService.updateMetadata(request.params.id, {
           ...('title' in request.body ? { title: request.body.title } : {}),
@@ -777,9 +761,7 @@ export function taskRoutes(fastify: FastifyInstance) {
       },
     },
     async (request, reply) => {
-      const { identityId, subjectType } = getAuthContext(request);
-      const callerNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs: callerNs } = requireKetoSubject(request);
       try {
         const result = await fastify.taskService.claim(
           request.params.id,
@@ -832,9 +814,7 @@ export function taskRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectType } = getAuthContext(request);
-      const callerNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs: callerNs } = requireKetoSubject(request);
       try {
         return await fastify.taskService.heartbeat(
           request.params.id,
@@ -873,9 +853,7 @@ export function taskRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectType } = getAuthContext(request);
-      const callerNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs: callerNs } = requireKetoSubject(request);
       try {
         return await fastify.taskService.complete(
           request.params.id,
@@ -923,9 +901,7 @@ export function taskRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectType } = getAuthContext(request);
-      const callerNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs: callerNs } = requireKetoSubject(request);
       try {
         return await fastify.taskService.failAttempt(
           request.params.id,
@@ -967,9 +943,7 @@ export function taskRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectType } = getAuthContext(request);
-      const callerNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs: callerNs } = requireKetoSubject(request);
       try {
         return await fastify.taskService.abort(
           request.params.id,
@@ -1007,9 +981,7 @@ export function taskRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectType } = getAuthContext(request);
-      const callerNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs: callerNs } = requireKetoSubject(request);
       try {
         return await fastify.taskService.cancel(
           request.params.id,
@@ -1050,9 +1022,7 @@ export function taskRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectType } = getAuthContext(request);
-      const callerNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs: callerNs } = requireKetoSubject(request);
       try {
         return await fastify.taskService.listAttempts(
           request.params.id,
@@ -1090,9 +1060,7 @@ export function taskRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectType } = getAuthContext(request);
-      const callerNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs: callerNs } = requireKetoSubject(request);
       try {
         return await fastify.taskService.listMessages(
           request.params.id,
@@ -1133,9 +1101,7 @@ export function taskRoutes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { identityId, subjectType } = getAuthContext(request);
-      const callerNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs: callerNs } = requireKetoSubject(request);
       try {
         return await fastify.taskService.appendMessages(
           request.params.id,

--- a/apps/rest-api/src/routes/teams.ts
+++ b/apps/rest-api/src/routes/teams.ts
@@ -49,6 +49,7 @@ import { Type } from 'typebox';
 
 import { createProblem } from '../problems/index.js';
 import { authContextToCreator } from '../utils/auth-principal.js';
+import { requireKetoSubject } from '../utils/require-keto-subject.js';
 import {
   FOUNDING_ACCEPT_EVENT,
   teamFoundingWorkflow,
@@ -270,9 +271,7 @@ export function teamRoutes(fastify: FastifyInstance) {
       },
     },
     async (request, reply) => {
-      const { identityId, subjectType } = getAuthContext(request);
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
       const { name, foundingMembers } = request.body;
 
       const creator = authContextToCreator(request);
@@ -453,9 +452,7 @@ export function teamRoutes(fastify: FastifyInstance) {
     },
     async (request) => {
       const { id } = request.params;
-      const { identityId, subjectType } = getAuthContext(request);
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       const canAccess = await fastify.permissionChecker.canAccessTeam(
         id,
@@ -507,9 +504,7 @@ export function teamRoutes(fastify: FastifyInstance) {
     },
     async (request, reply) => {
       const { id } = request.params;
-      const { identityId, subjectType } = getAuthContext(request);
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       const canManage = await fastify.permissionChecker.canManageTeam(
         id,
@@ -574,9 +569,7 @@ export function teamRoutes(fastify: FastifyInstance) {
     },
     async (request) => {
       const { id } = request.params;
-      const { identityId, subjectType } = getAuthContext(request);
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       const canAccess = await fastify.permissionChecker.canAccessTeam(
         id,
@@ -616,9 +609,7 @@ export function teamRoutes(fastify: FastifyInstance) {
     },
     async (request, reply) => {
       const { id, subjectId } = request.params;
-      const { identityId, subjectType } = getAuthContext(request);
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       const canManageMembers =
         await fastify.permissionChecker.canManageTeamMembers(
@@ -699,9 +690,7 @@ export function teamRoutes(fastify: FastifyInstance) {
     },
     async (request, reply) => {
       const { id, subjectId } = request.params;
-      const { identityId, subjectType } = getAuthContext(request);
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       const canManageMembers =
         await fastify.permissionChecker.canManageTeamMembers(
@@ -761,9 +750,7 @@ export function teamRoutes(fastify: FastifyInstance) {
     },
     async (request, reply) => {
       const { id } = request.params;
-      const { identityId, subjectType } = getAuthContext(request);
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       const canManageMembers =
         await fastify.permissionChecker.canManageTeamMembers(
@@ -823,9 +810,7 @@ export function teamRoutes(fastify: FastifyInstance) {
     },
     async (request) => {
       const { id } = request.params;
-      const { identityId, subjectType } = getAuthContext(request);
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       const canManageMembers =
         await fastify.permissionChecker.canManageTeamMembers(
@@ -872,9 +857,7 @@ export function teamRoutes(fastify: FastifyInstance) {
     },
     async (request, reply) => {
       const { id, inviteId } = request.params;
-      const { identityId, subjectType } = getAuthContext(request);
-      const subjectNs =
-        subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent;
+      const { identityId, subjectNs } = requireKetoSubject(request);
 
       const canManageMembers =
         await fastify.permissionChecker.canManageTeamMembers(
@@ -914,8 +897,7 @@ export function teamRoutes(fastify: FastifyInstance) {
       },
     },
     async (request, reply) => {
-      const authContext = getAuthContext(request);
-      const { identityId } = authContext;
+      const { identityId, subjectNs: ns } = requireKetoSubject(request);
       const { code } = request.body;
 
       const invite = await fastify.teamRepository.findInviteByCode(code);
@@ -955,10 +937,6 @@ export function teamRoutes(fastify: FastifyInstance) {
         throw createProblem('invite-exhausted');
       }
 
-      const ns =
-        authContext.subjectType === 'human'
-          ? KetoNamespace.Human
-          : KetoNamespace.Agent;
       try {
         if (existingMember) {
           await rewriteTeamRole(

--- a/apps/rest-api/src/schemas/runtime-policies.ts
+++ b/apps/rest-api/src/schemas/runtime-policies.ts
@@ -1,4 +1,7 @@
-import { UuidSchema } from '@moltnet/models';
+import {
+  ToolEnforcementSchema as CanonicalToolEnforcementSchema,
+  UuidSchema,
+} from '@moltnet/models';
 import { Type } from 'typebox';
 
 const TOOL_NAME_PATTERN = '^[a-zA-Z0-9_.:-]{1,128}$';
@@ -10,14 +13,10 @@ const ToolNameSchema = Type.String({
   description: 'A tool identifier, e.g. an executable name like "git".',
 });
 
-export const ToolEnforcementSchema = Type.Union(
-  [Type.Literal('off'), Type.Literal('watch'), Type.Literal('enforce')],
-  {
-    $id: 'ToolEnforcement',
-    description:
-      'Runtime tool-policy enforcement mode: off (inert), watch (audit only), enforce (block disallowed tools, fail-closed).',
-  },
-);
+export const ToolEnforcementSchema = {
+  ...CanonicalToolEnforcementSchema,
+  $id: 'ToolEnforcement',
+};
 
 export const RuntimePolicySchema = Type.Object(
   {

--- a/apps/rest-api/src/utils/require-keto-subject.ts
+++ b/apps/rest-api/src/utils/require-keto-subject.ts
@@ -1,0 +1,30 @@
+import { KetoNamespace, type SubjectType } from '@moltnet/auth';
+
+import { createProblem } from '../problems/index.js';
+
+export interface KetoSubject {
+  identityId: string;
+  subjectType: SubjectType;
+  subjectNs: KetoNamespace;
+}
+
+interface AuthenticatedRequest {
+  authContext?: {
+    identityId: string;
+    subjectType: SubjectType;
+  } | null;
+}
+
+export function requireKetoSubject(request: AuthenticatedRequest): KetoSubject {
+  const auth = request.authContext;
+  if (!auth) {
+    throw createProblem('unauthorized', 'Authentication context missing');
+  }
+
+  return {
+    identityId: auth.identityId,
+    subjectType: auth.subjectType,
+    subjectNs:
+      auth.subjectType === 'human' ? KetoNamespace.Human : KetoNamespace.Agent,
+  };
+}

--- a/libs/api-client/src/generated/types.gen.ts
+++ b/libs/api-client/src/generated/types.gen.ts
@@ -574,6 +574,9 @@ export type CreateRuntimeProfileBody = {
     | 'high'
     | 'xhigh'
     | null;
+  /**
+   * Runtime tool-policy enforcement mode: off (inert), watch (audit only), enforce (block disallowed tools, fail-closed).
+   */
   toolEnforcement?: 'off' | 'watch' | 'enforce';
   topK?: number | null;
   topP?: null | number;
@@ -2045,6 +2048,9 @@ export type RuntimeProfile = {
   teamId: string;
   temperature: null | number;
   thinkingLevel: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | null;
+  /**
+   * Runtime tool-policy enforcement mode: off (inert), watch (audit only), enforce (block disallowed tools, fail-closed).
+   */
   toolEnforcement: 'off' | 'watch' | 'enforce';
   topK: number | null;
   topP: null | number;
@@ -2139,6 +2145,9 @@ export type RuntimeProfileListResponse = {
       | 'high'
       | 'xhigh'
       | null;
+    /**
+     * Runtime tool-policy enforcement mode: off (inert), watch (audit only), enforce (block disallowed tools, fail-closed).
+     */
     toolEnforcement: 'off' | 'watch' | 'enforce';
     topK: number | null;
     topP: null | number;
@@ -2966,6 +2975,9 @@ export type UpdateRuntimeProfileBody = {
     | 'high'
     | 'xhigh'
     | null;
+  /**
+   * Runtime tool-policy enforcement mode: off (inert), watch (audit only), enforce (block disallowed tools, fail-closed).
+   */
   toolEnforcement?: 'off' | 'watch' | 'enforce';
   topK?: number | null;
   topP?: null | number;

--- a/libs/database/src/repositories/runtime-policy.repository.ts
+++ b/libs/database/src/repositories/runtime-policy.repository.ts
@@ -1,3 +1,4 @@
+import type { ToolEnforcement } from '@moltnet/models';
 import { and, eq, inArray, sql } from 'drizzle-orm';
 
 import type { Database } from '../db.js';
@@ -10,7 +11,7 @@ import {
 import { getExecutor } from '../transaction-context.js';
 import { translateUniqueViolation } from '../unique-violation.js';
 
-export type ToolEnforcement = 'off' | 'watch' | 'enforce';
+export type { ToolEnforcement } from '@moltnet/models';
 
 /** Hard cap on a single team's policy listing (bounds response size). */
 export const RUNTIME_POLICY_LIST_LIMIT = 500;
@@ -168,7 +169,7 @@ export function createRuntimePolicyRepository(db: Database) {
           ),
         )
         .limit(1);
-      return row ? (row.toolEnforcement as ToolEnforcement) : null;
+      return row?.toolEnforcement ?? null;
     },
 
     /** Team-scoped existence check used before binding policies to a profile. */

--- a/libs/database/src/schema/runtime-profiles.ts
+++ b/libs/database/src/schema/runtime-profiles.ts
@@ -1,3 +1,4 @@
+import { TOOL_ENFORCEMENT_VALUES, type ToolEnforcement } from '@moltnet/models';
 import { sql } from 'drizzle-orm';
 import type { AnyPgColumn } from 'drizzle-orm/pg-core';
 import {
@@ -22,6 +23,10 @@ interface RuntimeProfileSchemaDeps {
   runtimeKindEnum: PgEnum<['gondolin_pi']>;
   storageModeEnum: PgEnum<['local']>;
 }
+
+const toolEnforcementSqlArray = sql.raw(
+  `ARRAY[${TOOL_ENFORCEMENT_VALUES.map((mode) => `'${mode}'`).join(',')}]::text[]`,
+);
 
 export function defineRuntimeProfilesTable({
   agents,
@@ -83,6 +88,7 @@ export function defineRuntimeProfilesTable({
         .notNull()
         .default(sql`'{}'::text[]`),
       toolEnforcement: varchar('tool_enforcement', { length: 16 })
+        .$type<ToolEnforcement>()
         .notNull()
         .default('off'),
       context: jsonb('context')
@@ -171,7 +177,7 @@ export function defineRuntimeProfilesTable({
       ),
       check(
         'runtime_profiles_tool_enforcement_valid',
-        sql`tool_enforcement = ANY(ARRAY['off','watch','enforce']::text[])`,
+        sql`tool_enforcement = ANY(${toolEnforcementSqlArray})`,
       ),
     ],
   );

--- a/libs/models/__tests__/schemas.test.ts
+++ b/libs/models/__tests__/schemas.test.ts
@@ -11,6 +11,8 @@ import {
   PaginatedResponseSchema,
   PublicKeySchema,
   SignRequestSchema,
+  TOOL_ENFORCEMENT_VALUES,
+  ToolEnforcementSchema,
   UpdateDiaryEntrySchema,
   VerifyRequestSchema,
   VisibilitySchema,
@@ -30,6 +32,18 @@ beforeAll(() => {
 });
 
 describe('Common schemas', () => {
+  describe('ToolEnforcementSchema', () => {
+    it('accepts every canonical enforcement mode', () => {
+      for (const mode of TOOL_ENFORCEMENT_VALUES) {
+        expect(Value.Check(ToolEnforcementSchema, mode)).toBe(true);
+      }
+    });
+
+    it('rejects values outside the canonical enforcement modes', () => {
+      expect(Value.Check(ToolEnforcementSchema, 'audit')).toBe(false);
+    });
+  });
+
   describe('PublicKeySchema', () => {
     it('accepts valid ed25519 keys', () => {
       expect(Value.Check(PublicKeySchema, 'ed25519:AAAA+/bbbb==')).toBe(true);

--- a/libs/models/package.json
+++ b/libs/models/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": {
       "import": "./src/index.ts",
-      "types": "./src/index.ts"
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
     },
     "./verification-method": {
       "import": "./src/verification-method.ts",

--- a/libs/models/src/index.ts
+++ b/libs/models/src/index.ts
@@ -11,4 +11,5 @@ export * from './provenance-graph.js';
 export * from './schemas.js';
 export * from './signer-constraint.js';
 export * from './signer-protocol.js';
+export * from './tool-enforcement.js';
 export * from './verification-method.js';

--- a/libs/models/src/tool-enforcement.ts
+++ b/libs/models/src/tool-enforcement.ts
@@ -1,0 +1,20 @@
+import { type Static, Type } from 'typebox';
+
+export const TOOL_ENFORCEMENT_VALUES = ['off', 'watch', 'enforce'] as const;
+
+const toolEnforcementLiterals = [
+  Type.Literal(TOOL_ENFORCEMENT_VALUES[0]),
+  Type.Literal(TOOL_ENFORCEMENT_VALUES[1]),
+  Type.Literal(TOOL_ENFORCEMENT_VALUES[2]),
+] satisfies [
+  ReturnType<typeof Type.Literal<'off'>>,
+  ReturnType<typeof Type.Literal<'watch'>>,
+  ReturnType<typeof Type.Literal<'enforce'>>,
+];
+
+export const ToolEnforcementSchema = Type.Union(toolEnforcementLiterals, {
+  description:
+    'Runtime tool-policy enforcement mode: off (inert), watch (audit only), enforce (block disallowed tools, fail-closed).',
+});
+
+export type ToolEnforcement = Static<typeof ToolEnforcementSchema>;

--- a/libs/moltnet-api-client/oas_schemas_gen.go
+++ b/libs/moltnet-api-client/oas_schemas_gen.go
@@ -6164,11 +6164,13 @@ type CreateRuntimeProfileBody struct {
 	SessionTtlSec         OptInt                                              `json:"sessionTtlSec"`
 	Temperature           OptNilFloat64                                       `json:"temperature"`
 	ThinkingLevel         OptNilCreateRuntimeProfileBodyThinkingLevel         `json:"thinkingLevel"`
-	ToolEnforcement       OptCreateRuntimeProfileBodyToolEnforcement          `json:"toolEnforcement"`
-	TopK                  OptNilInt                                           `json:"topK"`
-	TopP                  OptNilFloat64                                       `json:"topP"`
-	WorkspaceStorageMode  OptCreateRuntimeProfileBodyWorkspaceStorageMode     `json:"workspaceStorageMode"`
-	WorkspaceTtlSec       OptInt                                              `json:"workspaceTtlSec"`
+	// Runtime tool-policy enforcement mode: off (inert), watch (audit only), enforce (block disallowed
+	// tools, fail-closed).
+	ToolEnforcement      OptCreateRuntimeProfileBodyToolEnforcement      `json:"toolEnforcement"`
+	TopK                 OptNilInt                                       `json:"topK"`
+	TopP                 OptNilFloat64                                   `json:"topP"`
+	WorkspaceStorageMode OptCreateRuntimeProfileBodyWorkspaceStorageMode `json:"workspaceStorageMode"`
+	WorkspaceTtlSec      OptInt                                          `json:"workspaceTtlSec"`
 }
 
 // GetAllowedWorkspaceModes returns the value of AllowedWorkspaceModes.
@@ -7203,6 +7205,8 @@ func (s *CreateRuntimeProfileBodyThinkingLevel) UnmarshalText(data []byte) error
 	}
 }
 
+// Runtime tool-policy enforcement mode: off (inert), watch (audit only), enforce (block disallowed
+// tools, fail-closed).
 type CreateRuntimeProfileBodyToolEnforcement string
 
 const (
@@ -45241,12 +45245,14 @@ type RuntimeProfile struct {
 	TeamId                uuid.UUID                                 `json:"teamId"`
 	Temperature           NilFloat64                                `json:"temperature"`
 	ThinkingLevel         NilRuntimeProfileThinkingLevel            `json:"thinkingLevel"`
-	ToolEnforcement       RuntimeProfileToolEnforcement             `json:"toolEnforcement"`
-	TopK                  NilInt                                    `json:"topK"`
-	TopP                  NilFloat64                                `json:"topP"`
-	UpdatedAt             time.Time                                 `json:"updatedAt"`
-	WorkspaceStorageMode  RuntimeProfileWorkspaceStorageMode        `json:"workspaceStorageMode"`
-	WorkspaceTtlSec       int                                       `json:"workspaceTtlSec"`
+	// Runtime tool-policy enforcement mode: off (inert), watch (audit only), enforce (block disallowed
+	// tools, fail-closed).
+	ToolEnforcement      RuntimeProfileToolEnforcement      `json:"toolEnforcement"`
+	TopK                 NilInt                             `json:"topK"`
+	TopP                 NilFloat64                         `json:"topP"`
+	UpdatedAt            time.Time                          `json:"updatedAt"`
+	WorkspaceStorageMode RuntimeProfileWorkspaceStorageMode `json:"workspaceStorageMode"`
+	WorkspaceTtlSec      int                                `json:"workspaceTtlSec"`
 }
 
 // GetAllowedWorkspaceModes returns the value of AllowedWorkspaceModes.
@@ -45826,12 +45832,14 @@ type RuntimeProfileListResponseItemsItem struct {
 	TeamId                uuid.UUID                                                      `json:"teamId"`
 	Temperature           NilFloat64                                                     `json:"temperature"`
 	ThinkingLevel         NilRuntimeProfileListResponseItemsItemThinkingLevel            `json:"thinkingLevel"`
-	ToolEnforcement       RuntimeProfileListResponseItemsItemToolEnforcement             `json:"toolEnforcement"`
-	TopK                  NilInt                                                         `json:"topK"`
-	TopP                  NilFloat64                                                     `json:"topP"`
-	UpdatedAt             time.Time                                                      `json:"updatedAt"`
-	WorkspaceStorageMode  RuntimeProfileListResponseItemsItemWorkspaceStorageMode        `json:"workspaceStorageMode"`
-	WorkspaceTtlSec       int                                                            `json:"workspaceTtlSec"`
+	// Runtime tool-policy enforcement mode: off (inert), watch (audit only), enforce (block disallowed
+	// tools, fail-closed).
+	ToolEnforcement      RuntimeProfileListResponseItemsItemToolEnforcement      `json:"toolEnforcement"`
+	TopK                 NilInt                                                  `json:"topK"`
+	TopP                 NilFloat64                                              `json:"topP"`
+	UpdatedAt            time.Time                                               `json:"updatedAt"`
+	WorkspaceStorageMode RuntimeProfileListResponseItemsItemWorkspaceStorageMode `json:"workspaceStorageMode"`
+	WorkspaceTtlSec      int                                                     `json:"workspaceTtlSec"`
 }
 
 // GetAllowedWorkspaceModes returns the value of AllowedWorkspaceModes.
@@ -46946,6 +46954,8 @@ func (s *RuntimeProfileListResponseItemsItemThinkingLevel) UnmarshalText(data []
 	}
 }
 
+// Runtime tool-policy enforcement mode: off (inert), watch (audit only), enforce (block disallowed
+// tools, fail-closed).
 type RuntimeProfileListResponseItemsItemToolEnforcement string
 
 const (
@@ -47646,6 +47656,8 @@ func (s *RuntimeProfileThinkingLevel) UnmarshalText(data []byte) error {
 	}
 }
 
+// Runtime tool-policy enforcement mode: off (inert), watch (audit only), enforce (block disallowed
+// tools, fail-closed).
 type RuntimeProfileToolEnforcement string
 
 const (
@@ -54749,11 +54761,13 @@ type UpdateRuntimeProfileBody struct {
 	SessionTtlSec         OptInt                                              `json:"sessionTtlSec"`
 	Temperature           OptNilFloat64                                       `json:"temperature"`
 	ThinkingLevel         OptNilUpdateRuntimeProfileBodyThinkingLevel         `json:"thinkingLevel"`
-	ToolEnforcement       OptUpdateRuntimeProfileBodyToolEnforcement          `json:"toolEnforcement"`
-	TopK                  OptNilInt                                           `json:"topK"`
-	TopP                  OptNilFloat64                                       `json:"topP"`
-	WorkspaceStorageMode  OptUpdateRuntimeProfileBodyWorkspaceStorageMode     `json:"workspaceStorageMode"`
-	WorkspaceTtlSec       OptInt                                              `json:"workspaceTtlSec"`
+	// Runtime tool-policy enforcement mode: off (inert), watch (audit only), enforce (block disallowed
+	// tools, fail-closed).
+	ToolEnforcement      OptUpdateRuntimeProfileBodyToolEnforcement      `json:"toolEnforcement"`
+	TopK                 OptNilInt                                       `json:"topK"`
+	TopP                 OptNilFloat64                                   `json:"topP"`
+	WorkspaceStorageMode OptUpdateRuntimeProfileBodyWorkspaceStorageMode `json:"workspaceStorageMode"`
+	WorkspaceTtlSec      OptInt                                          `json:"workspaceTtlSec"`
 }
 
 // GetAllowedWorkspaceModes returns the value of AllowedWorkspaceModes.
@@ -55788,6 +55802,8 @@ func (s *UpdateRuntimeProfileBodyThinkingLevel) UnmarshalText(data []byte) error
 	}
 }
 
+// Runtime tool-policy enforcement mode: off (inert), watch (audit only), enforce (block disallowed
+// tools, fail-closed).
 type UpdateRuntimeProfileBodyToolEnforcement string
 
 const (

--- a/libs/pi-extension/package.json
+++ b/libs/pi-extension/package.json
@@ -48,14 +48,14 @@
   "dependencies": {
     "@earendil-works/gondolin": "catalog:",
     "@opentelemetry/api": "catalog:",
-    "typebox": "catalog:",
     "@themoltnet/agent-runtime": "workspace:*",
     "@themoltnet/sdk": "workspace:*",
-    "@themoltnet/shell-command-analyzer": "workspace:*"
+    "@themoltnet/shell-command-analyzer": "workspace:*",
+    "typebox": "catalog:"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": ">=0.74.0",
-    "@earendil-works/pi-ai": ">=0.74.0"
+    "@earendil-works/pi-ai": ">=0.74.0",
+    "@earendil-works/pi-coding-agent": ">=0.74.0"
   },
   "peerDependenciesMeta": {
     "@earendil-works/pi-coding-agent": {
@@ -66,9 +66,10 @@
     }
   },
   "devDependencies": {
-    "@moltnet/crypto-service": "workspace:*",
     "@earendil-works/pi-ai": "catalog:",
     "@earendil-works/pi-coding-agent": "catalog:",
+    "@moltnet/crypto-service": "workspace:*",
+    "@moltnet/models": "workspace:*",
     "@opentelemetry/sdk-metrics": "catalog:",
     "@opentelemetry/sdk-trace-base": "catalog:",
     "@types/node": "catalog:",

--- a/libs/pi-extension/src/tool-policy/gate.ts
+++ b/libs/pi-extension/src/tool-policy/gate.ts
@@ -1,10 +1,10 @@
+import type { ToolEnforcement } from '@moltnet/models';
 import type {
   CommandAnalysis,
   RiskTier,
 } from '@themoltnet/shell-command-analyzer';
 
-/** Enforcement mode resolved for the session's runtime profile. */
-export type ToolEnforcement = 'off' | 'watch' | 'enforce';
+export type { ToolEnforcement } from '@moltnet/models';
 
 export interface GateInput {
   /** Pi tool name (e.g. 'bash', 'read', 'write', or a custom tool id). */

--- a/libs/pi-extension/tsconfig.lib.json
+++ b/libs/pi-extension/tsconfig.lib.json
@@ -23,13 +23,16 @@
   "include": ["src"],
   "references": [
     {
-      "path": "../sdk/tsconfig.lib.json"
-    },
-    {
       "path": "../shell-command-analyzer/tsconfig.lib.json"
     },
     {
+      "path": "../sdk/tsconfig.lib.json"
+    },
+    {
       "path": "../agent-runtime/tsconfig.lib.json"
+    },
+    {
+      "path": "../models/tsconfig.lib.json"
     },
     {
       "path": "../crypto-service/tsconfig.lib.json"

--- a/libs/pi-extension/vite.config.ts
+++ b/libs/pi-extension/vite.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   plugins: [
     dts({
       rollupTypes: true,
+      bundledPackages: ['@moltnet/models'],
       tsconfigPath: './tsconfig.lib.json',
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts'],

--- a/libs/runtime-policy-service/src/runtime-policy-service.ts
+++ b/libs/runtime-policy-service/src/runtime-policy-service.ts
@@ -7,13 +7,13 @@ import type {
 import type {
   RuntimePolicy as RuntimePolicyRow,
   RuntimePolicyRepository,
-  ToolEnforcement,
   TransactionRunner,
 } from '@moltnet/database';
+import type { ToolEnforcement } from '@moltnet/models';
 
 import { createProblem, createValidationProblem } from './problems.js';
 
-export type { ToolEnforcement };
+export type { ToolEnforcement } from '@moltnet/models';
 
 const TOOL_NAME_RE = /^[a-zA-Z0-9_.:-]{1,128}$/;
 const MAX_DESCRIPTION_LENGTH = 4096;

--- a/libs/tasks/package.json
+++ b/libs/tasks/package.json
@@ -21,8 +21,9 @@
     "dev": "tsc --watch"
   },
   "dependencies": {
-    "typebox": "catalog:",
-    "multiformats": "catalog:"
+    "@moltnet/models": "workspace:*",
+    "multiformats": "catalog:",
+    "typebox": "catalog:"
   },
   "devDependencies": {
     "typescript": "catalog:",

--- a/libs/tasks/src/runtime-profiles.ts
+++ b/libs/tasks/src/runtime-profiles.ts
@@ -1,3 +1,4 @@
+import { type ToolEnforcement, ToolEnforcementSchema } from '@moltnet/models';
 import { type Static, Type } from 'typebox';
 
 export const RuntimeProfileName = Type.String({
@@ -35,14 +36,8 @@ export type RuntimeProfileWorkspaceMode = Static<
  * `off` (inert), `watch` (audit only), `enforce` (block disallowed tools,
  * fail-closed). Read by the daemon via `GET /runtime-profiles/:id/allowed-tools`.
  */
-export const RuntimeProfileToolEnforcement = Type.Union([
-  Type.Literal('off'),
-  Type.Literal('watch'),
-  Type.Literal('enforce'),
-]);
-export type RuntimeProfileToolEnforcement = Static<
-  typeof RuntimeProfileToolEnforcement
->;
+export const RuntimeProfileToolEnforcement = ToolEnforcementSchema;
+export type RuntimeProfileToolEnforcement = ToolEnforcement;
 
 export const RuntimeProfileAllowedWorkspaceModes = Type.Array(
   RuntimeProfileWorkspaceMode,

--- a/libs/tasks/tsconfig.lib.json
+++ b/libs/tasks/tsconfig.lib.json
@@ -19,5 +19,9 @@
   ],
   "extends": "./tsconfig.json",
   "include": ["src/**/*.ts"],
-  "references": []
+  "references": [
+    {
+      "path": "../models/tsconfig.lib.json"
+    }
+  ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2142,6 +2142,9 @@ importers:
       '@moltnet/crypto-service':
         specifier: workspace:*
         version: link:../crypto-service
+      '@moltnet/models':
+        specifier: workspace:*
+        version: link:../models
       '@opentelemetry/sdk-metrics':
         specifier: 'catalog:'
         version: 2.5.1(@opentelemetry/api@1.9.0)
@@ -2493,6 +2496,9 @@ importers:
 
   libs/tasks:
     dependencies:
+      '@moltnet/models':
+        specifier: workspace:*
+        version: link:../models
       multiformats:
         specifier: 'catalog:'
         version: 13.4.2


### PR DESCRIPTION
Closes #1684

## Summary

- establish `@moltnet/models` as the canonical source for `off`/`watch`/`enforce` and derive REST, database, task, runtime, Pi, and generated-client representations
- add `requireKetoSubject` and migrate all 82 duplicated auth-context-to-Keto namespace mappings across 15 REST route modules
- preserve publishability and tooling compatibility with an embeddable anonymous schema, REST-only OpenAPI `$id`, a drizzle-kit default-export fallback, and bundled Pi declarations

## Why

The security-sensitive enforcement and authorization contracts were independently redeclared across layers, allowing subtle drift and inconsistent missing-auth behavior.

## Validation

- REST typecheck, lint, and 630/630 tests
- affected models, tasks, database, runtime-policy, Pi, and API-client builds, typechecks, lints, and tests
- `pnpm db:generate` — no schema changes
- Pi `check:pack`, loader bundle, and loader smoke test
- TypeScript and Go client regeneration
- `moltnet-api-client:lint` — 0 issues with golangci-lint 2.12.2
- Go client `go test ./...`
- both commits verified with LeGreffier SSH signatures
