### PR TITLE
ci: add CodeBoarding architecture reviews

### DIFF
--- a/.github/workflows/codeboarding-sync.yml
+++ b/.github/workflows/codeboarding-sync.yml
@@ -1,0 +1,36 @@
+name: CodeBoarding sync
+
+on:
+  push:
+    branches: [main]
+    # Prevent the sync commit from triggering another analysis. Keep the list
+    # explicit so changes to `.codeboarding/.codeboardingignore` still run.
+    paths-ignore:
+      - '.codeboarding/*.md'
+      - '.codeboarding/analysis.json'
+      - '.codeboarding/static_analysis.pkl'
+      - '.codeboarding/static_analysis.sha'
+      - '.codeboarding/codeboarding_version.json'
+      - '.codeboarding/health/**'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  # CodeBoarding uses a short-lived OIDC token for its free hosted tier.
+  id-token: write
+
+concurrency:
+  group: codeboarding-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: CodeBoarding/CodeBoarding-action@v1
+        with:
+          mode: sync
+          # Keep generated output separate from the canonical hand-maintained
+          # architecture guide at docs/understand/architecture.md.
+          write_architecture_md: false

--- a/.github/workflows/codeboarding.yml
+++ b/.github/workflows/codeboarding.yml
@@ -1,0 +1,38 @@
+name: CodeBoarding review
+
+on:
+  pull_request:
+    # Analyze once when a PR becomes reviewable. Refresh the architecture diff
+    # against the latest head at any time with a `/codeboarding` comment.
+    types: [opened, reopened, ready_for_review, closed]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  # CodeBoarding uses a short-lived OIDC token for its free hosted tier.
+  id-token: write
+
+concurrency:
+  group: codeboarding-${{ github.event.pull_request.number || github.event.issue.number }}
+  # Closing a PR should cancel its review. Comment-triggered refreshes queue so
+  # they do not interrupt an analysis already in progress.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' }}
+
+jobs:
+  review:
+    if: >
+      (github.event_name == 'pull_request' &&
+       github.event.action != 'closed' &&
+       github.event.pull_request.draft == false) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request != null &&
+       startsWith(github.event.comment.body, '/codeboarding') &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+                github.event.comment.author_association))
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: CodeBoarding/CodeBoarding-action@v1


### PR DESCRIPTION
## Summary

- add a CodeBoarding PR review workflow that posts architecture diffs when a pull request becomes reviewable
- support trusted on-demand refreshes through `/codeboarding` comments
- add a separate main-branch sync workflow that maintains the versioned `.codeboarding/` baseline
- use the free hosted OIDC tier, so no repository LLM secret is required

## Design

The review and sync modes live in separate workflows with least-privilege permissions. Review can read contents and write PR/issue comments; sync can write the generated baseline to `main`. Generated architecture output stays under `.codeboarding/`, and `write_architecture_md` is disabled so it does not compete with the canonical `docs/understand/architecture.md` guide.

## Validation

- `pnpm exec prettier --check .github/workflows/codeboarding.yml .github/workflows/codeboarding-sync.yml`
- `pnpm run check:actionlint`
- `git diff --check`
- signed diary entry: `a6515a25-e775-4326-80c1-58c7cd4603c1`