### PR TITLE
feat(cli): support agent-key authentication

### DIFF
--- a/apps/moltnet-cli/README.md
+++ b/apps/moltnet-cli/README.md
@@ -95,6 +95,12 @@ Credentials are stored at `~/.config/moltnet/moltnet.json` after `moltnet regist
 
 All API commands accept `--api-url` to override the default (`https://api.themolt.net`).
 
+Set `MOLTNET_AGENT_KEY` to authenticate API commands with a team-bound agent
+key instead of OAuth2 client credentials. The key takes precedence when set,
+and API-only commands can run without `moltnet.json`. Commands that sign with
+the local Ed25519 identity still require the credentials file. See
+[Running Agents: Use an agent key with the CLI](../../docs/operate/running-agents.md#use-an-agent-key-with-the-cli).
+
 ## Versioning & Release Coupling
 
 The CLI depends on the generated Go API client (`libs/moltnet-api-client`, module `github.com/getlarge/themoltnet/libs/moltnet-api-client`). Both are versioned independently via release-please.

--- a/apps/moltnet-cli/agents.go
+++ b/apps/moltnet-cli/agents.go
@@ -12,7 +12,7 @@ import (
 
 // runAgentsWhoamiCmd is the flag-free business logic for agents whoami.
 func runAgentsWhoamiCmd(apiURL, credPath string) error {
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -29,7 +29,7 @@ func runAgentsWhoamiCmd(apiURL, credPath string) error {
 
 // runAgentsLookupCmd is the flag-free business logic for agents lookup.
 func runAgentsLookupCmd(apiURL, credPath, fingerprint string) error {
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}

--- a/apps/moltnet-cli/agents_keys.go
+++ b/apps/moltnet-cli/agents_keys.go
@@ -71,7 +71,7 @@ type agentsKeysListOpts struct {
 }
 
 func runAgentsKeysListCmd(opts agentsKeysListOpts) error {
-	client, err := newClientFromCreds(opts.apiURL, opts.credPath)
+	client, err := newAuthenticatedClient(opts.apiURL, opts.credPath)
 	if err != nil {
 		return err
 	}
@@ -214,7 +214,7 @@ type createAgentKeyOutput struct {
 }
 
 func runAgentsKeysCreateCmd(opts agentsKeysCreateOpts) error {
-	client, err := newClientFromCreds(opts.apiURL, opts.credPath)
+	client, err := newAuthenticatedClient(opts.apiURL, opts.credPath)
 	if err != nil {
 		return err
 	}
@@ -303,7 +303,7 @@ type agentsKeysRotateOpts struct {
 }
 
 func runAgentsKeysRotateCmd(opts agentsKeysRotateOpts) error {
-	client, err := newClientFromCreds(opts.apiURL, opts.credPath)
+	client, err := newAuthenticatedClient(opts.apiURL, opts.credPath)
 	if err != nil {
 		return err
 	}
@@ -361,7 +361,7 @@ type revokeAgentKeyOutput struct {
 }
 
 func runAgentsKeysRevokeCmd(opts agentsKeysRevokeOpts) error {
-	client, err := newClientFromCreds(opts.apiURL, opts.credPath)
+	client, err := newAuthenticatedClient(opts.apiURL, opts.credPath)
 	if err != nil {
 		return err
 	}

--- a/apps/moltnet-cli/api.go
+++ b/apps/moltnet-cli/api.go
@@ -3,48 +3,58 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"os"
 	"strings"
 
 	moltnetapi "github.com/getlarge/themoltnet/libs/moltnet-api-client"
 	"github.com/ogen-go/ogen/ogenerrors"
 )
 
-// tokenSecuritySource implements moltnetapi.SecuritySource using a TokenManager.
-// It provides Bearer tokens obtained via OAuth2 client_credentials flow.
+const agentKeyEnv = "MOLTNET_AGENT_KEY"
+
+type bearerTokenFunc func(context.Context) (string, error)
+
+// bearerSecuritySource implements the CLI's single supported HTTP security
+// scheme. The callback may return either an OAuth2 access token or a static
+// agent-key secret.
 //
 // The API now declares three security alternatives per operation (BearerAuth,
-// SessionAuth, CookieAuth). The CLI only supports OAuth2 client_credentials,
-// so CookieAuth and SessionAuth return ogenerrors.ErrSkipClientSecurity —
+// SessionAuth, CookieAuth). The CLI only supports bearer credentials, so
+// CookieAuth and SessionAuth return ogenerrors.ErrSkipClientSecurity —
 // ogen's documented signal to skip an alternative without mutating the
 // request. Because ogen calls every source method and then checks whether
 // ANY security requirement is satisfied (OR across alternatives), returning
 // ErrSkipClientSecurity is order-independent: only the BearerAuth method
 // actually sets a header, so the final request always carries exactly one
 // credential regardless of how the generator lists the alternatives.
-type tokenSecuritySource struct {
-	tm *TokenManager
+type bearerSecuritySource struct {
+	token bearerTokenFunc
 }
 
 // BearerAuth satisfies moltnetapi.SecuritySource.
-func (s *tokenSecuritySource) BearerAuth(_ context.Context, _ moltnetapi.OperationName) (moltnetapi.BearerAuth, error) {
-	token, err := s.tm.GetToken()
+func (s *bearerSecuritySource) BearerAuth(ctx context.Context, _ moltnetapi.OperationName) (moltnetapi.BearerAuth, error) {
+	token, err := s.token(ctx)
 	if err != nil {
 		return moltnetapi.BearerAuth{}, fmt.Errorf("get token: %w", err)
+	}
+	if token == "" {
+		return moltnetapi.BearerAuth{}, fmt.Errorf("get token: empty bearer token")
 	}
 	return moltnetapi.BearerAuth{Token: token}, nil
 }
 
 // CookieAuth is not used by the CLI — it authenticates with OAuth2 bearer
-// tokens only. Returning ErrSkipClientSecurity tells ogen's security picker
+// tokens or agent keys only. Returning ErrSkipClientSecurity tells ogen's security picker
 // to skip this alternative without touching the request.
-func (s *tokenSecuritySource) CookieAuth(_ context.Context, _ moltnetapi.OperationName) (moltnetapi.CookieAuth, error) {
+func (s *bearerSecuritySource) CookieAuth(_ context.Context, _ moltnetapi.OperationName) (moltnetapi.CookieAuth, error) {
 	return moltnetapi.CookieAuth{}, ogenerrors.ErrSkipClientSecurity
 }
 
 // SessionAuth is not used by the CLI — it authenticates with OAuth2 bearer
-// tokens only. Returning ErrSkipClientSecurity tells ogen's security picker
+// tokens or agent keys only. Returning ErrSkipClientSecurity tells ogen's security picker
 // to skip this alternative without touching the request.
-func (s *tokenSecuritySource) SessionAuth(_ context.Context, _ moltnetapi.OperationName) (moltnetapi.SessionAuth, error) {
+func (s *bearerSecuritySource) SessionAuth(_ context.Context, _ moltnetapi.OperationName) (moltnetapi.SessionAuth, error) {
 	return moltnetapi.SessionAuth{}, ogenerrors.ErrSkipClientSecurity
 }
 
@@ -52,18 +62,48 @@ func (s *tokenSecuritySource) SessionAuth(_ context.Context, _ moltnetapi.Operat
 // The underlying HTTP client uses a retry transport: 429 on all methods,
 // 408/5xx on idempotent methods only (GET, HEAD, OPTIONS, PUT).
 func newAuthedClient(apiURL string, tm *TokenManager) (*moltnetapi.Client, error) {
-	return moltnetapi.NewClient(
-		strings.TrimRight(apiURL, "/"),
-		&tokenSecuritySource{tm: tm},
-		moltnetapi.WithClient(tm.httpClient),
+	return newBearerClient(
+		apiURL,
+		func(_ context.Context) (string, error) {
+			return tm.GetToken()
+		},
+		tm.httpClient,
 	)
 }
 
-// newClientFromCreds loads stored credentials, creates a TokenManager, and
-// returns a fully authenticated moltnetapi.Client.
-// If credPath is non-empty, credentials are loaded from that path;
-// otherwise, the default auto-discovery is used.
-func newClientFromCreds(apiURL, credPath string) (*moltnetapi.Client, error) {
+// newBearerClient builds a generated client around one bearer-token callback.
+// The callback keeps credential resolution out of the generated API client and
+// lets OAuth2 and static agent keys share the same ogen security adapter.
+func newBearerClient(
+	apiURL string,
+	token bearerTokenFunc,
+	httpClient *http.Client,
+) (*moltnetapi.Client, error) {
+	return moltnetapi.NewClient(
+		strings.TrimRight(apiURL, "/"),
+		&bearerSecuritySource{token: token},
+		moltnetapi.WithClient(httpClient),
+	)
+}
+
+// newAuthenticatedClient resolves the CLI authentication mode and returns a
+// fully authenticated generated client.
+//
+// A non-blank MOLTNET_AGENT_KEY is authoritative: it is sent directly as a
+// static bearer credential and OAuth2 is never attempted as a fallback. This
+// lets API-only commands run without moltnet.json. When the variable is absent
+// or blank, the existing OAuth2 client_credentials flow is used.
+func newAuthenticatedClient(apiURL, credPath string) (*moltnetapi.Client, error) {
+	if agentKey := strings.TrimSpace(os.Getenv(agentKeyEnv)); agentKey != "" {
+		return newBearerClient(
+			apiURL,
+			func(_ context.Context) (string, error) {
+				return agentKey, nil
+			},
+			newAPIHTTPClient(),
+		)
+	}
+
 	creds, err := loadCredentials(credPath)
 	if err != nil {
 		return nil, err

--- a/apps/moltnet-cli/api_test.go
+++ b/apps/moltnet-cli/api_test.go
@@ -5,11 +5,13 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 	"time"
 
 	moltnetapi "github.com/getlarge/themoltnet/libs/moltnet-api-client"
 	"github.com/google/uuid"
+	"github.com/ogen-go/ogen/ogenerrors"
 )
 
 // newTestServer builds a token stub and an ogen-generated API server backed by
@@ -66,8 +68,9 @@ func (noopSecurityHandler) HandleSessionAuth(_ context.Context, _ moltnetapi.Ope
 	return context.Background(), nil
 }
 
-// TestTokenSecuritySource verifies that GetToken is called and the Bearer header is set.
-func TestTokenSecuritySource(t *testing.T) {
+// TestBearerSecuritySource verifies that OAuth token resolution is lazy and
+// the resulting access token is exposed through the bearer scheme only.
+func TestBearerSecuritySource(t *testing.T) {
 	called := false
 	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
@@ -81,7 +84,11 @@ func TestTokenSecuritySource(t *testing.T) {
 	defer tokenSrv.Close()
 
 	tm := NewTokenManager(tokenSrv.URL, "cid", "csec")
-	src := &tokenSecuritySource{tm: tm}
+	src := &bearerSecuritySource{
+		token: func(_ context.Context) (string, error) {
+			return tm.GetToken()
+		},
+	}
 
 	bearer, err := src.BearerAuth(context.Background(), moltnetapi.GetWhoamiOperation)
 	if err != nil {
@@ -93,10 +100,17 @@ func TestTokenSecuritySource(t *testing.T) {
 	if !called {
 		t.Error("expected token server to be called")
 	}
+	if _, err := src.CookieAuth(context.Background(), moltnetapi.GetWhoamiOperation); err != ogenerrors.ErrSkipClientSecurity {
+		t.Errorf("CookieAuth() error = %v, want ErrSkipClientSecurity", err)
+	}
+	if _, err := src.SessionAuth(context.Background(), moltnetapi.GetWhoamiOperation); err != ogenerrors.ErrSkipClientSecurity {
+		t.Errorf("SessionAuth() error = %v, want ErrSkipClientSecurity", err)
+	}
 }
 
-// TestTokenSecuritySourceCached verifies that the token is cached on the second call.
-func TestTokenSecuritySourceCached(t *testing.T) {
+// TestBearerSecuritySourceCachesOAuthToken verifies that the TokenManager still
+// caches OAuth access tokens behind the shared bearer adapter.
+func TestBearerSecuritySourceCachesOAuthToken(t *testing.T) {
 	callCount := 0
 	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		callCount++
@@ -110,7 +124,11 @@ func TestTokenSecuritySourceCached(t *testing.T) {
 	defer tokenSrv.Close()
 
 	tm := NewTokenManager(tokenSrv.URL, "cid", "csec")
-	src := &tokenSecuritySource{tm: tm}
+	src := &bearerSecuritySource{
+		token: func(_ context.Context) (string, error) {
+			return tm.GetToken()
+		},
+	}
 
 	for i := 0; i < 3; i++ {
 		if _, err := src.BearerAuth(context.Background(), moltnetapi.GetWhoamiOperation); err != nil {
@@ -155,4 +173,89 @@ func TestNewAuthedClientCallsAPI(t *testing.T) {
 		t.Errorf("expected identity_id=%s, got %s", wantID, whoami.IdentityId)
 	}
 	_ = time.Now() // ensure time import used
+}
+
+func TestNewAuthenticatedClientUsesStandaloneAgentKey(t *testing.T) {
+	t.Setenv(agentKeyEnv, "  opaque-agent-key  ")
+	t.Setenv("HOME", t.TempDir())
+
+	wantID := uuid.MustParse("00000000-0000-0000-0000-000000000002")
+	generated, err := moltnetapi.NewServer(
+		&stubWhoamiHandler{identityID: wantID},
+		noopSecurityHandler{},
+	)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	var authorization string
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authorization = r.Header.Get("Authorization")
+		generated.ServeHTTP(w, r)
+	}))
+	defer apiSrv.Close()
+
+	client, err := newAuthenticatedClient(
+		apiSrv.URL,
+		filepath.Join(t.TempDir(), "missing-moltnet.json"),
+	)
+	if err != nil {
+		t.Fatalf("newAuthenticatedClient() error: %v", err)
+	}
+	res, err := client.GetWhoami(context.Background())
+	if err != nil {
+		t.Fatalf("GetWhoami() error: %v", err)
+	}
+	if _, ok := res.(*moltnetapi.Whoami); !ok {
+		t.Fatalf("expected *Whoami, got %T", res)
+	}
+	if authorization != "Bearer opaque-agent-key" {
+		t.Errorf("Authorization = %q, want static agent-key bearer", authorization)
+	}
+}
+
+func TestNewAuthenticatedClientBlankAgentKeyFallsBackToOAuth(t *testing.T) {
+	t.Setenv(agentKeyEnv, "   ")
+
+	wantID := uuid.MustParse("00000000-0000-0000-0000-000000000003")
+	generated, err := moltnetapi.NewServer(
+		&stubWhoamiHandler{identityID: wantID},
+		noopSecurityHandler{},
+	)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	tokenCalls := 0
+	var authorization string
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/oauth2/token" {
+			tokenCalls++
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"access_token": "oauth-access-token",
+				"token_type":   "Bearer",
+				"expires_in":   3600,
+			})
+			return
+		}
+		authorization = r.Header.Get("Authorization")
+		generated.ServeHTTP(w, r)
+	}))
+	defer apiSrv.Close()
+
+	credPath := writeCredsWithAPI(t, apiSrv.URL)
+	client, err := newAuthenticatedClient(apiSrv.URL, credPath)
+	if err != nil {
+		t.Fatalf("newAuthenticatedClient() error: %v", err)
+	}
+	if _, err := client.GetWhoami(context.Background()); err != nil {
+		t.Fatalf("GetWhoami() error: %v", err)
+	}
+	if tokenCalls != 1 {
+		t.Errorf("OAuth token calls = %d, want 1", tokenCalls)
+	}
+	if authorization != "Bearer oauth-access-token" {
+		t.Errorf("Authorization = %q, want OAuth bearer", authorization)
+	}
 }

--- a/apps/moltnet-cli/crypto_ops.go
+++ b/apps/moltnet-cli/crypto_ops.go
@@ -9,7 +9,7 @@ import (
 
 // runCryptoIdentityCmd is the flag-free business logic for crypto identity.
 func runCryptoIdentityCmd(apiURL, credPath string) error {
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -26,7 +26,7 @@ func runCryptoIdentityCmd(apiURL, credPath string) error {
 
 // runCryptoVerifyCmd is the flag-free business logic for crypto verify.
 func runCryptoVerifyCmd(apiURL, credPath, signature string) error {
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}

--- a/apps/moltnet-cli/diary.go
+++ b/apps/moltnet-cli/diary.go
@@ -12,7 +12,7 @@ import (
 
 // runDiaryListCmd lists all agent's diaries.
 func runDiaryListCmd(apiURL, credPath string) error {
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -29,7 +29,7 @@ func runDiaryListCmd(apiURL, credPath string) error {
 
 // runDiaryCreateCmd creates a new diary.
 func runDiaryCreateCmd(apiURL, credPath, name, visibility, teamID string) error {
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -62,7 +62,7 @@ func runDiaryGetCmd(apiURL, credPath, diaryID string) error {
 		return fmt.Errorf("invalid diary ID %q: %w", diaryID, err)
 	}
 
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -84,7 +84,7 @@ func runDiaryTagsCmd(apiURL, credPath, diaryID, prefix, entryTypes string, minCo
 		return fmt.Errorf("invalid diary ID %q: %w", diaryID, err)
 	}
 
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}

--- a/apps/moltnet-cli/diary_transfer.go
+++ b/apps/moltnet-cli/diary_transfer.go
@@ -21,7 +21,7 @@ func runDiaryTransferInitiateCmd(apiURL, credPath, diaryID, destinationTeamID st
 		return fmt.Errorf("invalid destination team ID %q: %w", destinationTeamID, err)
 	}
 
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -41,7 +41,7 @@ func runDiaryTransferInitiateCmd(apiURL, credPath, diaryID, destinationTeamID st
 // runDiaryTransferListCmd lists pending transfers where the caller owns the
 // destination team.
 func runDiaryTransferListCmd(apiURL, credPath string) error {
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -65,7 +65,7 @@ func runDiaryTransferAcceptCmd(apiURL, credPath, transferID string) error {
 		return fmt.Errorf("invalid transfer ID %q: %w", transferID, err)
 	}
 
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -89,7 +89,7 @@ func runDiaryTransferRejectCmd(apiURL, credPath, transferID string) error {
 		return fmt.Errorf("invalid transfer ID %q: %w", transferID, err)
 	}
 
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}

--- a/apps/moltnet-cli/e2e_agent_keys_test.go
+++ b/apps/moltnet-cli/e2e_agent_keys_test.go
@@ -3,47 +3,24 @@
 package main
 
 import (
-	"context"
 	"strings"
 	"testing"
 
-	moltnetapi "github.com/getlarge/themoltnet/libs/moltnet-api-client"
 	"github.com/google/uuid"
-	"github.com/ogen-go/ogen/ogenerrors"
 )
 
-// staticBearerSource authenticates the generated client with a fixed bearer
-// token — here, an agent-key secret — so the test can verify that a secret
-// authenticates while active and is rejected after rotation or revocation.
-type staticBearerSource struct{ token string }
-
-func (s staticBearerSource) BearerAuth(context.Context, moltnetapi.OperationName) (moltnetapi.BearerAuth, error) {
-	return moltnetapi.BearerAuth{Token: s.token}, nil
-}
-
-func (s staticBearerSource) CookieAuth(context.Context, moltnetapi.OperationName) (moltnetapi.CookieAuth, error) {
-	return moltnetapi.CookieAuth{}, ogenerrors.ErrSkipClientSecurity
-}
-
-func (s staticBearerSource) SessionAuth(context.Context, moltnetapi.OperationName) (moltnetapi.SessionAuth, error) {
-	return moltnetapi.SessionAuth{}, ogenerrors.ErrSkipClientSecurity
-}
-
-// keyAuthenticates reports whether the given agent-key secret can authenticate a
-// whoami call. A revoked or rotated-away secret yields a 401, which surfaces as
-// a transport error or a non-Whoami response variant — either way, false.
-func keyAuthenticates(t *testing.T, apiURL, secret string) bool {
+// keyAuthenticatesCLI reports whether the standalone agent-key mode can
+// complete a real `moltnet agents whoami` invocation. A revoked or rotated-away
+// secret yields a non-zero exit.
+func keyAuthenticatesCLI(t *testing.T, binPath, secret string) bool {
 	t.Helper()
-	client, err := moltnetapi.NewClient(strings.TrimRight(apiURL, "/"), staticBearerSource{token: secret})
-	if err != nil {
-		t.Fatalf("build static-bearer client: %v", err)
-	}
-	res, err := client.GetWhoami(context.Background())
-	if err != nil {
-		return false
-	}
-	_, ok := res.(*moltnetapi.Whoami)
-	return ok
+	_, _, err := runE2ECLIWithAgentKey(
+		binPath,
+		secret,
+		"agents",
+		"whoami",
+	)
+	return err == nil
 }
 
 // createAgentKeyResult mirrors the CLI create/rotate stdout JSON.
@@ -91,9 +68,34 @@ func TestE2E_CLI_AgentKeyLifecycle(t *testing.T) {
 		t.Errorf("the secret must never appear on stderr")
 	}
 
-	// 2. The fresh secret authenticates.
-	if !keyAuthenticates(t, e2eAPIURL, created.Secret) {
-		t.Fatal("newly created key secret should authenticate")
+	// 2. The fresh secret authenticates through the compiled CLI without a
+	// credentials file.
+	if !keyAuthenticatesCLI(t, h.bin, created.Secret) {
+		t.Fatal("newly created key secret should authenticate the CLI")
+	}
+
+	// The same key can perform an authorized team-scoped read when the matching
+	// team header is supplied by the command.
+	keyListOut, keyListErr, err := runE2ECLIWithAgentKey(
+		h.bin,
+		created.Secret,
+		"agents",
+		"keys",
+		"list",
+		"--team-id",
+		team,
+		"--agent-id",
+		agentID,
+		"--limit",
+		"1",
+	)
+	if err != nil {
+		t.Fatalf(
+			"agent-key team-scoped list failed: %v\nstdout:\n%s\nstderr:\n%s",
+			err,
+			keyListOut,
+			keyListErr,
+		)
 	}
 
 	// 3. Replaying the same idempotency key cannot mint a second key: the API
@@ -159,11 +161,11 @@ func TestE2E_CLI_AgentKeyLifecycle(t *testing.T) {
 	if strings.Contains(rotateStderr, rotated.Secret) {
 		t.Error("the rotated secret must never appear on stderr")
 	}
-	if keyAuthenticates(t, e2eAPIURL, created.Secret) {
-		t.Error("the pre-rotation secret must stop authenticating after rotation")
+	if keyAuthenticatesCLI(t, h.bin, created.Secret) {
+		t.Error("the pre-rotation secret must stop authenticating the CLI after rotation")
 	}
-	if !keyAuthenticates(t, e2eAPIURL, rotated.Secret) {
-		t.Error("the rotated secret should authenticate")
+	if !keyAuthenticatesCLI(t, h.bin, rotated.Secret) {
+		t.Error("the rotated secret should authenticate the CLI")
 	}
 
 	// 8. Revoke the rotated key. The revoked secret is rejected.
@@ -178,8 +180,8 @@ func TestE2E_CLI_AgentKeyLifecycle(t *testing.T) {
 	if revoked.Status != "revoked" || revoked.KeyID != rotated.Key.ID || revoked.Reason != "key_compromise" {
 		t.Errorf("unexpected revoke confirmation: %+v", revoked)
 	}
-	if keyAuthenticates(t, e2eAPIURL, rotated.Secret) {
-		t.Error("a revoked secret must be rejected")
+	if keyAuthenticatesCLI(t, h.bin, rotated.Secret) {
+		t.Error("a revoked secret must be rejected by the CLI")
 	}
 }
 

--- a/apps/moltnet-cli/e2e_helpers_test.go
+++ b/apps/moltnet-cli/e2e_helpers_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 )
@@ -78,23 +79,44 @@ func runE2ECLI(
 	credsPath string,
 	args ...string,
 ) (stdout string, stderr string, runErr error) {
+	return runE2eCLIWithAuth(binPath, credsPath, "", args...)
+}
+
+// runE2ECLIWithAgentKey invokes the compiled CLI with a standalone agent key
+// and deliberately omits --credentials. This proves API-only commands do not
+// depend on moltnet.json when key authentication is active.
+func runE2ECLIWithAgentKey(
+	binPath string,
+	agentKey string,
+	args ...string,
+) (stdout string, stderr string, runErr error) {
+	return runE2eCLIWithAuth(binPath, "", agentKey, args...)
+}
+
+func runE2eCLIWithAuth(
+	binPath string,
+	credsPath string,
+	agentKey string,
+	args ...string,
+) (stdout string, stderr string, runErr error) {
 	ctx, cancel := context.WithTimeout(context.Background(), e2eCLIInvocationTimeout)
 	defer cancel()
 
-	fullArgs := append(
-		[]string{
-			"--api-url", e2eAPIURL,
-			"--credentials", credsPath,
-		},
-		args...,
-	)
+	fullArgs := []string{"--api-url", e2eAPIURL}
+	if credsPath != "" {
+		fullArgs = append(fullArgs, "--credentials", credsPath)
+	}
+	fullArgs = append(fullArgs, args...)
 
 	cmd := exec.CommandContext(ctx, binPath, fullArgs...)
 	var outBuf bytes.Buffer
 	var errBuf bytes.Buffer
 	cmd.Stdout = &outBuf
 	cmd.Stderr = &errBuf
-	cmd.Env = os.Environ()
+	cmd.Env = withoutEnv(os.Environ(), agentKeyEnv)
+	if agentKey != "" {
+		cmd.Env = append(cmd.Env, agentKeyEnv+"="+agentKey)
+	}
 	runErr = cmd.Run()
 	if ctx.Err() == context.DeadlineExceeded {
 		runErr = fmt.Errorf(
@@ -104,4 +126,15 @@ func runE2ECLI(
 		)
 	}
 	return outBuf.String(), errBuf.String(), runErr
+}
+
+func withoutEnv(env []string, name string) []string {
+	prefix := name + "="
+	filtered := make([]string, 0, len(env))
+	for _, value := range env {
+		if !strings.HasPrefix(value, prefix) {
+			filtered = append(filtered, value)
+		}
+	}
+	return filtered
 }

--- a/apps/moltnet-cli/entry.go
+++ b/apps/moltnet-cli/entry.go
@@ -19,7 +19,7 @@ func runEntryCreateCmd(apiURL, credPath, diaryID, content, title, entryType, tag
 		return fmt.Errorf("invalid diary ID %q: %w", diaryID, err)
 	}
 
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -85,7 +85,7 @@ func runEntryCreateSignedCmd(apiURL, credPath, diaryID, content, title, entryTyp
 	if err != nil {
 		return err
 	}
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -147,7 +147,7 @@ func runEntryListCmd(apiURL, credPath, diaryID, ids, tags, excludeTags, entryTyp
 		return fmt.Errorf("invalid diary ID %q: %w", diaryID, err)
 	}
 
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -196,7 +196,7 @@ func runEntryGetCmd(apiURL, credPath, entryID, expand string, depth int) error {
 		return fmt.Errorf("invalid entry ID %q: %w", entryID, err)
 	}
 
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -232,7 +232,7 @@ func runEntryUpdateCmd(apiURL, credPath, entryID, content, title, entryType, tag
 		return fmt.Errorf("invalid entry ID %q: %w", entryID, err)
 	}
 
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -276,7 +276,7 @@ func runEntryDeleteCmd(apiURL, credPath, entryID string) error {
 		return fmt.Errorf("invalid entry ID %q: %w", entryID, err)
 	}
 
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -361,7 +361,7 @@ func runEntrySearchCmd(apiURL, credPath string, opts entrySearchOptions) error {
 	if !hasEntrySearchCriteria(req) {
 		return fmt.Errorf("entry search: provide --query or at least one filter flag")
 	}
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -400,7 +400,7 @@ func runEntryVerifyCmd(apiURL, credPath, entryID string) error {
 		return fmt.Errorf("invalid entry ID %q: %w", entryID, err)
 	}
 
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}

--- a/apps/moltnet-cli/entry_commit.go
+++ b/apps/moltnet-cli/entry_commit.go
@@ -59,11 +59,7 @@ func runEntryCommitCmd(w io.Writer, apiURL, credPath, diaryID, rationale, risk, 
 		entryTitle = "Accountable commit: " + firstSentence(rationale)
 	}
 
-	if creds.OAuth2.ClientID == "" || creds.OAuth2.ClientSecret == "" {
-		return fmt.Errorf("credentials missing client_id or client_secret — run 'moltnet register'")
-	}
-	tm := NewTokenManager(apiURL, creds.OAuth2.ClientID, creds.OAuth2.ClientSecret)
-	client, err := newAuthedClient(apiURL, tm)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}

--- a/apps/moltnet-cli/grants.go
+++ b/apps/moltnet-cli/grants.go
@@ -15,7 +15,7 @@ func runDiaryGrantsListCmd(apiURL, credPath, diaryID string) error {
 	if err != nil {
 		return fmt.Errorf("invalid diary ID %q: %w", diaryID, err)
 	}
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -48,7 +48,7 @@ func runDiaryGrantsCreateCmd(apiURL, credPath, diaryID, subjectID, subjectNs, ro
 		return err
 	}
 
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -86,7 +86,7 @@ func runDiaryGrantsRevokeCmd(apiURL, credPath, diaryID, subjectID, subjectNs, ro
 		return err
 	}
 
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}

--- a/apps/moltnet-cli/pack.go
+++ b/apps/moltnet-cli/pack.go
@@ -25,7 +25,7 @@ func runPackRenderCmd(apiURL, credPath, packID, renderMethod string, preview boo
 		return fmt.Errorf("invalid pack ID %q: %w", packID, err)
 	}
 
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -251,7 +251,7 @@ func runPackProvenanceCmd(apiURL, credPath, packID, packCID string, depth int, o
 		}
 	}
 
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -405,7 +405,7 @@ func runPackCreateCmd(apiURL, credPath, diaryID, entriesJSON string, tokenBudget
 		}
 	}
 
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -477,7 +477,7 @@ func runPackUpdateCmd(apiURL, credPath, packID string, pinned *bool, expiresAt s
 		return fmt.Errorf("invalid pack ID %q: %w", packID, err)
 	}
 
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -517,7 +517,7 @@ func runPackListCmd(apiURL, credPath, diaryID, containsEntry string, includeRend
 		return fmt.Errorf("exactly one of --diary-id or --contains-entry must be provided")
 	}
 
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -593,7 +593,7 @@ func runPackGetCmd(apiURL, credPath, packID, expand string) error {
 		return fmt.Errorf("invalid pack ID %q: %w", packID, err)
 	}
 
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}

--- a/apps/moltnet-cli/profile.go
+++ b/apps/moltnet-cli/profile.go
@@ -16,7 +16,7 @@ import (
 // runProfileListCmd lists runtime profiles for a team. The team header is
 // optional; when omitted the server falls back to the token's current team.
 func runProfileListCmd(apiURL, credPath, teamID string) error {
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -41,7 +41,7 @@ func runProfileListCmd(apiURL, credPath, teamID string) error {
 
 // runProfileGetCmd fetches a single runtime profile by id or name.
 func runProfileGetCmd(apiURL, credPath, ref, teamID string) error {
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func runProfileCreateCmd(apiURL, credPath, fromFile, teamID string) error {
 	if err := decodeProfileFile(fromFile, &body); err != nil {
 		return err
 	}
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -95,7 +95,7 @@ func runProfileUpdateCmd(apiURL, credPath, ref, fromFile, teamID string) error {
 	if err := decodeProfileFile(fromFile, &body); err != nil {
 		return err
 	}
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -116,7 +116,7 @@ func runProfileUpdateCmd(apiURL, credPath, ref, fromFile, teamID string) error {
 
 // runProfileDeleteCmd deletes a runtime profile by id or name.
 func runProfileDeleteCmd(apiURL, credPath, ref, teamID string) error {
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}

--- a/apps/moltnet-cli/relations.go
+++ b/apps/moltnet-cli/relations.go
@@ -74,7 +74,7 @@ func runRelationsCreateCmd(apiURL, credPath, entryID, targetID, relation, status
 		return err
 	}
 
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -112,7 +112,7 @@ func runRelationsListCmd(apiURL, credPath, entryID, relation, status, direction 
 		return fmt.Errorf("invalid entry ID %q: %w", entryID, err)
 	}
 
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -164,7 +164,7 @@ func runRelationsUpdateCmd(apiURL, credPath, relationID, status string) error {
 		return err
 	}
 
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -188,7 +188,7 @@ func runRelationsDeleteCmd(apiURL, credPath, relationID string) error {
 		return fmt.Errorf("invalid relation ID %q: %w", relationID, err)
 	}
 
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}

--- a/apps/moltnet-cli/rendered_packs.go
+++ b/apps/moltnet-cli/rendered_packs.go
@@ -15,7 +15,7 @@ func runRenderedPacksList(apiURL, credPath, diaryID string, limit, offset int, s
 		return fmt.Errorf("invalid diary ID %q: %w", diaryID, err)
 	}
 
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -57,7 +57,7 @@ func runRenderedPacksGet(apiURL, credPath, id string) error {
 		return fmt.Errorf("invalid --id: %w", err)
 	}
 
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return fmt.Errorf("auth failed: %w", err)
 	}
@@ -84,7 +84,7 @@ func runRenderedPacksUpdate(apiURL, credPath, id string, pinned *bool, expiresAt
 		return fmt.Errorf("invalid --id %q: %w", id, err)
 	}
 
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}

--- a/apps/moltnet-cli/rendered_packs_judge.go
+++ b/apps/moltnet-cli/rendered_packs_judge.go
@@ -72,7 +72,7 @@ func runRenderedPacksJudgeLocal(
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return fmt.Errorf("auth failed: %w", err)
 	}

--- a/apps/moltnet-cli/rendered_packs_to_skill.go
+++ b/apps/moltnet-cli/rendered_packs_to_skill.go
@@ -168,7 +168,7 @@ func runRenderedPackToSkill(apiURL, credPath, id, outDir string) error {
 		return fmt.Errorf("invalid --id %q: %w", id, err)
 	}
 
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}

--- a/apps/moltnet-cli/sign.go
+++ b/apps/moltnet-cli/sign.go
@@ -20,10 +20,7 @@ func runSignCmd(w io.Writer, credPath, apiURL, nonce, requestID string, args []s
 
 	// --request-id: one-shot fetch + sign + submit
 	if requestID != "" {
-		if creds.OAuth2.ClientID == "" || creds.OAuth2.ClientSecret == "" {
-			return fmt.Errorf("credentials missing client_id or client_secret — run 'moltnet register'")
-		}
-		client, err := newClientFromCreds(apiURL, credPath)
+		client, err := newAuthenticatedClient(apiURL, credPath)
 		if err != nil {
 			return err
 		}

--- a/apps/moltnet-cli/sign_test.go
+++ b/apps/moltnet-cli/sign_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -171,6 +173,59 @@ func TestSignWithRequestID(t *testing.T) {
 	}
 	if !valid {
 		t.Error("submitted signature failed verification")
+	}
+}
+
+func TestRunSignRequestIDUsesAgentKeyWithLocalSigningCredentials(t *testing.T) {
+	kp, err := GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate keypair: %v", err)
+	}
+
+	credPath := filepath.Join(t.TempDir(), "moltnet.json")
+	if _, err := WriteConfigTo(&CredentialsFile{
+		IdentityID: "test-identity",
+		Keys: CredentialsKeys{
+			PublicKey:   kp.PublicKey,
+			PrivateKey:  kp.PrivateKey,
+			Fingerprint: kp.Fingerprint,
+		},
+	}, credPath); err != nil {
+		t.Fatalf("write credentials: %v", err)
+	}
+
+	reqID := uuid.MustParse("00000000-0000-0000-0000-000000000098")
+	handler := &stubSigningHandler{
+		requestID:          reqID,
+		message:            "agent-key authenticated signing",
+		nonce:              uuid.MustParse("aaaaaaaa-0000-0000-0000-000000000001"),
+		verificationMethod: moltnetapi.SigningRequestVerificationMethodAgentEd25519,
+	}
+	generated, err := moltnetapi.NewServer(handler, noopSecurityHandler{})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	apiSrv := httptest.NewServer(generated)
+	defer apiSrv.Close()
+
+	t.Setenv(agentKeyEnv, "agent-key-secret")
+	var stdout bytes.Buffer
+	err = runSignCmd(
+		&stdout,
+		credPath,
+		apiSrv.URL,
+		"",
+		reqID.String(),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("runSignCmd() error: %v", err)
+	}
+	if stdout.String() == "" {
+		t.Fatal("expected signature on stdout")
+	}
+	if handler.gotSig != stdout.String() {
+		t.Error("submitted signature does not match stdout")
 	}
 }
 

--- a/apps/moltnet-cli/signing_commands.go
+++ b/apps/moltnet-cli/signing_commands.go
@@ -15,7 +15,7 @@ type signingRequestCreateOpts struct {
 }
 
 func runSigningRequestCreateCmd(opts signingRequestCreateOpts) error {
-	client, err := newClientFromCreds(opts.apiURL, opts.credPath)
+	client, err := newAuthenticatedClient(opts.apiURL, opts.credPath)
 	if err != nil {
 		return err
 	}
@@ -105,7 +105,7 @@ func signingRequestConstraint(
 }
 
 func runSigningRequestListCmd(apiURL, credPath, scope string, out io.Writer) error {
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -133,7 +133,7 @@ func runSigningRequestGetCmd(apiURL, credPath, id string, out io.Writer) error {
 	if err != nil {
 		return fmt.Errorf("invalid signing request ID: %w", err)
 	}
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -153,7 +153,7 @@ func runSigningCredentialListCmd(apiURL, credPath, teamID string, out io.Writer)
 	if err != nil {
 		return err
 	}
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -179,7 +179,7 @@ func runSigningCredentialGetCmd(apiURL, credPath, teamID, id string, out io.Writ
 	if err != nil {
 		return fmt.Errorf("invalid signing credential ID: %w", err)
 	}
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -208,7 +208,7 @@ func runSigningCredentialActionCmd(apiURL, credPath, teamID, id, action string, 
 	if err != nil {
 		return fmt.Errorf("invalid signing credential ID: %w", err)
 	}
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}

--- a/apps/moltnet-cli/task.go
+++ b/apps/moltnet-cli/task.go
@@ -68,7 +68,7 @@ type taskListOpts struct {
 }
 
 func runTaskListCmd(opts taskListOpts) error {
-	client, err := newClientFromCreds(opts.apiURL, opts.credPath)
+	client, err := newAuthenticatedClient(opts.apiURL, opts.credPath)
 	if err != nil {
 		return err
 	}
@@ -205,7 +205,7 @@ func parseOptRFC3339Flag(name, value string) (moltnetapi.OptDateTime, error) {
 }
 
 func runTaskGetCmd(apiURL, credPath, taskID string) error {
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -239,7 +239,7 @@ type taskAttemptsOpts struct {
 }
 
 func runTaskAttemptsCmd(opts taskAttemptsOpts) error {
-	client, err := newClientFromCreds(opts.apiURL, opts.credPath)
+	client, err := newAuthenticatedClient(opts.apiURL, opts.credPath)
 	if err != nil {
 		return err
 	}
@@ -362,7 +362,7 @@ func runTaskTailCmd(opts taskTailOpts) error {
 	if opts.intervalSec < 1 {
 		return fmt.Errorf("--interval must be >= 1, got %d", opts.intervalSec)
 	}
-	client, err := newClientFromCreds(opts.apiURL, opts.credPath)
+	client, err := newAuthenticatedClient(opts.apiURL, opts.credPath)
 	if err != nil {
 		return err
 	}

--- a/apps/moltnet-cli/task_artifacts.go
+++ b/apps/moltnet-cli/task_artifacts.go
@@ -64,7 +64,7 @@ type taskArtifactsDownloadOpts struct {
 }
 
 func runTaskArtifactsStageCmd(opts taskArtifactsStageOpts) error {
-	client, err := newClientFromCreds(opts.apiURL, opts.credPath)
+	client, err := newAuthenticatedClient(opts.apiURL, opts.credPath)
 	if err != nil {
 		return err
 	}
@@ -109,7 +109,7 @@ func buildStageTaskArtifactParams(opts taskArtifactsStageOpts) (moltnetapi.Stage
 }
 
 func runTaskArtifactsListCmd(opts taskArtifactsListOpts) error {
-	client, err := newClientFromCreds(opts.apiURL, opts.credPath)
+	client, err := newAuthenticatedClient(opts.apiURL, opts.credPath)
 	if err != nil {
 		return err
 	}
@@ -154,7 +154,7 @@ func buildListTaskArtifactsParams(opts taskArtifactsListOpts) (moltnetapi.ListTa
 }
 
 func runTaskArtifactsUploadCmd(opts taskArtifactsUploadOpts) error {
-	client, err := newClientFromCreds(opts.apiURL, opts.credPath)
+	client, err := newAuthenticatedClient(opts.apiURL, opts.credPath)
 	if err != nil {
 		return err
 	}
@@ -214,7 +214,7 @@ func buildUploadTaskArtifactParams(opts taskArtifactsUploadOpts) (moltnetapi.Upl
 }
 
 func runTaskArtifactsDownloadCmd(opts taskArtifactsDownloadOpts) error {
-	client, err := newClientFromCreds(opts.apiURL, opts.credPath)
+	client, err := newAuthenticatedClient(opts.apiURL, opts.credPath)
 	if err != nil {
 		return err
 	}

--- a/apps/moltnet-cli/task_continue.go
+++ b/apps/moltnet-cli/task_continue.go
@@ -55,7 +55,7 @@ type taskContinueOpts struct {
 }
 
 func runTaskContinueCmd(opts taskContinueOpts) error {
-	client, err := newClientFromCreds(opts.apiURL, opts.credPath)
+	client, err := newAuthenticatedClient(opts.apiURL, opts.credPath)
 	if err != nil {
 		return err
 	}

--- a/apps/moltnet-cli/task_create.go
+++ b/apps/moltnet-cli/task_create.go
@@ -57,7 +57,7 @@ type taskCreateOpts struct {
 }
 
 func runTaskCreateCmd(opts taskCreateOpts) error {
-	client, err := newClientFromCreds(opts.apiURL, opts.credPath)
+	client, err := newAuthenticatedClient(opts.apiURL, opts.credPath)
 	if err != nil {
 		return err
 	}

--- a/apps/moltnet-cli/task_runtime_sessions.go
+++ b/apps/moltnet-cli/task_runtime_sessions.go
@@ -44,7 +44,7 @@ type taskRuntimeSessionDownloadOpts struct {
 }
 
 func runTaskRuntimeSessionGetCmd(opts taskRuntimeSessionGetOpts) error {
-	client, err := newClientFromCreds(opts.apiURL, opts.credPath)
+	client, err := newAuthenticatedClient(opts.apiURL, opts.credPath)
 	if err != nil {
 		return err
 	}
@@ -83,7 +83,7 @@ func buildGetRuntimeSessionParams(opts taskRuntimeSessionGetOpts) (moltnetapi.Ge
 }
 
 func runTaskRuntimeSessionUploadCmd(opts taskRuntimeSessionUploadOpts) error {
-	client, err := newClientFromCreds(opts.apiURL, opts.credPath)
+	client, err := newAuthenticatedClient(opts.apiURL, opts.credPath)
 	if err != nil {
 		return err
 	}
@@ -155,7 +155,7 @@ func buildUploadRuntimeSessionParams(opts taskRuntimeSessionUploadOpts) (moltnet
 }
 
 func runTaskRuntimeSessionDownloadCmd(opts taskRuntimeSessionDownloadOpts) error {
-	client, err := newClientFromCreds(opts.apiURL, opts.credPath)
+	client, err := newAuthenticatedClient(opts.apiURL, opts.credPath)
 	if err != nil {
 		return err
 	}

--- a/apps/moltnet-cli/task_schemas.go
+++ b/apps/moltnet-cli/task_schemas.go
@@ -24,7 +24,7 @@ type taskSchemasGetOpts struct {
 }
 
 func runTaskSchemasListCmd(opts taskSchemasListOpts) error {
-	client, err := newClientFromCreds(opts.apiURL, opts.credPath)
+	client, err := newAuthenticatedClient(opts.apiURL, opts.credPath)
 	if err != nil {
 		return err
 	}
@@ -59,7 +59,7 @@ func runTaskSchemasListWithClient(ctx context.Context, client *moltnetapi.Client
 }
 
 func runTaskSchemasGetCmd(opts taskSchemasGetOpts) error {
-	client, err := newClientFromCreds(opts.apiURL, opts.credPath)
+	client, err := newAuthenticatedClient(opts.apiURL, opts.credPath)
 	if err != nil {
 		return err
 	}

--- a/apps/moltnet-cli/teams.go
+++ b/apps/moltnet-cli/teams.go
@@ -10,7 +10,7 @@ import (
 
 // runTeamsListCmd lists all teams for the authenticated agent.
 func runTeamsListCmd(apiURL, credPath string) error {
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -34,7 +34,7 @@ func runTeamsGetCmd(apiURL, credPath, teamID string) error {
 	if err != nil {
 		return fmt.Errorf("invalid team ID %q: %w", teamID, err)
 	}
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -55,7 +55,7 @@ func runTeamsMembersCmd(apiURL, credPath, teamID string) error {
 	if err != nil {
 		return fmt.Errorf("invalid team ID %q: %w", teamID, err)
 	}
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -72,7 +72,7 @@ func runTeamsMembersCmd(apiURL, credPath, teamID string) error {
 
 // runTeamsCreateCmd creates a new team.
 func runTeamsCreateCmd(apiURL, credPath, name string) error {
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -92,7 +92,7 @@ func runTeamsCreateCmd(apiURL, credPath, name string) error {
 
 // runTeamsJoinCmd joins a team using an invite code.
 func runTeamsJoinCmd(apiURL, credPath, code string) error {
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -116,7 +116,7 @@ func runTeamsInviteCreateCmd(apiURL, credPath, teamID, role string, expiresInHou
 	if err != nil {
 		return fmt.Errorf("invalid team ID %q: %w", teamID, err)
 	}
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -152,7 +152,7 @@ func runTeamsDeleteCmd(apiURL, credPath, teamID string) error {
 	if err != nil {
 		return fmt.Errorf("invalid team ID %q: %w", teamID, err)
 	}
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -177,7 +177,7 @@ func runTeamsMemberRemoveCmd(apiURL, credPath, teamID, subjectID string) error {
 	if err != nil {
 		return fmt.Errorf("invalid subject ID %q: %w", subjectID, err)
 	}
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -205,7 +205,7 @@ func runTeamsMemberUpdateRoleCmd(apiURL, credPath, teamID, subjectID, role strin
 	if err != nil {
 		return fmt.Errorf("invalid subject ID %q: %w", subjectID, err)
 	}
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -236,7 +236,7 @@ func runTeamsInviteDeleteCmd(apiURL, credPath, teamID, inviteID string) error {
 	if err != nil {
 		return fmt.Errorf("invalid invite ID %q: %w", inviteID, err)
 	}
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -260,7 +260,7 @@ func runTeamsInviteListCmd(apiURL, credPath, teamID string) error {
 	if err != nil {
 		return fmt.Errorf("invalid team ID %q: %w", teamID, err)
 	}
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}

--- a/apps/moltnet-cli/token.go
+++ b/apps/moltnet-cli/token.go
@@ -32,10 +32,16 @@ func NewTokenManager(apiURL, clientID, clientSecret string) *TokenManager {
 		clientID:           clientID,
 		clientSecret:       clientSecret,
 		earlyExpirySeconds: 30,
-		httpClient: &http.Client{
-			Timeout:   30 * time.Second,
-			Transport: NewRetryTransport(nil, nil),
-		},
+		httpClient:         newAPIHTTPClient(),
+	}
+}
+
+// newAPIHTTPClient provides the common timeout and retry policy used by both
+// OAuth2 and static agent-key clients.
+func newAPIHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout:   30 * time.Second,
+		Transport: NewRetryTransport(nil, nil),
 	}
 }
 

--- a/apps/moltnet-cli/vouch.go
+++ b/apps/moltnet-cli/vouch.go
@@ -9,7 +9,7 @@ import (
 
 // runVouchIssueCmd is the flag-free business logic for vouch issue.
 func runVouchIssueCmd(apiURL, credPath string) error {
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}
@@ -26,7 +26,7 @@ func runVouchIssueCmd(apiURL, credPath string) error {
 
 // runVouchListCmd is the flag-free business logic for vouch list.
 func runVouchListCmd(apiURL, credPath string) error {
-	client, err := newClientFromCreds(apiURL, credPath)
+	client, err := newAuthenticatedClient(apiURL, credPath)
 	if err != nil {
 		return err
 	}

--- a/docs/operate/running-agents.md
+++ b/docs/operate/running-agents.md
@@ -182,6 +182,37 @@ without selecting a team. Sensitive and unclassified routes fail closed,
 including team creation, voucher issuance, Hydra secret rotation, and any
 cross-team request.
 
+### Use an agent key with the CLI
+
+Set `MOLTNET_AGENT_KEY` to authenticate API-backed CLI commands with the issued
+secret. The CLI sends it directly as a bearer credential and does not exchange
+it for an OAuth2 token.
+
+```bash
+export MOLTNET_AGENT_KEY="$(cat daemon.key)"
+
+# API-only commands do not require moltnet.json in agent-key mode.
+moltnet agents whoami
+moltnet agents keys list --team-id <team-uuid> --status active
+```
+
+A non-empty `MOLTNET_AGENT_KEY` takes precedence over OAuth2 credentials in
+`moltnet.json`. If the key is invalid, expired, rotated, revoked, or forbidden
+for the requested route, the command fails with the API response; it never
+falls back to OAuth2. Use `--api-url` for a non-default API when no credentials
+file is present.
+
+Keep the secret in the process environment or a host credential store. The CLI
+does not accept an agent-key flag, write the key to `moltnet.json`, or include it
+in `config export-env`. Commands that sign with the agent's Ed25519 identity
+(`sign --request-id`, `entry create-signed`, and `entry commit`) still need a
+credentials file containing the private key, but its OAuth2 fields may be empty
+while `MOLTNET_AGENT_KEY` is set.
+
+The server remains authoritative for the key's team ceiling. Pass the matching
+`--team-id` on team-scoped commands; cross-team and unclassified operations fail
+closed.
+
 ### Run the daemon with an agent key
 
 Point the daemon at a key by exporting it as `MOLTNET_AGENT_KEY`. The secret is

--- a/packages/cli/bin/README.md
+++ b/packages/cli/bin/README.md
@@ -93,6 +93,12 @@ Credentials are stored at `~/.config/moltnet/moltnet.json` after `moltnet regist
 
 All API commands accept `--api-url` to override the default (`https://api.themolt.net`).
 
+Set `MOLTNET_AGENT_KEY` to authenticate API commands with a team-bound agent
+key instead of OAuth2 client credentials. The key takes precedence when set,
+and API-only commands can run without `moltnet.json`. Commands that sign with
+the local Ed25519 identity still require the credentials file. See the
+[agent-key CLI guide](https://docs.themolt.net/operate/running-agents#use-an-agent-key-with-the-cli).
+
 ## Versioning & Release Coupling
 
 The CLI depends on the generated Go API client (`libs/moltnet-api-client`, module `github.com/getlarge/themoltnet/libs/moltnet-api-client`). Both are versioned independently via release-please.


### PR DESCRIPTION
## Summary

- accept `MOLTNET_AGENT_KEY` as an authoritative static bearer credential for every API-backed CLI command
- allow API-only commands to run without `moltnet.json`, while keeping local Ed25519 credentials mandatory for signing commands
- preserve the existing OAuth2 client-credentials flow when the environment key is absent or blank
- document precedence, secret-handling, endpoint selection, and server-enforced team scope
- exercise the behavior through the compiled CLI, including team-scoped reads, rotation, and revocation

## Why

The REST API already accepts agent keys, but the CLI always loaded OAuth2 credentials before constructing its generated client. That prevented autonomous agents from using the CLI with an issued agent key unless they also retained a full OAuth configuration.

A nonblank environment key now selects a static bearer source before credential loading. Invalid, expired, rotated, revoked, or unauthorized keys fail with the API response and never fall back to OAuth2, avoiding a privilege-broadening surprise.

Issue #767 proposes reusable `SecuritySource` constructors for the Go API client. This change is intentionally independent of that library ergonomics work and retains the CLI-local bearer adapter; #767 can migrate it later without changing the authentication contract introduced here.

## User and developer impact

```bash
export MOLTNET_AGENT_KEY="$(cat agent.key)"
moltnet agents whoami
moltnet agents keys list --team-id <team-uuid>
```

No key flag or persistence path is added. The secret remains environment-only and is excluded from `config export-env`. Existing OAuth-only usage is unchanged when `MOLTNET_AGENT_KEY` is unset.

## Validation

- `pnpm exec nx run-many -t test lint build --projects=moltnet-cli,@moltnet/docs --parallel=3`
- `NX_LOAD_DOT_ENV_FILES=false go test -tags e2e -v -timeout 120s ./apps/moltnet-cli/...`
- `git diff --check`
- verified the signed commit with `git verify-commit HEAD`

Related: #767