### PR TITLE
fix(pi): retry provider 5xx errors in-session

### DIFF
--- a/libs/pi-extension/src/runtime/execute-pi-task.test.ts
+++ b/libs/pi-extension/src/runtime/execute-pi-task.test.ts
@@ -147,6 +147,11 @@ describe('provider error same-session retry helpers', () => {
 
   it('retries generic and transient provider diagnostics', () => {
     expect(shouldRetryProviderErrorMessage(null)).toBe(true);
+    expect(
+      shouldRetryProviderErrorMessage(
+        '500 "Internal Server Error (ref: 0405cf74-1a7c-4dba-90eb-380ba278f306)"',
+      ),
+    ).toBe(true);
     expect(shouldRetryProviderErrorMessage('provider returned 503')).toBe(true);
     expect(shouldRetryProviderErrorMessage('request timed out')).toBe(true);
     expect(shouldRetryProviderErrorMessage('EAI_AGAIN DNS lookup failed')).toBe(
@@ -246,7 +251,8 @@ describe('provider error same-session retry helpers', () => {
           prompts.length === 1
             ? {
                 llmAbort: true,
-                llmErrorMessage: 'provider returned 503 unavailable',
+                llmErrorMessage:
+                  '500 "Internal Server Error (ref: 0405cf74-1a7c-4dba-90eb-380ba278f306)"',
               }
             : { llmAbort: false, llmErrorMessage: null };
       },

--- a/libs/pi-extension/src/runtime/execute-pi-task.ts
+++ b/libs/pi-extension/src/runtime/execute-pi-task.ts
@@ -1984,7 +1984,7 @@ const PROVIDER_ERROR_NON_RETRYABLE_PATTERNS = [
 
 const PROVIDER_ERROR_RETRYABLE_PATTERNS = [
   /\b429\b/i,
-  /\b5(?:02|03|04)\b/i,
+  /\b5\d{2}\b/i,
   /\btimeout\b/i,
   /\btimed out\b/i,
   /\brate limit/i,


### PR DESCRIPTION
## Summary

- treat every provider HTTP 5xx response as retryable in the bounded, same-session Pi retry layer
- add the exact observed `500 Internal Server Error` diagnostic as regression coverage
- verify the continuation prompt reuses the active session after that 500

## Why

The provider retry matcher explicitly covered 502, 503, and 504 but omitted a bare 500. A transient provider-side 500 could therefore terminate an attempt after substantial completed work. Retrying in the active Pi session preserves that context and remains bounded by the existing provider retry budget and exponential backoff.

Known authentication, billing, and model-configuration failures are still classified as non-retryable before the 5xx matcher runs.

## Validation

- `pnpm exec nx run @themoltnet/pi-extension:test-ci--src/runtime/execute-pi-task.test.ts --skipNxCache` — 99 tests passed
- pre-commit affected lint and formatting checks passed
- commit SSH signature verified for `legreffier[bot]`

Fixes #1706