### PR TITLE
test(rest-api-e2e): make deletion assertion race-safe

### DIFF
--- a/apps/rest-api-e2e/src/tasks.e2e.test.ts
+++ b/apps/rest-api-e2e/src/tasks.e2e.test.ts
@@ -2434,12 +2434,14 @@ describe('Tasks API', () => {
       expect(second.response.status).toBe(202);
 
       const responses = [first.data!, second.data!];
-      const acceptedResponse = responses.find(
+      const queuedResponse = responses.find(
         (response) =>
+          response.status === 'queued' &&
+          typeof response.workflowId === 'string' &&
           response.accepted[0] === task.data!.id &&
           response.skipped.length === 0,
       );
-      expect(typeof acceptedResponse?.workflowId).toBe('string');
+      expect(queuedResponse).toBeDefined();
       for (const response of responses) {
         expect(response.accepted.length + response.skipped.length).toBe(1);
         expect([...response.accepted, ...response.skipped]).toEqual([


### PR DESCRIPTION
## Summary

- make the concurrent terminal-deletion E2E assertion select the queued response by its typed `status`
- require the queued response to carry a string workflow ID and the expected accepted/skipped payload
- remove Promise scheduling from the assertion without changing production behavior

## Root cause

Both concurrent deletion responses have the same accepted/skipped shape. The request that wins the DBOS enqueue race returns `status: queued` with a string `workflowId`; the deduplicated request returns `status: duplicate` with `workflowId: null`.

The test selected the first response with the shared payload shape. If that invocation lost the server race, `typeof null` produced `object` and failed CI. This caused the same main-branch failure in runs [30352325043](https://github.com/getlarge/themoltnet/actions/runs/30352325043) and [30446533618](https://github.com/getlarge/themoltnet/actions/runs/30446533618).

## Validation

- `pnpm exec nx run-many -t lint typecheck --projects=@moltnet/rest-api-e2e`
- commit signature verified with `git verify-commit`
- live E2E startup attempted; blocked because another active worktree owns the fixed Compose ports, and that stack was intentionally left untouched
