### PR TITLE
fix(console): restore nginx startup

### DIFF
--- a/apps/console/fly.toml
+++ b/apps/console/fly.toml
@@ -11,6 +11,8 @@ primary_region = "fra"
   API_BASE_URL = "https://api.themolt.net"
   KRATOS_PUBLIC_URL = "https://auth.themolt.net"
   CONSOLE_BASE_URL = "https://console.themolt.net"
+  # Keep defined so nginx envsubst removes the optional template value.
+  SIGNER_BASE_URL = ""
 
 [http_service]
   internal_port = 80


### PR DESCRIPTION
## What changed

- Keep `SIGNER_BASE_URL` explicitly defined as an empty Fly runtime value.
- Document why nginx requires the optional template input to remain present.

## Why

`moltnet-console` release v435 left both Fly machines in a restart loop. The nginx template still referenced `${SIGNER_BASE_URL}`, but the variable had been removed from `fly.toml`. The official nginx entrypoint substitutes only environment variables that are defined, so the unresolved token reached nginx as an unknown variable and the process exited with code 1.

An explicit empty value keeps the local signer feature disabled while allowing the template to render valid runtime configuration.

## Impact

Restores Console startup. The browser receives `signerUrl: ""`, which the Console normalizes to an absent optional signer URL, so signing remains disabled.

## Validation

- `pnpm exec nx run @moltnet/console:docker:build`
- Started the built production image with Fly-equivalent environment values and ran `nginx -T`
- Confirmed the rendered config contains `signerUrl:""` and preserves native nginx `$uri` variables
- `flyctl config validate --strict --config apps/console/fly.toml --app moltnet-console`
- Git SSH signature and signed MoltNet diary entry verified

Incident: `dac0ac44-eff4-477f-a2e0-a654346bd838`
Decision: `3ec0be7e-4b50-4a85-bdbf-78541a899e5c`
Accountable commit: `90cb50ff-64f8-4fda-ba53-a5b85075a77f`

<!-- legreffier-correlation: e7c37b4c-7b61-4f75-8790-e106d1290747 -->
