### PR TITLE
test(e2e): honor live retry triage verdict

### DIFF
--- a/apps/agent-daemon-e2e/src/live-ollama.e2e.test.ts
+++ b/apps/agent-daemon-e2e/src/live-ollama.e2e.test.ts
@@ -304,7 +304,7 @@ describeLive('Agent daemon live Ollama Cloud execution (e2e)', () => {
     }
   }, 900_000);
 
-  it('uses live Pi retry triage to requeue an ambiguous failed attempt', async () => {
+  it('persists and honors a live Pi retry-triage decision', async () => {
     const created = await agent.tasks.create(
       {
         taskType: 'curate_pack',
@@ -408,20 +408,34 @@ describeLive('Agent daemon live Ollama Cloud execution (e2e)', () => {
 
     await runtime.start();
 
-    expect(seenAttempts).toEqual([1, 2]);
-    const final = await agent.tasks.get(created.id);
-    expect(final.status).toBe('completed');
-    expect(final.acceptedAttemptN).toBe(2);
     const attempts = await agent.tasks.listAttempts(created.id);
     const failedAttempt = attempts.find((attempt) => attempt.attemptN === 1);
     expect(failedAttempt?.status).toBe('failed');
-    expect(failedAttempt?.error).toMatchObject({
-      retryable: true,
-      retry: {
-        source: 'triage',
-        decision: 'retry',
-      },
-    });
+    const retry = failedAttempt?.error?.retry;
+    expect(retry?.source).toBe('triage');
+    expect(['retry', 'do_not_retry']).toContain(retry?.decision);
+    expect(['low', 'medium', 'high']).toContain(retry?.confidence);
+    expect(retry?.reason?.trim() ?? '').not.toHaveLength(0);
+
+    // The deterministic E2E above owns the exact retry-policy assertion.
+    // This live integration test instead proves that runtime behavior honors
+    // whichever valid policy verdict the external triage model produced.
+    const shouldRetry =
+      retry?.decision === 'retry' &&
+      (retry.confidence === 'medium' || retry.confidence === 'high');
+    const final = await agent.tasks.get(created.id);
+
+    if (shouldRetry) {
+      expect(failedAttempt?.error?.retryable).toBe(true);
+      expect(seenAttempts).toEqual([1, 2]);
+      expect(final.status).toBe('completed');
+      expect(final.acceptedAttemptN).toBe(2);
+    } else {
+      expect(failedAttempt?.error?.retryable).toBe(false);
+      expect(seenAttempts).toEqual([1]);
+      expect(final.status).toBe('failed');
+      expect(final.acceptedAttemptN).toBeNull();
+    }
   }, 180_000);
 });
 


### PR DESCRIPTION
## Summary

- make the live Ollama retry-triage E2E accept either valid model verdict
- assert that the structured triage result is persisted with a valid decision, confidence, and non-empty reason
- verify the daemon behavior matches the returned verdict
- keep the deterministic E2E responsible for the exact retry-policy assertion

## Root cause

The live test required the external model to return `retry` with medium or high confidence and always expected attempts `[1, 2]`. That output is probabilistic: the same ambiguous failure can validly produce `do_not_retry` or low confidence. The runtime was behaving consistently with the model verdict, but the test treated one valid verdict as a failure.

This was the third occurrence of the same merge-gate flake in the live Ollama test.

## Impact

The live integration still fails for missing, malformed, or failed triage results, and it now verifies that runtime behavior honors whichever valid policy verdict the external model produces. The exact retry sequence remains covered deterministically, so the merge gate no longer depends on probabilistic model judgment.

## Validation

- Prettier check passed
- targeted Nx lint and typecheck passed
- agent-daemon deterministic E2E: 29 passed, 2 live tests skipped
- LeGreffier commit signature verified

The Ollama Cloud invocation was not run locally because it transmits synthetic task and failure context to an external service and requires explicit authorization.

Failed run: https://github.com/getlarge/themoltnet/actions/runs/30441161250/job/90542425729?pr=1741

MoltNet diary: `7b59b3fb-06ff-4908-a848-527fe24c9172`

<!-- legreffier-correlation: b353ed3a-0026-4620-8340-44a65259e50f -->
