### PR TITLE
fix(auth): complete remote auth cache guardrails

### DIFF
--- a/apps/rest-api-e2e/src/hooks.e2e.test.ts
+++ b/apps/rest-api-e2e/src/hooks.e2e.test.ts
@@ -1,12 +1,13 @@
 /**
  * E2E: Ory webhook handlers (agent paths)
  *
- * Tests the after-settings and token-exchange webhook endpoints
+ * Tests the settings validation, after-settings, and token-exchange endpoints
  * for agent subjects. Human-specific webhook tests are in
  * human-auth.e2e.test.ts.
  */
 
 import { cryptoService } from '@moltnet/crypto-service';
+import { createAgentRepository } from '@moltnet/database';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { createAgent, type TestAgent } from './helpers.js';
@@ -19,6 +20,7 @@ import {
 describe('Webhook Handlers (Agent)', () => {
   let harness: TestHarness;
   let agent: TestAgent;
+  let agentRepository: ReturnType<typeof createAgentRepository>;
 
   beforeAll(async () => {
     harness = await createTestHarness();
@@ -28,16 +30,126 @@ describe('Webhook Handlers (Agent)', () => {
       db: harness.db,
       bootstrapIdentityId: harness.bootstrapIdentityId,
     });
+    agentRepository = createAgentRepository(harness.db);
   });
 
   afterAll(async () => {
     await harness?.teardown();
   });
 
-  // ── After Settings (Key Rotation) ───────────────────────────
+  // ── Settings Validation (Pre-Persist) ───────────────────────
+
+  describe('POST /hooks/kratos/validate-settings', () => {
+    it('accepts a valid key without updating the agent projection', async () => {
+      const before = await agentRepository.findByIdentityId(agent.identityId);
+      const newKeyPair = await cryptoService.generateKeyPair();
+
+      const resp = await fetch(
+        `${harness.baseUrl}/hooks/kratos/validate-settings`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-ory-api-key': WEBHOOK_API_KEY,
+          },
+          body: JSON.stringify({
+            identity: {
+              id: agent.identityId,
+              traits: {
+                public_key: newKeyPair.publicKey,
+              },
+            },
+          }),
+        },
+      );
+
+      expect(resp.status).toBe(200);
+      const body = (await resp.json()) as { success: boolean };
+      expect(body.success).toBe(true);
+
+      const after = await agentRepository.findByIdentityId(agent.identityId);
+      expect(after).toEqual(before);
+    });
+
+    it('rejects invalid public key format', async () => {
+      const resp = await fetch(
+        `${harness.baseUrl}/hooks/kratos/validate-settings`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-ory-api-key': WEBHOOK_API_KEY,
+          },
+          body: JSON.stringify({
+            identity: {
+              id: agent.identityId,
+              traits: { public_key: 'invalid-format' },
+            },
+          }),
+        },
+      );
+
+      expect(resp.status).toBe(400);
+      const body = (await resp.json()) as {
+        messages: Array<{ instance_ptr: string }>;
+      };
+      expect(body.messages[0].instance_ptr).toBe('#/traits/public_key');
+    });
+
+    it('rejects a public key with the wrong decoded length', async () => {
+      const resp = await fetch(
+        `${harness.baseUrl}/hooks/kratos/validate-settings`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-ory-api-key': WEBHOOK_API_KEY,
+          },
+          body: JSON.stringify({
+            identity: {
+              id: agent.identityId,
+              traits: {
+                public_key: `ed25519:${Buffer.alloc(31).toString('base64')}`,
+              },
+            },
+          }),
+        },
+      );
+
+      expect(resp.status).toBe(400);
+      const body = (await resp.json()) as {
+        messages: Array<{
+          instance_ptr: string;
+          messages: Array<{ text: string }>;
+        }>;
+      };
+      expect(body.messages[0].instance_ptr).toBe('#/traits/public_key');
+      expect(body.messages[0].messages[0].text).toContain('exactly 32 bytes');
+    });
+
+    it('rejects missing webhook API key', async () => {
+      const resp = await fetch(
+        `${harness.baseUrl}/hooks/kratos/validate-settings`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            identity: {
+              id: agent.identityId,
+              traits: { public_key: agent.keyPair.publicKey },
+            },
+          }),
+        },
+      );
+
+      expect(resp.status).toBe(403);
+    });
+  });
+
+  // ── After Settings (Post-Persist Key Projection) ────────────
 
   describe('POST /hooks/kratos/after-settings', () => {
-    it('updates agent key on settings change', async () => {
+    it('updates the persisted agent key and fingerprint', async () => {
       const newKeyPair = await cryptoService.generateKeyPair();
 
       const resp = await fetch(
@@ -62,9 +174,13 @@ describe('Webhook Handlers (Agent)', () => {
       expect(resp.status).toBe(200);
       const body = (await resp.json()) as { success: boolean };
       expect(body.success).toBe(true);
+
+      const updated = await agentRepository.findByIdentityId(agent.identityId);
+      expect(updated?.publicKey).toBe(newKeyPair.publicKey);
+      expect(updated?.fingerprint).toBe(newKeyPair.fingerprint);
     });
 
-    it('rejects invalid public key format', async () => {
+    it('returns an Ory error envelope for invalid post-persist state', async () => {
       const resp = await fetch(
         `${harness.baseUrl}/hooks/kratos/after-settings`,
         {
@@ -82,11 +198,11 @@ describe('Webhook Handlers (Agent)', () => {
         },
       );
 
-      expect(resp.status).toBe(400);
+      expect(resp.status).toBe(500);
       const body = (await resp.json()) as {
-        messages: Array<{ instance_ptr: string }>;
+        messages: Array<{ messages: Array<{ id: number }> }>;
       };
-      expect(body.messages[0].instance_ptr).toBe('#/traits/public_key');
+      expect(body.messages[0].messages[0].id).toBe(5000002);
     });
 
     it('rejects missing webhook API key', async () => {

--- a/apps/rest-api-e2e/src/human-auth.e2e.test.ts
+++ b/apps/rest-api-e2e/src/human-auth.e2e.test.ts
@@ -100,6 +100,41 @@ describe('Human Authentication E2E', { timeout: 60_000 }, () => {
 
       expect(after.identityId).toBe(before.identityId);
     });
+
+    it('changes a password through the configured Kratos settings hooks', async () => {
+      const newPassword = `${human.password}-rotated`;
+      const settingsFlow =
+        await harness.kratosPublicFrontend.createNativeSettingsFlow({
+          xSessionToken: human.sessionToken,
+        });
+
+      await harness.kratosPublicFrontend.updateSettingsFlow({
+        flow: settingsFlow.id,
+        xSessionToken: human.sessionToken,
+        updateSettingsFlowBody: {
+          method: 'password',
+          password: newPassword,
+        },
+      });
+
+      const loginFlow =
+        await harness.kratosPublicFrontend.createNativeLoginFlow();
+      const loginResult = await harness.kratosPublicFrontend.updateLoginFlow({
+        flow: loginFlow.id,
+        updateLoginFlowBody: {
+          method: 'password',
+          identifier: human.email,
+          password: newPassword,
+        },
+      });
+
+      expect(loginResult.session.identity?.id).toBe(human.identityId);
+      if (!loginResult.session_token) {
+        throw new Error('Password-change login did not return a session token');
+      }
+      human.password = newPassword;
+      human.sessionToken = loginResult.session_token;
+    });
   });
 
   // ── After-Registration Webhook Security ───────────────────────

--- a/apps/rest-api/__tests__/helpers.ts
+++ b/apps/rest-api/__tests__/helpers.ts
@@ -804,6 +804,7 @@ export async function createTestApp(
         identity_id: OWNER_ID,
       },
     }),
+    setOAuth2Client: vi.fn().mockResolvedValue(undefined),
   } as unknown as OryClients['oauth2'];
 
   const mockIdentityApi = {

--- a/apps/rest-api/__tests__/hooks.test.ts
+++ b/apps/rest-api/__tests__/hooks.test.ts
@@ -1,6 +1,13 @@
 import type { FastifyInstance } from 'fastify';
-import type { vi } from 'vitest';
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 
 import {
   createMockAgent,
@@ -23,6 +30,10 @@ describe('Hook routes', () => {
     mocks = createMockServices();
     // Hooks don't require auth (they're called by Ory services)
     app = await createTestApp(mocks, null);
+    app.sessionResolver = {
+      evictIdentity: vi.fn(),
+      resolveSession: vi.fn(),
+    };
   });
 
   afterAll(async () => {
@@ -31,6 +42,7 @@ describe('Hook routes', () => {
 
   beforeEach(() => {
     resetMockServices(mocks);
+    vi.mocked(app.sessionResolver!.evictIdentity).mockClear();
   });
 
   describe('POST /hooks/kratos/after-registration', () => {
@@ -115,6 +127,52 @@ describe('Hook routes', () => {
 
       expect(response.statusCode).toBe(200);
       expect(response.json().success).toBe(true);
+      expect(app.sessionResolver?.evictIdentity).toHaveBeenCalledWith(OWNER_ID);
+      expect(
+        vi.mocked(app.sessionResolver!.evictIdentity).mock
+          .invocationCallOrder[0],
+      ).toBeLessThan(mocks.agentRepository.upsert.mock.invocationCallOrder[0]);
+    });
+
+    it('evicts human sessions after password settings without an agent key', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/hooks/kratos/after-settings',
+        headers: { 'x-ory-api-key': TEST_WEBHOOK_API_KEY },
+        payload: {
+          identity: {
+            id: HUMAN_IDENTITY_ID,
+            traits: { email: 'human@test.local', username: 'human' },
+          },
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(mocks.agentRepository.upsert).not.toHaveBeenCalled();
+      expect(app.sessionResolver?.evictIdentity).toHaveBeenCalledWith(
+        HUMAN_IDENTITY_ID,
+      );
+    });
+
+    it('still evicts after Kratos commits settings when key projection fails', async () => {
+      mocks.cryptoService.parsePublicKey.mockImplementation(() => {
+        throw new Error('invalid key');
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/hooks/kratos/after-settings',
+        headers: { 'x-ory-api-key': TEST_WEBHOOK_API_KEY },
+        payload: {
+          identity: {
+            id: OWNER_ID,
+            traits: { public_key: 'invalid' },
+          },
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(app.sessionResolver?.evictIdentity).toHaveBeenCalledWith(OWNER_ID);
     });
   });
 

--- a/apps/rest-api/__tests__/hooks.test.ts
+++ b/apps/rest-api/__tests__/hooks.test.ts
@@ -43,6 +43,10 @@ describe('Hook routes', () => {
   beforeEach(() => {
     resetMockServices(mocks);
     vi.mocked(app.sessionResolver!.evictIdentity).mockClear();
+    mocks.cryptoService.parsePublicKey.mockReturnValue(new Uint8Array(32));
+    mocks.cryptoService.generateFingerprint.mockReturnValue(
+      'C212-DAFA-27C5-6C57',
+    );
   });
 
   describe('POST /hooks/kratos/after-registration', () => {
@@ -102,6 +106,62 @@ describe('Hook routes', () => {
     });
   });
 
+  describe('POST /hooks/kratos/validate-settings', () => {
+    it('validates an agent public key without mutating dependent state', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/hooks/kratos/validate-settings',
+        headers: { 'x-ory-api-key': TEST_WEBHOOK_API_KEY },
+        payload: {
+          identity: {
+            id: OWNER_ID,
+            traits: {
+              public_key:
+                'ed25519:bW9sdG5ldC10ZXN0LWtleS0yLWZvci11bml0LXRlc3Q=',
+            },
+          },
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().success).toBe(true);
+      expect(mocks.cryptoService.parsePublicKey).toHaveBeenCalledOnce();
+      expect(mocks.agentRepository.upsert).not.toHaveBeenCalled();
+      expect(app.sessionResolver?.evictIdentity).not.toHaveBeenCalled();
+    });
+
+    it('returns an Ory validation error for an invalid public key', async () => {
+      mocks.cryptoService.parsePublicKey.mockImplementation(() => {
+        throw new Error('invalid key');
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/hooks/kratos/validate-settings',
+        headers: { 'x-ory-api-key': TEST_WEBHOOK_API_KEY },
+        payload: {
+          identity: {
+            id: OWNER_ID,
+            traits: { public_key: 'invalid' },
+          },
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json()).toEqual(
+        expect.objectContaining({
+          messages: [
+            expect.objectContaining({
+              instance_ptr: '#/traits/public_key',
+            }),
+          ],
+        }),
+      );
+      expect(mocks.agentRepository.upsert).not.toHaveBeenCalled();
+      expect(app.sessionResolver?.evictIdentity).not.toHaveBeenCalled();
+    });
+  });
+
   describe('POST /hooks/kratos/after-settings', () => {
     it('updates agent entry', async () => {
       mocks.agentRepository.upsert.mockResolvedValue(
@@ -154,10 +214,10 @@ describe('Hook routes', () => {
       );
     });
 
-    it('still evicts after Kratos commits settings when key projection fails', async () => {
-      mocks.cryptoService.parsePublicKey.mockImplementation(() => {
-        throw new Error('invalid key');
-      });
+    it('returns an Ory error and keeps the committed identity evicted when projection fails', async () => {
+      mocks.agentRepository.upsert.mockRejectedValue(
+        new Error('database unavailable'),
+      );
 
       const response = await app.inject({
         method: 'POST',
@@ -166,12 +226,30 @@ describe('Hook routes', () => {
         payload: {
           identity: {
             id: OWNER_ID,
-            traits: { public_key: 'invalid' },
+            traits: {
+              public_key:
+                'ed25519:bW9sdG5ldC10ZXN0LWtleS0yLWZvci11bml0LXRlc3Q=',
+            },
           },
         },
       });
 
-      expect(response.statusCode).toBe(400);
+      expect(response.statusCode).toBe(500);
+      expect(response.json()).toEqual(
+        expect.objectContaining({
+          messages: [
+            expect.objectContaining({
+              instance_ptr: '#/',
+              messages: [
+                expect.objectContaining({
+                  id: 5000002,
+                  type: 'error',
+                }),
+              ],
+            }),
+          ],
+        }),
+      );
       expect(app.sessionResolver?.evictIdentity).toHaveBeenCalledWith(OWNER_ID);
     });
   });

--- a/apps/rest-api/__tests__/registration.test.ts
+++ b/apps/rest-api/__tests__/registration.test.ts
@@ -24,6 +24,7 @@ import {
   createMockServices,
   createTestApp,
   type MockServices,
+  VALID_AUTH_CONTEXT,
 } from './helpers.js';
 
 // ── DBOS + Workflow Mocks ──────────────────────────────────────
@@ -138,6 +139,54 @@ describe('Registration routes', () => {
         FINGERPRINT,
         VALID_VOUCHER_CODE,
       );
+    });
+  });
+
+  describe('POST /auth/rotate-secret', () => {
+    let rotateApp: FastifyInstance;
+
+    beforeAll(async () => {
+      rotateApp = await createTestApp(mocks, VALID_AUTH_CONTEXT);
+    });
+
+    afterAll(async () => {
+      await rotateApp.close();
+    });
+
+    it('evicts cached OAuth contexts after Hydra rotates the secret', async () => {
+      const response = await rotateApp.inject({
+        method: 'POST',
+        url: '/auth/rotate-secret',
+        headers: { authorization: 'Bearer test-token' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(rotateApp.oauth2Client.setOAuth2Client).toHaveBeenCalledOnce();
+      expect(rotateApp.tokenValidator.evictOAuthClient).toHaveBeenCalledWith(
+        VALID_AUTH_CONTEXT.clientId,
+      );
+      expect(
+        vi.mocked(rotateApp.oauth2Client.setOAuth2Client).mock
+          .invocationCallOrder[0],
+      ).toBeLessThan(
+        vi.mocked(rotateApp.tokenValidator.evictOAuthClient).mock
+          .invocationCallOrder[0],
+      );
+    });
+
+    it('does not evict when Hydra rejects the secret rotation', async () => {
+      vi.mocked(rotateApp.oauth2Client.setOAuth2Client).mockRejectedValueOnce(
+        new Error('Hydra unavailable'),
+      );
+
+      const response = await rotateApp.inject({
+        method: 'POST',
+        url: '/auth/rotate-secret',
+        headers: { authorization: 'Bearer test-token' },
+      });
+
+      expect(response.statusCode).toBe(502);
+      expect(rotateApp.tokenValidator.evictOAuthClient).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/rest-api/__tests__/settings-cache-eviction.integration.test.ts
+++ b/apps/rest-api/__tests__/settings-cache-eviction.integration.test.ts
@@ -1,0 +1,146 @@
+import { readFileSync } from 'node:fs';
+
+import { createSessionResolver, RemoteAuthCache } from '@moltnet/auth';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import {
+  createMockServices,
+  createTestApp,
+  type MockServices,
+  TEST_WEBHOOK_API_KEY,
+} from './helpers.js';
+
+const IDENTITY_ID = '550e8400-e29b-41d4-a716-446655440000';
+const FIRST_HUMAN_ID = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+const SECOND_HUMAN_ID = '7ca7b810-9dad-11d1-80b4-00c04fd430c9';
+const KRATOS_SESSION_TOKEN = 'ory_st_settings_cache_integration';
+
+describe('Kratos settings cache lifecycle', () => {
+  let app: Awaited<ReturnType<typeof createTestApp>>;
+  let mocks: MockServices;
+
+  beforeAll(async () => {
+    mocks = createMockServices();
+    app = await createTestApp(mocks, null);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('keeps validation side-effect free and refetches after the committed hook', async () => {
+    let committedHumanId = FIRST_HUMAN_ID;
+    const toSession = vi.fn().mockImplementation(async () => ({
+      id: 'session-uuid',
+      active: true,
+      identity: {
+        id: IDENTITY_ID,
+        schema_id: 'moltnet_human',
+        traits: { email: 'human@example.com' },
+        metadata_public: { human_id: committedHumanId },
+      },
+    }));
+    const resolver = createSessionResolver({ toSession } as never, {
+      remoteAuthCache: new RemoteAuthCache({ ttlMs: 60_000 }),
+    });
+    app.sessionResolver = resolver;
+
+    const first = await resolver.resolveSession({
+      sessionToken: KRATOS_SESSION_TOKEN,
+    });
+    expect(first).toMatchObject({ humanId: FIRST_HUMAN_ID });
+
+    const validationResponse = await app.inject({
+      method: 'POST',
+      url: '/hooks/kratos/validate-settings',
+      headers: { 'x-ory-api-key': TEST_WEBHOOK_API_KEY },
+      payload: {
+        identity: {
+          id: IDENTITY_ID,
+          traits: { email: 'human@example.com' },
+        },
+      },
+    });
+    expect(validationResponse.statusCode).toBe(200);
+
+    committedHumanId = SECOND_HUMAN_ID;
+    const stillCached = await resolver.resolveSession({
+      sessionToken: KRATOS_SESSION_TOKEN,
+    });
+    expect(stillCached).toMatchObject({ humanId: FIRST_HUMAN_ID });
+    expect(toSession).toHaveBeenCalledOnce();
+
+    const committedResponse = await app.inject({
+      method: 'POST',
+      url: '/hooks/kratos/after-settings',
+      headers: { 'x-ory-api-key': TEST_WEBHOOK_API_KEY },
+      payload: {
+        identity: {
+          id: IDENTITY_ID,
+          traits: { email: 'human@example.com' },
+        },
+      },
+    });
+    expect(committedResponse.statusCode).toBe(200);
+
+    const refreshed = await resolver.resolveSession({
+      sessionToken: KRATOS_SESSION_TOKEN,
+    });
+    expect(refreshed).toMatchObject({ humanId: SECOND_HUMAN_ID });
+    expect(toSession).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(['password', 'profile'] as const)(
+    'configures %s settings validation before committed side effects',
+    (method) => {
+      const project = JSON.parse(
+        readFileSync(
+          new URL('../../../infra/ory/project.json', import.meta.url),
+          'utf8',
+        ),
+      ) as {
+        services: {
+          identity: {
+            config: {
+              selfservice: {
+                flows: {
+                  settings: {
+                    after: Record<
+                      typeof method,
+                      {
+                        hooks: Array<{
+                          config: {
+                            can_interrupt: boolean;
+                            response: { ignore: boolean; parse: boolean };
+                            url: string;
+                          };
+                        }>;
+                      }
+                    >;
+                  };
+                };
+              };
+            };
+          };
+        };
+      };
+
+      const hooks =
+        project.services.identity.config.selfservice.flows.settings.after[
+          method
+        ].hooks;
+
+      expect(hooks).toHaveLength(2);
+      expect(hooks[0]?.config).toMatchObject({
+        can_interrupt: true,
+        response: { ignore: false, parse: true },
+        url: '${API_BASE_URL}/hooks/kratos/validate-settings',
+      });
+      expect(hooks[1]?.config).toMatchObject({
+        can_interrupt: false,
+        response: { ignore: false, parse: false },
+        url: '${API_BASE_URL}/hooks/kratos/after-settings',
+      });
+    },
+  );
+});

--- a/apps/rest-api/public/openapi.json
+++ b/apps/rest-api/public/openapi.json
@@ -1121,6 +1121,10 @@
               "instance": {
                 "type": "string"
               },
+              "retryAfter": {
+                "minimum": 0,
+                "type": "integer"
+              },
               "status": {
                 "maximum": 599,
                 "minimum": 100,
@@ -4236,6 +4240,10 @@
                   "instance": {
                     "type": "string"
                   },
+                  "retryAfter": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
                   "status": {
                     "maximum": 599,
                     "minimum": 100,
@@ -5846,6 +5854,10 @@
           },
           "instance": {
             "type": "string"
+          },
+          "retryAfter": {
+            "minimum": 0,
+            "type": "integer"
           },
           "status": {
             "maximum": 599,
@@ -13899,6 +13911,10 @@
               },
               "instance": {
                 "type": "string"
+              },
+              "retryAfter": {
+                "minimum": 0,
+                "type": "integer"
               },
               "status": {
                 "maximum": 599,
@@ -28530,6 +28546,10 @@
                         "instance": {
                           "type": "string"
                         },
+                        "retryAfter": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
                         "status": {
                           "maximum": 599,
                           "minimum": 100,
@@ -28761,6 +28781,10 @@
                     "instance": {
                       "type": "string"
                     },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
                     "status": {
                       "maximum": 599,
                       "minimum": 100,
@@ -28976,6 +29000,10 @@
                     "instance": {
                       "type": "string"
                     },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
                     "status": {
                       "maximum": 599,
                       "minimum": 100,
@@ -29190,6 +29218,10 @@
                     },
                     "instance": {
                       "type": "string"
+                    },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
                     },
                     "status": {
                       "maximum": 599,
@@ -29492,6 +29524,10 @@
                         "instance": {
                           "type": "string"
                         },
+                        "retryAfter": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
                         "status": {
                           "maximum": 599,
                           "minimum": 100,
@@ -29723,6 +29759,10 @@
                     "instance": {
                       "type": "string"
                     },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
                     "status": {
                       "maximum": 599,
                       "minimum": 100,
@@ -29938,6 +29978,10 @@
                     "instance": {
                       "type": "string"
                     },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
                     "status": {
                       "maximum": 599,
                       "minimum": 100,
@@ -30152,6 +30196,10 @@
                     },
                     "instance": {
                       "type": "string"
+                    },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
                     },
                     "status": {
                       "maximum": 599,
@@ -30377,6 +30425,10 @@
                     },
                     "instance": {
                       "type": "string"
+                    },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
                     },
                     "status": {
                       "maximum": 599,
@@ -30856,6 +30908,10 @@
                         "instance": {
                           "type": "string"
                         },
+                        "retryAfter": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
                         "status": {
                           "maximum": 599,
                           "minimum": 100,
@@ -31087,6 +31143,10 @@
                     "instance": {
                       "type": "string"
                     },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
                     "status": {
                       "maximum": 599,
                       "minimum": 100,
@@ -31301,6 +31361,10 @@
                     },
                     "instance": {
                       "type": "string"
+                    },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
                     },
                     "status": {
                       "maximum": 599,
@@ -31517,6 +31581,10 @@
                     "instance": {
                       "type": "string"
                     },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
                     "status": {
                       "maximum": 599,
                       "minimum": 100,
@@ -31731,6 +31799,10 @@
                     },
                     "instance": {
                       "type": "string"
+                    },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
                     },
                     "status": {
                       "maximum": 599,
@@ -31956,6 +32028,10 @@
                     },
                     "instance": {
                       "type": "string"
+                    },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
                     },
                     "status": {
                       "maximum": 599,
@@ -32500,6 +32576,10 @@
                         "instance": {
                           "type": "string"
                         },
+                        "retryAfter": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
                         "status": {
                           "maximum": 599,
                           "minimum": 100,
@@ -32731,6 +32811,10 @@
                     "instance": {
                       "type": "string"
                     },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
                     "status": {
                       "maximum": 599,
                       "minimum": 100,
@@ -32946,6 +33030,10 @@
                     "instance": {
                       "type": "string"
                     },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
                     "status": {
                       "maximum": 599,
                       "minimum": 100,
@@ -33160,6 +33248,10 @@
                     },
                     "instance": {
                       "type": "string"
+                    },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
                     },
                     "status": {
                       "maximum": 599,
@@ -33676,6 +33768,10 @@
                         "instance": {
                           "type": "string"
                         },
+                        "retryAfter": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
                         "status": {
                           "maximum": 599,
                           "minimum": 100,
@@ -33907,6 +34003,10 @@
                     "instance": {
                       "type": "string"
                     },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
                     "status": {
                       "maximum": 599,
                       "minimum": 100,
@@ -34122,6 +34222,10 @@
                     "instance": {
                       "type": "string"
                     },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
                     "status": {
                       "maximum": 599,
                       "minimum": 100,
@@ -34336,6 +34440,10 @@
                     },
                     "instance": {
                       "type": "string"
+                    },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
                     },
                     "status": {
                       "maximum": 599,
@@ -34553,6 +34661,10 @@
                         },
                         "instance": {
                           "type": "string"
+                        },
+                        "retryAfter": {
+                          "minimum": 0,
+                          "type": "integer"
                         },
                         "status": {
                           "maximum": 599,
@@ -35038,6 +35150,10 @@
                         "instance": {
                           "type": "string"
                         },
+                        "retryAfter": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
                         "status": {
                           "maximum": 599,
                           "minimum": 100,
@@ -35269,6 +35385,10 @@
                     "instance": {
                       "type": "string"
                     },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
                     "status": {
                       "maximum": 599,
                       "minimum": 100,
@@ -35484,6 +35604,10 @@
                     "instance": {
                       "type": "string"
                     },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
                     "status": {
                       "maximum": 599,
                       "minimum": 100,
@@ -35698,6 +35822,10 @@
                     },
                     "instance": {
                       "type": "string"
+                    },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
                     },
                     "status": {
                       "maximum": 599,
@@ -35915,6 +36043,10 @@
                         },
                         "instance": {
                           "type": "string"
+                        },
+                        "retryAfter": {
+                          "minimum": 0,
+                          "type": "integer"
                         },
                         "status": {
                           "maximum": 599,
@@ -36449,6 +36581,10 @@
                         "instance": {
                           "type": "string"
                         },
+                        "retryAfter": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
                         "status": {
                           "maximum": 599,
                           "minimum": 100,
@@ -36680,6 +36816,10 @@
                     "instance": {
                       "type": "string"
                     },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
                     "status": {
                       "maximum": 599,
                       "minimum": 100,
@@ -36895,6 +37035,10 @@
                     "instance": {
                       "type": "string"
                     },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
                     "status": {
                       "maximum": 599,
                       "minimum": 100,
@@ -37109,6 +37253,10 @@
                     },
                     "instance": {
                       "type": "string"
+                    },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
                     },
                     "status": {
                       "maximum": 599,
@@ -37446,6 +37594,10 @@
                         "instance": {
                           "type": "string"
                         },
+                        "retryAfter": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
                         "status": {
                           "maximum": 599,
                           "minimum": 100,
@@ -37677,6 +37829,10 @@
                     "instance": {
                       "type": "string"
                     },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
                     "status": {
                       "maximum": 599,
                       "minimum": 100,
@@ -37892,6 +38048,10 @@
                     "instance": {
                       "type": "string"
                     },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
                     "status": {
                       "maximum": 599,
                       "minimum": 100,
@@ -38106,6 +38266,10 @@
                     },
                     "instance": {
                       "type": "string"
+                    },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
                     },
                     "status": {
                       "maximum": 599,
@@ -38331,6 +38495,10 @@
                     },
                     "instance": {
                       "type": "string"
+                    },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
                     },
                     "status": {
                       "maximum": 599,
@@ -41112,6 +41280,10 @@
                         "instance": {
                           "type": "string"
                         },
+                        "retryAfter": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
                         "status": {
                           "maximum": 599,
                           "minimum": 100,
@@ -41343,6 +41515,10 @@
                     "instance": {
                       "type": "string"
                     },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
                     "status": {
                       "maximum": 599,
                       "minimum": 100,
@@ -41558,6 +41734,10 @@
                     "instance": {
                       "type": "string"
                     },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
                     "status": {
                       "maximum": 599,
                       "minimum": 100,
@@ -41772,6 +41952,10 @@
                     },
                     "instance": {
                       "type": "string"
+                    },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
                     },
                     "status": {
                       "maximum": 599,
@@ -42101,6 +42285,10 @@
                         "instance": {
                           "type": "string"
                         },
+                        "retryAfter": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
                         "status": {
                           "maximum": 599,
                           "minimum": 100,
@@ -42332,6 +42520,10 @@
                     "instance": {
                       "type": "string"
                     },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
                     "status": {
                       "maximum": 599,
                       "minimum": 100,
@@ -42547,6 +42739,10 @@
                     "instance": {
                       "type": "string"
                     },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
                     "status": {
                       "maximum": 599,
                       "minimum": 100,
@@ -42761,6 +42957,10 @@
                     },
                     "instance": {
                       "type": "string"
+                    },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
                     },
                     "status": {
                       "maximum": 599,
@@ -42986,6 +43186,10 @@
                     },
                     "instance": {
                       "type": "string"
+                    },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
                     },
                     "status": {
                       "maximum": 599,
@@ -43422,6 +43626,10 @@
                         "instance": {
                           "type": "string"
                         },
+                        "retryAfter": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
                         "status": {
                           "maximum": 599,
                           "minimum": 100,
@@ -43653,6 +43861,10 @@
                     "instance": {
                       "type": "string"
                     },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
                     "status": {
                       "maximum": 599,
                       "minimum": 100,
@@ -43868,6 +44080,10 @@
                     "instance": {
                       "type": "string"
                     },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
                     "status": {
                       "maximum": 599,
                       "minimum": 100,
@@ -44082,6 +44298,10 @@
                     },
                     "instance": {
                       "type": "string"
+                    },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
                     },
                     "status": {
                       "maximum": 599,
@@ -44317,6 +44537,10 @@
                     },
                     "instance": {
                       "type": "string"
+                    },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
                     },
                     "status": {
                       "maximum": 599,
@@ -44635,6 +44859,10 @@
                         "instance": {
                           "type": "string"
                         },
+                        "retryAfter": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
                         "status": {
                           "maximum": 599,
                           "minimum": 100,
@@ -44866,6 +45094,10 @@
                     "instance": {
                       "type": "string"
                     },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
                     "status": {
                       "maximum": 599,
                       "minimum": 100,
@@ -45081,6 +45313,10 @@
                     "instance": {
                       "type": "string"
                     },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
                     "status": {
                       "maximum": 599,
                       "minimum": 100,
@@ -45295,6 +45531,10 @@
                     },
                     "instance": {
                       "type": "string"
+                    },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
                     },
                     "status": {
                       "maximum": 599,
@@ -45520,6 +45760,10 @@
                     },
                     "instance": {
                       "type": "string"
+                    },
+                    "retryAfter": {
+                      "minimum": 0,
+                      "type": "integer"
                     },
                     "status": {
                       "maximum": 599,

--- a/apps/rest-api/public/openapi.json
+++ b/apps/rest-api/public/openapi.json
@@ -1122,6 +1122,7 @@
                 "type": "string"
               },
               "retryAfter": {
+                "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                 "minimum": 0,
                 "type": "integer"
               },
@@ -4241,6 +4242,7 @@
                     "type": "string"
                   },
                   "retryAfter": {
+                    "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                     "minimum": 0,
                     "type": "integer"
                   },
@@ -5856,6 +5858,7 @@
             "type": "string"
           },
           "retryAfter": {
+            "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
             "minimum": 0,
             "type": "integer"
           },
@@ -13913,6 +13916,7 @@
                 "type": "string"
               },
               "retryAfter": {
+                "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                 "minimum": 0,
                 "type": "integer"
               },
@@ -28547,6 +28551,7 @@
                           "type": "string"
                         },
                         "retryAfter": {
+                          "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                           "minimum": 0,
                           "type": "integer"
                         },
@@ -28782,6 +28787,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -29001,6 +29007,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -29220,6 +29227,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -29525,6 +29533,7 @@
                           "type": "string"
                         },
                         "retryAfter": {
+                          "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                           "minimum": 0,
                           "type": "integer"
                         },
@@ -29760,6 +29769,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -29979,6 +29989,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -30198,6 +30209,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -30427,6 +30439,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -30909,6 +30922,7 @@
                           "type": "string"
                         },
                         "retryAfter": {
+                          "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                           "minimum": 0,
                           "type": "integer"
                         },
@@ -31144,6 +31158,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -31363,6 +31378,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -31582,6 +31598,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -31801,6 +31818,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -32030,6 +32048,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -32577,6 +32596,7 @@
                           "type": "string"
                         },
                         "retryAfter": {
+                          "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                           "minimum": 0,
                           "type": "integer"
                         },
@@ -32812,6 +32832,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -33031,6 +33052,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -33250,6 +33272,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -33769,6 +33792,7 @@
                           "type": "string"
                         },
                         "retryAfter": {
+                          "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                           "minimum": 0,
                           "type": "integer"
                         },
@@ -34004,6 +34028,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -34223,6 +34248,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -34442,6 +34468,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -34663,6 +34690,7 @@
                           "type": "string"
                         },
                         "retryAfter": {
+                          "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                           "minimum": 0,
                           "type": "integer"
                         },
@@ -35151,6 +35179,7 @@
                           "type": "string"
                         },
                         "retryAfter": {
+                          "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                           "minimum": 0,
                           "type": "integer"
                         },
@@ -35386,6 +35415,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -35605,6 +35635,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -35824,6 +35855,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -36045,6 +36077,7 @@
                           "type": "string"
                         },
                         "retryAfter": {
+                          "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                           "minimum": 0,
                           "type": "integer"
                         },
@@ -36582,6 +36615,7 @@
                           "type": "string"
                         },
                         "retryAfter": {
+                          "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                           "minimum": 0,
                           "type": "integer"
                         },
@@ -36817,6 +36851,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -37036,6 +37071,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -37255,6 +37291,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -37595,6 +37632,7 @@
                           "type": "string"
                         },
                         "retryAfter": {
+                          "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                           "minimum": 0,
                           "type": "integer"
                         },
@@ -37830,6 +37868,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -38049,6 +38088,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -38268,6 +38308,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -38497,6 +38538,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -41281,6 +41323,7 @@
                           "type": "string"
                         },
                         "retryAfter": {
+                          "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                           "minimum": 0,
                           "type": "integer"
                         },
@@ -41516,6 +41559,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -41735,6 +41779,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -41954,6 +41999,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -42286,6 +42332,7 @@
                           "type": "string"
                         },
                         "retryAfter": {
+                          "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                           "minimum": 0,
                           "type": "integer"
                         },
@@ -42521,6 +42568,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -42740,6 +42788,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -42959,6 +43008,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -43188,6 +43238,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -43627,6 +43678,7 @@
                           "type": "string"
                         },
                         "retryAfter": {
+                          "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                           "minimum": 0,
                           "type": "integer"
                         },
@@ -43862,6 +43914,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -44081,6 +44134,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -44300,6 +44354,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -44539,6 +44594,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -44860,6 +44916,7 @@
                           "type": "string"
                         },
                         "retryAfter": {
+                          "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                           "minimum": 0,
                           "type": "integer"
                         },
@@ -45095,6 +45152,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -45314,6 +45372,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -45533,6 +45592,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },
@@ -45762,6 +45822,7 @@
                       "type": "string"
                     },
                     "retryAfter": {
+                      "description": "Non-negative delay in seconds before retrying, matching the Retry-After response header when present.",
                       "minimum": 0,
                       "type": "integer"
                     },

--- a/apps/rest-api/src/routes/hooks.ts
+++ b/apps/rest-api/src/routes/hooks.ts
@@ -256,7 +256,7 @@ export async function hookRoutes(fastify: FastifyInstance) {
                 id: Type.String(),
                 traits: Type.Object(
                   {
-                    public_key: Type.String(),
+                    public_key: Type.Optional(Type.String()),
                   },
                   { additionalProperties: true },
                 ),
@@ -272,44 +272,53 @@ export async function hookRoutes(fastify: FastifyInstance) {
     async (request, reply) => {
       const { identity } = request.body;
 
+      // This is an after-settings hook: Kratos has already committed the
+      // authoritative identity change. Invalidate first even if the optional
+      // agent profile projection below fails.
+      fastify.sessionResolver?.evictIdentity(identity.id);
+
       const { public_key } = identity.traits;
 
-      // ── Validate public_key format and Ed25519 key bytes ──────────
-      let settingsKeyBytes: Uint8Array;
-      try {
-        settingsKeyBytes = cryptoService.parsePublicKey(public_key);
-      } catch {
-        return reply
-          .status(400)
-          .send(
-            oryValidationError(
-              '#/traits/public_key',
-              4000001,
-              'public_key must use format "ed25519:<base64>"',
-            ),
-          );
+      if (public_key !== undefined) {
+        // Agent profile changes also rotate the canonical public key. Human
+        // profile/password settings have no public_key and need only the
+        // Kratos-session invalidation above.
+        let settingsKeyBytes: Uint8Array;
+        try {
+          settingsKeyBytes = cryptoService.parsePublicKey(public_key);
+        } catch {
+          return reply
+            .status(400)
+            .send(
+              oryValidationError(
+                '#/traits/public_key',
+                4000001,
+                'public_key must use format "ed25519:<base64>"',
+              ),
+            );
+        }
+
+        if (settingsKeyBytes.length !== 32) {
+          return reply
+            .status(400)
+            .send(
+              oryValidationError(
+                '#/traits/public_key',
+                4000001,
+                `public_key must be exactly 32 bytes (got ${settingsKeyBytes.length}).`,
+              ),
+            );
+        }
+
+        const settingsFingerprint =
+          cryptoService.generateFingerprint(settingsKeyBytes);
+
+        await fastify.agentRepository.upsert({
+          identityId: identity.id,
+          publicKey: public_key,
+          fingerprint: settingsFingerprint,
+        });
       }
-
-      if (settingsKeyBytes.length !== 32) {
-        return reply
-          .status(400)
-          .send(
-            oryValidationError(
-              '#/traits/public_key',
-              4000001,
-              `public_key must be exactly 32 bytes (got ${settingsKeyBytes.length}).`,
-            ),
-          );
-      }
-
-      const settingsFingerprint =
-        cryptoService.generateFingerprint(settingsKeyBytes);
-
-      await fastify.agentRepository.upsert({
-        identityId: identity.id,
-        publicKey: public_key,
-        fingerprint: settingsFingerprint,
-      });
 
       return reply.status(200).send({ success: true });
     },

--- a/apps/rest-api/src/routes/hooks.ts
+++ b/apps/rest-api/src/routes/hooks.ts
@@ -2,6 +2,7 @@
  * Ory webhook handler routes (internal — hidden from public OpenAPI spec)
  *
  * POST /hooks/kratos/after-registration — Kratos after-registration webhook
+ * POST /hooks/kratos/validate-settings — Kratos pre-persist settings validation
  * POST /hooks/kratos/after-settings — Kratos after-settings webhook
  * POST /hooks/hydra/token-exchange — Hydra token exchange webhook
  */
@@ -10,7 +11,6 @@ import crypto from 'node:crypto';
 
 import type { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 import type { OryClients } from '@moltnet/auth';
-import { cryptoService } from '@moltnet/crypto-service';
 import { DBOS, type HumanRepository } from '@moltnet/database';
 import type { IdentityApi } from '@ory/client-fetch';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
@@ -242,86 +242,130 @@ export async function hookRoutes(fastify: FastifyInstance) {
     },
   );
 
-  // ── Kratos After Settings ──────────────────────────────────
+  const SettingsWebhookBodySchema = Type.Object(
+    {
+      identity: Type.Object(
+        {
+          id: Type.String(),
+          traits: Type.Object(
+            {
+              public_key: Type.Optional(Type.String()),
+            },
+            { additionalProperties: true },
+          ),
+        },
+        { additionalProperties: true },
+      ),
+    },
+    { additionalProperties: true },
+  );
+
+  // ── Kratos Settings Validation (Pre-Persist) ──────────────
+  server.post(
+    '/hooks/kratos/validate-settings',
+    {
+      schema: {
+        operationId: 'kratosValidateSettings',
+        tags: ['X-HIDDEN'],
+        body: SettingsWebhookBodySchema,
+      },
+      preHandler: [webhookAuth],
+    },
+    async (request, reply) => {
+      const { public_key } = request.body.identity.traits;
+      if (public_key === undefined) {
+        return reply.status(200).send({ success: true });
+      }
+
+      let settingsKeyBytes: Uint8Array;
+      try {
+        settingsKeyBytes = fastify.cryptoService.parsePublicKey(public_key);
+      } catch {
+        return reply
+          .status(400)
+          .send(
+            oryValidationError(
+              '#/traits/public_key',
+              4000001,
+              'public_key must use format "ed25519:<base64>"',
+            ),
+          );
+      }
+
+      if (settingsKeyBytes.length !== 32) {
+        return reply
+          .status(400)
+          .send(
+            oryValidationError(
+              '#/traits/public_key',
+              4000001,
+              `public_key must be exactly 32 bytes (got ${settingsKeyBytes.length}).`,
+            ),
+          );
+      }
+
+      return reply.status(200).send({ success: true });
+    },
+  );
+
+  // ── Kratos Settings Side Effects (Post-Persist) ───────────
   server.post(
     '/hooks/kratos/after-settings',
     {
       schema: {
         operationId: 'kratosAfterSettings',
         tags: ['X-HIDDEN'],
-        body: Type.Object(
-          {
-            identity: Type.Object(
-              {
-                id: Type.String(),
-                traits: Type.Object(
-                  {
-                    public_key: Type.Optional(Type.String()),
-                  },
-                  { additionalProperties: true },
-                ),
-              },
-              { additionalProperties: true },
-            ),
-          },
-          { additionalProperties: true },
-        ),
+        body: SettingsWebhookBodySchema,
       },
       preHandler: [webhookAuth],
     },
     async (request, reply) => {
       const { identity } = request.body;
-
-      // The settings hook parses responses, so Kratos invokes it before
-      // persisting the authoritative identity change. Invalidate the old
-      // cached identity before allowing the update to complete; any validation
-      // or projection error below interrupts the settings flow.
-      fastify.sessionResolver?.evictIdentity(identity.id);
-
       const { public_key } = identity.traits;
 
-      if (public_key !== undefined) {
-        // Agent profile changes also rotate the canonical public key. Human
-        // profile/password settings have no public_key and need only the
-        // Kratos-session invalidation above.
-        let settingsKeyBytes: Uint8Array;
-        try {
-          settingsKeyBytes = cryptoService.parsePublicKey(public_key);
-        } catch {
-          return reply
-            .status(400)
-            .send(
-              oryValidationError(
-                '#/traits/public_key',
-                4000001,
-                'public_key must use format "ed25519:<base64>"',
-              ),
+      try {
+        // This hook is configured as non-interrupting and non-parsing, so
+        // Kratos invokes it only after the identity change is authoritative.
+        fastify.sessionResolver?.evictIdentity(identity.id);
+
+        if (public_key !== undefined) {
+          // The pre-persist hook already validated this key. Re-parse it here
+          // to keep this idempotent projection independent from request-local
+          // state.
+          const settingsKeyBytes =
+            fastify.cryptoService.parsePublicKey(public_key);
+          if (settingsKeyBytes.length !== 32) {
+            throw new Error(
+              `Validated public key has ${settingsKeyBytes.length} bytes`,
             );
+          }
+
+          const settingsFingerprint =
+            fastify.cryptoService.generateFingerprint(settingsKeyBytes);
+
+          await fastify.agentRepository.upsert({
+            identityId: identity.id,
+            publicKey: public_key,
+            fingerprint: settingsFingerprint,
+          });
         }
 
-        if (settingsKeyBytes.length !== 32) {
-          return reply
-            .status(400)
-            .send(
-              oryValidationError(
-                '#/traits/public_key',
-                4000001,
-                `public_key must be exactly 32 bytes (got ${settingsKeyBytes.length}).`,
-              ),
-            );
-        }
-
-        const settingsFingerprint =
-          cryptoService.generateFingerprint(settingsKeyBytes);
-
-        await fastify.agentRepository.upsert({
-          identityId: identity.id,
-          publicKey: public_key,
-          fingerprint: settingsFingerprint,
-        });
+        return await reply.status(200).send({ success: true });
+      } catch (err) {
+        fastify.log.error(
+          { err, identity_id: identity.id },
+          'Post-settings projection failed unexpectedly',
+        );
+        return reply
+          .status(500)
+          .send(
+            oryValidationError(
+              '#/',
+              5000002,
+              'Settings were saved, but dependent state could not be updated.',
+            ),
+          );
       }
-
-      return reply.status(200).send({ success: true });
     },
   );
 

--- a/apps/rest-api/src/routes/hooks.ts
+++ b/apps/rest-api/src/routes/hooks.ts
@@ -272,9 +272,10 @@ export async function hookRoutes(fastify: FastifyInstance) {
     async (request, reply) => {
       const { identity } = request.body;
 
-      // This is an after-settings hook: Kratos has already committed the
-      // authoritative identity change. Invalidate first even if the optional
-      // agent profile projection below fails.
+      // The settings hook parses responses, so Kratos invokes it before
+      // persisting the authoritative identity change. Invalidate the old
+      // cached identity before allowing the update to complete; any validation
+      // or projection error below interrupts the settings flow.
       fastify.sessionResolver?.evictIdentity(identity.id);
 
       const { public_key } = identity.traits;

--- a/apps/rest-api/src/routes/registration.ts
+++ b/apps/rest-api/src/routes/registration.ts
@@ -173,6 +173,7 @@ export async function registrationRoutes(fastify: FastifyInstance) {
             client_secret: newSecret,
           },
         });
+        fastify.tokenValidator.evictOAuthClient(clientId);
 
         return {
           clientId,

--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -76,8 +76,10 @@ services:
       SELFSERVICE_FLOWS_REGISTRATION_AFTER_PASSWORD_HOOKS_0_CONFIG_URL: http://rest-api:8080/hooks/kratos/after-registration
       SELFSERVICE_FLOWS_LOGIN_AFTER_OIDC_HOOKS_0_CONFIG_URL: http://rest-api:8080/hooks/kratos/after-login
       SELFSERVICE_FLOWS_LOGIN_AFTER_PASSWORD_HOOKS_0_CONFIG_URL: http://rest-api:8080/hooks/kratos/after-login
-      SELFSERVICE_FLOWS_SETTINGS_AFTER_PASSWORD_HOOKS_0_CONFIG_URL: http://rest-api:8080/hooks/kratos/after-settings
-      SELFSERVICE_FLOWS_SETTINGS_AFTER_PROFILE_HOOKS_0_CONFIG_URL: http://rest-api:8080/hooks/kratos/after-settings
+      SELFSERVICE_FLOWS_SETTINGS_AFTER_PASSWORD_HOOKS_0_CONFIG_URL: http://rest-api:8080/hooks/kratos/validate-settings
+      SELFSERVICE_FLOWS_SETTINGS_AFTER_PASSWORD_HOOKS_1_CONFIG_URL: http://rest-api:8080/hooks/kratos/after-settings
+      SELFSERVICE_FLOWS_SETTINGS_AFTER_PROFILE_HOOKS_0_CONFIG_URL: http://rest-api:8080/hooks/kratos/validate-settings
+      SELFSERVICE_FLOWS_SETTINGS_AFTER_PROFILE_HOOKS_1_CONFIG_URL: http://rest-api:8080/hooks/kratos/after-settings
     depends_on:
       kratos-migrate:
         condition: service_completed_successfully

--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -76,6 +76,8 @@ services:
       SELFSERVICE_FLOWS_REGISTRATION_AFTER_PASSWORD_HOOKS_0_CONFIG_URL: http://rest-api:8080/hooks/kratos/after-registration
       SELFSERVICE_FLOWS_LOGIN_AFTER_OIDC_HOOKS_0_CONFIG_URL: http://rest-api:8080/hooks/kratos/after-login
       SELFSERVICE_FLOWS_LOGIN_AFTER_PASSWORD_HOOKS_0_CONFIG_URL: http://rest-api:8080/hooks/kratos/after-login
+      SELFSERVICE_FLOWS_SETTINGS_AFTER_PASSWORD_HOOKS_0_CONFIG_URL: http://rest-api:8080/hooks/kratos/after-settings
+      SELFSERVICE_FLOWS_SETTINGS_AFTER_PROFILE_HOOKS_0_CONFIG_URL: http://rest-api:8080/hooks/kratos/after-settings
     depends_on:
       kratos-migrate:
         condition: service_completed_successfully

--- a/infra/ory/kratos/kratos.yaml
+++ b/infra/ory/kratos/kratos.yaml
@@ -174,6 +174,21 @@ selfservice:
           hooks: &after_settings_hooks
             - hook: web_hook
               config:
+                url: http://host.docker.internal:8000/hooks/kratos/validate-settings
+                method: POST
+                auth:
+                  type: api_key
+                  config:
+                    name: X-Ory-Api-Key
+                    value: local-dev-webhook-key
+                    in: header
+                body: 'base64://ZnVuY3Rpb24oY3R4KSB7IGlkZW50aXR5OiBjdHguaWRlbnRpdHkgfQ=='
+                response:
+                  ignore: false
+                  parse: true
+                can_interrupt: true
+            - hook: web_hook
+              config:
                 url: http://host.docker.internal:8000/hooks/kratos/after-settings
                 method: POST
                 auth:
@@ -185,10 +200,8 @@ selfservice:
                 body: 'base64://ZnVuY3Rpb24oY3R4KSB7IGlkZW50aXR5OiBjdHguaWRlbnRpdHkgfQ=='
                 response:
                   ignore: false
-                  # Match registration: parse the Ory validation response so
-                  # hook failures are attached to the settings flow/API result.
-                  parse: true
-                can_interrupt: true
+                  parse: false
+                can_interrupt: false
         profile:
           hooks: *after_settings_hooks
 

--- a/infra/ory/kratos/kratos.yaml
+++ b/infra/ory/kratos/kratos.yaml
@@ -185,8 +185,10 @@ selfservice:
                 body: 'base64://ZnVuY3Rpb24oY3R4KSB7IGlkZW50aXR5OiBjdHguaWRlbnRpdHkgfQ=='
                 response:
                   ignore: false
-                  parse: false
-                can_interrupt: false
+                  # Match registration: parse the Ory validation response so
+                  # hook failures are attached to the settings flow/API result.
+                  parse: true
+                can_interrupt: true
         profile:
           hooks: *after_settings_hooks
 

--- a/infra/ory/kratos/kratos.yaml
+++ b/infra/ory/kratos/kratos.yaml
@@ -169,6 +169,26 @@ selfservice:
       ui_url: http://localhost:4455/settings
       lifespan: 1h
       privileged_session_max_age: 15m
+      after:
+        password:
+          hooks: &after_settings_hooks
+            - hook: web_hook
+              config:
+                url: http://host.docker.internal:8000/hooks/kratos/after-settings
+                method: POST
+                auth:
+                  type: api_key
+                  config:
+                    name: X-Ory-Api-Key
+                    value: local-dev-webhook-key
+                    in: header
+                body: 'base64://ZnVuY3Rpb24oY3R4KSB7IGlkZW50aXR5OiBjdHguaWRlbnRpdHkgfQ=='
+                response:
+                  ignore: false
+                  parse: false
+                can_interrupt: false
+        profile:
+          hooks: *after_settings_hooks
 
     error:
       ui_url: http://localhost:4455/error

--- a/infra/ory/project.json
+++ b/infra/ory/project.json
@@ -250,6 +250,31 @@
             },
             "settings": {
               "after": {
+                "password": {
+                  "hooks": [
+                    {
+                      "config": {
+                        "auth": {
+                          "config": {
+                            "in": "header",
+                            "name": "X-Ory-Api-Key",
+                            "value": "${ORY_ACTION_API_KEY}"
+                          },
+                          "type": "api_key"
+                        },
+                        "body": "base64://ZnVuY3Rpb24oY3R4KSB7IGlkZW50aXR5OiBjdHguaWRlbnRpdHkgfQ==",
+                        "can_interrupt": false,
+                        "method": "POST",
+                        "response": {
+                          "ignore": false,
+                          "parse": false
+                        },
+                        "url": "${API_BASE_URL}/hooks/kratos/after-settings"
+                      },
+                      "hook": "web_hook"
+                    }
+                  ]
+                },
                 "profile": {
                   "hooks": [
                     {

--- a/infra/ory/project.json
+++ b/infra/ory/project.json
@@ -263,11 +263,11 @@
                           "type": "api_key"
                         },
                         "body": "base64://ZnVuY3Rpb24oY3R4KSB7IGlkZW50aXR5OiBjdHguaWRlbnRpdHkgfQ==",
-                        "can_interrupt": false,
+                        "can_interrupt": true,
                         "method": "POST",
                         "response": {
                           "ignore": false,
-                          "parse": false
+                          "parse": true
                         },
                         "url": "${API_BASE_URL}/hooks/kratos/after-settings"
                       },
@@ -288,11 +288,11 @@
                           "type": "api_key"
                         },
                         "body": "base64://ZnVuY3Rpb24oY3R4KSB7IGlkZW50aXR5OiBjdHguaWRlbnRpdHkgfQ==",
-                        "can_interrupt": false,
+                        "can_interrupt": true,
                         "method": "POST",
                         "response": {
                           "ignore": false,
-                          "parse": false
+                          "parse": true
                         },
                         "url": "${API_BASE_URL}/hooks/kratos/after-settings"
                       },

--- a/infra/ory/project.json
+++ b/infra/ory/project.json
@@ -269,6 +269,27 @@
                           "ignore": false,
                           "parse": true
                         },
+                        "url": "${API_BASE_URL}/hooks/kratos/validate-settings"
+                      },
+                      "hook": "web_hook"
+                    },
+                    {
+                      "config": {
+                        "auth": {
+                          "config": {
+                            "in": "header",
+                            "name": "X-Ory-Api-Key",
+                            "value": "${ORY_ACTION_API_KEY}"
+                          },
+                          "type": "api_key"
+                        },
+                        "body": "base64://ZnVuY3Rpb24oY3R4KSB7IGlkZW50aXR5OiBjdHguaWRlbnRpdHkgfQ==",
+                        "can_interrupt": false,
+                        "method": "POST",
+                        "response": {
+                          "ignore": false,
+                          "parse": false
+                        },
                         "url": "${API_BASE_URL}/hooks/kratos/after-settings"
                       },
                       "hook": "web_hook"
@@ -293,6 +314,27 @@
                         "response": {
                           "ignore": false,
                           "parse": true
+                        },
+                        "url": "${API_BASE_URL}/hooks/kratos/validate-settings"
+                      },
+                      "hook": "web_hook"
+                    },
+                    {
+                      "config": {
+                        "auth": {
+                          "config": {
+                            "in": "header",
+                            "name": "X-Ory-Api-Key",
+                            "value": "${ORY_ACTION_API_KEY}"
+                          },
+                          "type": "api_key"
+                        },
+                        "body": "base64://ZnVuY3Rpb24oY3R4KSB7IGlkZW50aXR5OiBjdHguaWRlbnRpdHkgfQ==",
+                        "can_interrupt": false,
+                        "method": "POST",
+                        "response": {
+                          "ignore": false,
+                          "parse": false
                         },
                         "url": "${API_BASE_URL}/hooks/kratos/after-settings"
                       },

--- a/libs/api-client/src/generated/types.gen.ts
+++ b/libs/api-client/src/generated/types.gen.ts
@@ -264,6 +264,9 @@ export type ConflictProblemDetails = {
     | 'DIARY_TRANSFER_ALREADY_RESOLVED';
   detail?: string;
   instance?: string;
+  /**
+   * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+   */
   retryAfter?: number;
   status: number;
   title: string;
@@ -980,6 +983,9 @@ export type InjectionConflictProblemDetails = {
     | 'DIARY_TRANSFER_ALREADY_RESOLVED';
   detail?: string;
   instance?: string;
+  /**
+   * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+   */
   retryAfter?: number;
   status: number;
   title: string;
@@ -1398,6 +1404,9 @@ export type ProblemDetails = {
     | 'DIARY_TRANSFER_ALREADY_RESOLVED';
   detail?: string;
   instance?: string;
+  /**
+   * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+   */
   retryAfter?: number;
   status: number;
   title: string;
@@ -2976,6 +2985,9 @@ export type ValidationProblemDetails = {
     | 'DIARY_TRANSFER_ALREADY_RESOLVED';
   detail?: string;
   instance?: string;
+  /**
+   * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+   */
   retryAfter?: number;
   status: number;
   title: string;
@@ -8863,6 +8875,9 @@ export type GetRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -8941,6 +8956,9 @@ export type GetRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -9017,6 +9035,9 @@ export type GetRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -9093,6 +9114,9 @@ export type GetRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -9225,6 +9249,9 @@ export type DownloadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -9303,6 +9330,9 @@ export type DownloadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -9379,6 +9409,9 @@ export type DownloadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -9455,6 +9488,9 @@ export type DownloadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -9535,6 +9571,9 @@ export type DownloadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -9651,6 +9690,9 @@ export type UploadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -9729,6 +9771,9 @@ export type UploadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -9805,6 +9850,9 @@ export type UploadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -9881,6 +9929,9 @@ export type UploadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -9957,6 +10008,9 @@ export type UploadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -10037,6 +10091,9 @@ export type UploadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -10163,6 +10220,9 @@ export type ListRuntimeSlotsErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -10241,6 +10301,9 @@ export type ListRuntimeSlotsErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -10317,6 +10380,9 @@ export type ListRuntimeSlotsErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -10393,6 +10459,9 @@ export type ListRuntimeSlotsErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -10553,6 +10622,9 @@ export type BeginRuntimeSlotErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -10631,6 +10703,9 @@ export type BeginRuntimeSlotErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -10707,6 +10782,9 @@ export type BeginRuntimeSlotErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -10783,6 +10861,9 @@ export type BeginRuntimeSlotErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -10859,6 +10940,9 @@ export type BeginRuntimeSlotErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -11001,6 +11085,9 @@ export type FinishRuntimeSlotErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -11079,6 +11166,9 @@ export type FinishRuntimeSlotErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -11155,6 +11245,9 @@ export type FinishRuntimeSlotErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -11231,6 +11324,9 @@ export type FinishRuntimeSlotErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -11307,6 +11403,9 @@ export type FinishRuntimeSlotErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -11443,6 +11542,9 @@ export type FindLatestRuntimeSlotForAttemptErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -11521,6 +11623,9 @@ export type FindLatestRuntimeSlotForAttemptErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -11597,6 +11702,9 @@ export type FindLatestRuntimeSlotForAttemptErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -11673,6 +11781,9 @@ export type FindLatestRuntimeSlotForAttemptErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -11822,6 +11933,9 @@ export type StageTaskArtifactErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -11900,6 +12014,9 @@ export type StageTaskArtifactErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -11976,6 +12093,9 @@ export type StageTaskArtifactErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -12052,6 +12172,9 @@ export type StageTaskArtifactErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -12132,6 +12255,9 @@ export type StageTaskArtifactErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -13136,6 +13262,9 @@ export type ListTaskArtifactsErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -13214,6 +13343,9 @@ export type ListTaskArtifactsErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -13290,6 +13422,9 @@ export type ListTaskArtifactsErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -13366,6 +13501,9 @@ export type ListTaskArtifactsErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -13499,6 +13637,9 @@ export type DownloadTaskArtifactByCidErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -13577,6 +13718,9 @@ export type DownloadTaskArtifactByCidErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -13653,6 +13797,9 @@ export type DownloadTaskArtifactByCidErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -13729,6 +13876,9 @@ export type DownloadTaskArtifactByCidErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -13809,6 +13959,9 @@ export type DownloadTaskArtifactByCidErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -13925,6 +14078,9 @@ export type UploadTaskArtifactErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -14003,6 +14159,9 @@ export type UploadTaskArtifactErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -14079,6 +14238,9 @@ export type UploadTaskArtifactErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -14155,6 +14317,9 @@ export type UploadTaskArtifactErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -14239,6 +14404,9 @@ export type UploadTaskArtifactErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -14362,6 +14530,9 @@ export type DownloadTaskArtifactErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -14440,6 +14611,9 @@ export type DownloadTaskArtifactErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -14516,6 +14690,9 @@ export type DownloadTaskArtifactErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -14592,6 +14769,9 @@ export type DownloadTaskArtifactErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;
@@ -14672,6 +14852,9 @@ export type DownloadTaskArtifactErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    /**
+     * Non-negative delay in seconds before retrying, matching the Retry-After response header when present.
+     */
     retryAfter?: number;
     status: number;
     title: string;

--- a/libs/api-client/src/generated/types.gen.ts
+++ b/libs/api-client/src/generated/types.gen.ts
@@ -264,6 +264,7 @@ export type ConflictProblemDetails = {
     | 'DIARY_TRANSFER_ALREADY_RESOLVED';
   detail?: string;
   instance?: string;
+  retryAfter?: number;
   status: number;
   title: string;
   type: string;
@@ -299,6 +300,7 @@ export type ConflictProblemDetails = {
     | 'DIARY_TRANSFER_NOT_FOUND'
     | 'DIARY_TRANSFER_ALREADY_RESOLVED'
     | string
+    | number
     | number
     | undefined;
 } & {
@@ -978,6 +980,7 @@ export type InjectionConflictProblemDetails = {
     | 'DIARY_TRANSFER_ALREADY_RESOLVED';
   detail?: string;
   instance?: string;
+  retryAfter?: number;
   status: number;
   title: string;
   type: string;
@@ -1013,6 +1016,7 @@ export type InjectionConflictProblemDetails = {
     | 'DIARY_TRANSFER_NOT_FOUND'
     | 'DIARY_TRANSFER_ALREADY_RESOLVED'
     | string
+    | number
     | number
     | undefined;
 } & {
@@ -1394,6 +1398,7 @@ export type ProblemDetails = {
     | 'DIARY_TRANSFER_ALREADY_RESOLVED';
   detail?: string;
   instance?: string;
+  retryAfter?: number;
   status: number;
   title: string;
   type: string;
@@ -1429,6 +1434,7 @@ export type ProblemDetails = {
     | 'DIARY_TRANSFER_NOT_FOUND'
     | 'DIARY_TRANSFER_ALREADY_RESOLVED'
     | string
+    | number
     | number
     | undefined;
 };
@@ -2970,6 +2976,7 @@ export type ValidationProblemDetails = {
     | 'DIARY_TRANSFER_ALREADY_RESOLVED';
   detail?: string;
   instance?: string;
+  retryAfter?: number;
   status: number;
   title: string;
   type: string;
@@ -3005,6 +3012,7 @@ export type ValidationProblemDetails = {
     | 'DIARY_TRANSFER_NOT_FOUND'
     | 'DIARY_TRANSFER_ALREADY_RESOLVED'
     | string
+    | number
     | number
     | undefined;
 } & {
@@ -8855,6 +8863,7 @@ export type GetRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -8890,6 +8899,7 @@ export type GetRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   } & {
@@ -8931,6 +8941,7 @@ export type GetRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -8966,6 +8977,7 @@ export type GetRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -9005,6 +9017,7 @@ export type GetRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -9040,6 +9053,7 @@ export type GetRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -9079,6 +9093,7 @@ export type GetRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -9114,6 +9129,7 @@ export type GetRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -9209,6 +9225,7 @@ export type DownloadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -9244,6 +9261,7 @@ export type DownloadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   } & {
@@ -9285,6 +9303,7 @@ export type DownloadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -9320,6 +9339,7 @@ export type DownloadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -9359,6 +9379,7 @@ export type DownloadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -9394,6 +9415,7 @@ export type DownloadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -9433,6 +9455,7 @@ export type DownloadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -9468,6 +9491,7 @@ export type DownloadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -9511,6 +9535,7 @@ export type DownloadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -9546,6 +9571,7 @@ export type DownloadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -9625,6 +9651,7 @@ export type UploadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -9660,6 +9687,7 @@ export type UploadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   } & {
@@ -9701,6 +9729,7 @@ export type UploadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -9736,6 +9765,7 @@ export type UploadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -9775,6 +9805,7 @@ export type UploadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -9810,6 +9841,7 @@ export type UploadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -9849,6 +9881,7 @@ export type UploadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -9884,6 +9917,7 @@ export type UploadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -9923,6 +9957,7 @@ export type UploadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -9958,6 +9993,7 @@ export type UploadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -10001,6 +10037,7 @@ export type UploadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -10036,6 +10073,7 @@ export type UploadRuntimeSessionErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -10125,6 +10163,7 @@ export type ListRuntimeSlotsErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -10160,6 +10199,7 @@ export type ListRuntimeSlotsErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   } & {
@@ -10201,6 +10241,7 @@ export type ListRuntimeSlotsErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -10236,6 +10277,7 @@ export type ListRuntimeSlotsErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -10275,6 +10317,7 @@ export type ListRuntimeSlotsErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -10310,6 +10353,7 @@ export type ListRuntimeSlotsErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -10349,6 +10393,7 @@ export type ListRuntimeSlotsErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -10384,6 +10429,7 @@ export type ListRuntimeSlotsErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -10507,6 +10553,7 @@ export type BeginRuntimeSlotErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -10542,6 +10589,7 @@ export type BeginRuntimeSlotErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   } & {
@@ -10583,6 +10631,7 @@ export type BeginRuntimeSlotErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -10618,6 +10667,7 @@ export type BeginRuntimeSlotErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -10657,6 +10707,7 @@ export type BeginRuntimeSlotErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -10692,6 +10743,7 @@ export type BeginRuntimeSlotErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -10731,6 +10783,7 @@ export type BeginRuntimeSlotErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -10766,6 +10819,7 @@ export type BeginRuntimeSlotErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -10805,6 +10859,7 @@ export type BeginRuntimeSlotErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -10840,6 +10895,7 @@ export type BeginRuntimeSlotErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   } & {
@@ -10945,6 +11001,7 @@ export type FinishRuntimeSlotErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -10980,6 +11037,7 @@ export type FinishRuntimeSlotErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   } & {
@@ -11021,6 +11079,7 @@ export type FinishRuntimeSlotErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -11056,6 +11115,7 @@ export type FinishRuntimeSlotErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -11095,6 +11155,7 @@ export type FinishRuntimeSlotErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -11130,6 +11191,7 @@ export type FinishRuntimeSlotErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -11169,6 +11231,7 @@ export type FinishRuntimeSlotErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -11204,6 +11267,7 @@ export type FinishRuntimeSlotErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -11243,6 +11307,7 @@ export type FinishRuntimeSlotErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -11278,6 +11343,7 @@ export type FinishRuntimeSlotErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   } & {
@@ -11377,6 +11443,7 @@ export type FindLatestRuntimeSlotForAttemptErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -11412,6 +11479,7 @@ export type FindLatestRuntimeSlotForAttemptErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   } & {
@@ -11453,6 +11521,7 @@ export type FindLatestRuntimeSlotForAttemptErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -11488,6 +11557,7 @@ export type FindLatestRuntimeSlotForAttemptErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -11527,6 +11597,7 @@ export type FindLatestRuntimeSlotForAttemptErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -11562,6 +11633,7 @@ export type FindLatestRuntimeSlotForAttemptErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -11601,6 +11673,7 @@ export type FindLatestRuntimeSlotForAttemptErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -11636,6 +11709,7 @@ export type FindLatestRuntimeSlotForAttemptErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -11748,6 +11822,7 @@ export type StageTaskArtifactErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -11783,6 +11858,7 @@ export type StageTaskArtifactErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   } & {
@@ -11824,6 +11900,7 @@ export type StageTaskArtifactErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -11859,6 +11936,7 @@ export type StageTaskArtifactErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -11898,6 +11976,7 @@ export type StageTaskArtifactErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -11933,6 +12012,7 @@ export type StageTaskArtifactErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -11972,6 +12052,7 @@ export type StageTaskArtifactErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -12007,6 +12088,7 @@ export type StageTaskArtifactErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -12050,6 +12132,7 @@ export type StageTaskArtifactErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -12085,6 +12168,7 @@ export type StageTaskArtifactErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -13052,6 +13136,7 @@ export type ListTaskArtifactsErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -13087,6 +13172,7 @@ export type ListTaskArtifactsErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   } & {
@@ -13128,6 +13214,7 @@ export type ListTaskArtifactsErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -13163,6 +13250,7 @@ export type ListTaskArtifactsErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -13202,6 +13290,7 @@ export type ListTaskArtifactsErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -13237,6 +13326,7 @@ export type ListTaskArtifactsErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -13276,6 +13366,7 @@ export type ListTaskArtifactsErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -13311,6 +13402,7 @@ export type ListTaskArtifactsErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -13407,6 +13499,7 @@ export type DownloadTaskArtifactByCidErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -13442,6 +13535,7 @@ export type DownloadTaskArtifactByCidErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   } & {
@@ -13483,6 +13577,7 @@ export type DownloadTaskArtifactByCidErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -13518,6 +13613,7 @@ export type DownloadTaskArtifactByCidErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -13557,6 +13653,7 @@ export type DownloadTaskArtifactByCidErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -13592,6 +13689,7 @@ export type DownloadTaskArtifactByCidErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -13631,6 +13729,7 @@ export type DownloadTaskArtifactByCidErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -13666,6 +13765,7 @@ export type DownloadTaskArtifactByCidErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -13709,6 +13809,7 @@ export type DownloadTaskArtifactByCidErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -13744,6 +13845,7 @@ export type DownloadTaskArtifactByCidErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -13823,6 +13925,7 @@ export type UploadTaskArtifactErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -13858,6 +13961,7 @@ export type UploadTaskArtifactErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   } & {
@@ -13899,6 +14003,7 @@ export type UploadTaskArtifactErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -13934,6 +14039,7 @@ export type UploadTaskArtifactErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -13973,6 +14079,7 @@ export type UploadTaskArtifactErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -14008,6 +14115,7 @@ export type UploadTaskArtifactErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -14047,6 +14155,7 @@ export type UploadTaskArtifactErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -14082,6 +14191,7 @@ export type UploadTaskArtifactErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -14129,6 +14239,7 @@ export type UploadTaskArtifactErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -14164,6 +14275,7 @@ export type UploadTaskArtifactErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -14250,6 +14362,7 @@ export type DownloadTaskArtifactErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -14285,6 +14398,7 @@ export type DownloadTaskArtifactErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   } & {
@@ -14326,6 +14440,7 @@ export type DownloadTaskArtifactErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -14361,6 +14476,7 @@ export type DownloadTaskArtifactErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -14400,6 +14516,7 @@ export type DownloadTaskArtifactErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -14435,6 +14552,7 @@ export type DownloadTaskArtifactErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -14474,6 +14592,7 @@ export type DownloadTaskArtifactErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -14509,6 +14628,7 @@ export type DownloadTaskArtifactErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };
@@ -14552,6 +14672,7 @@ export type DownloadTaskArtifactErrors = {
       | 'DIARY_TRANSFER_ALREADY_RESOLVED';
     detail?: string;
     instance?: string;
+    retryAfter?: number;
     status: number;
     title: string;
     type: string;
@@ -14587,6 +14708,7 @@ export type DownloadTaskArtifactErrors = {
       | 'DIARY_TRANSFER_NOT_FOUND'
       | 'DIARY_TRANSFER_ALREADY_RESOLVED'
       | string
+      | number
       | number
       | undefined;
   };

--- a/libs/auth/__tests__/credential-cache-eviction.integration.test.ts
+++ b/libs/auth/__tests__/credential-cache-eviction.integration.test.ts
@@ -8,7 +8,8 @@ const CLIENT_ID = 'hydra-client-uuid';
 const IDENTITY_ID = '550e8400-e29b-41d4-a716-446655440000';
 const FIRST_HUMAN_ID = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
 const SECOND_HUMAN_ID = '7ca7b810-9dad-11d1-80b4-00c04fd430c9';
-const TOKEN = 'ory_at_positive_cache_integration';
+const OAUTH_ACCESS_TOKEN = 'ory_at_positive_cache_integration';
+const KRATOS_SESSION_TOKEN = 'ory_st_positive_cache_integration';
 
 describe('credential lifecycle cache eviction', () => {
   it('refetches an OAuth context after client eviction', async () => {
@@ -44,15 +45,15 @@ describe('credential lifecycle cache eviction', () => {
       { remoteAuthCache: new RemoteAuthCache({ ttlMs: 60_000 }) },
     );
 
-    const first = await validator.resolveAuthContext(TOKEN);
-    const cached = await validator.resolveAuthContext(TOKEN);
+    const first = await validator.resolveAuthContext(OAUTH_ACCESS_TOKEN);
+    const cached = await validator.resolveAuthContext(OAUTH_ACCESS_TOKEN);
 
     expect(first).toMatchObject({ fingerprint: 'FIRST' });
     expect(cached).toMatchObject({ fingerprint: 'FIRST' });
     expect(introspectOAuth2Token).toHaveBeenCalledOnce();
 
     validator.evictOAuthClient(CLIENT_ID);
-    const refreshed = await validator.resolveAuthContext(TOKEN);
+    const refreshed = await validator.resolveAuthContext(OAUTH_ACCESS_TOKEN);
 
     expect(refreshed).toMatchObject({ fingerprint: 'SECOND' });
     expect(introspectOAuth2Token).toHaveBeenCalledTimes(2);
@@ -85,15 +86,21 @@ describe('credential lifecycle cache eviction', () => {
       remoteAuthCache: new RemoteAuthCache({ ttlMs: 60_000 }),
     });
 
-    const first = await resolver.resolveSession({ sessionToken: TOKEN });
-    const cached = await resolver.resolveSession({ sessionToken: TOKEN });
+    const first = await resolver.resolveSession({
+      sessionToken: KRATOS_SESSION_TOKEN,
+    });
+    const cached = await resolver.resolveSession({
+      sessionToken: KRATOS_SESSION_TOKEN,
+    });
 
     expect(first).toMatchObject({ humanId: FIRST_HUMAN_ID });
     expect(cached).toMatchObject({ humanId: FIRST_HUMAN_ID });
     expect(toSession).toHaveBeenCalledOnce();
 
     resolver.evictIdentity(IDENTITY_ID);
-    const refreshed = await resolver.resolveSession({ sessionToken: TOKEN });
+    const refreshed = await resolver.resolveSession({
+      sessionToken: KRATOS_SESSION_TOKEN,
+    });
 
     expect(refreshed).toMatchObject({ humanId: SECOND_HUMAN_ID });
     expect(toSession).toHaveBeenCalledTimes(2);

--- a/libs/auth/__tests__/credential-cache-eviction.integration.test.ts
+++ b/libs/auth/__tests__/credential-cache-eviction.integration.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { RemoteAuthCache } from '../src/remote-auth-cache.js';
+import { createSessionResolver } from '../src/session-resolver.js';
+import { createTokenValidator } from '../src/token-validator.js';
+
+const CLIENT_ID = 'hydra-client-uuid';
+const IDENTITY_ID = '550e8400-e29b-41d4-a716-446655440000';
+const FIRST_HUMAN_ID = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+const SECOND_HUMAN_ID = '7ca7b810-9dad-11d1-80b4-00c04fd430c9';
+const TOKEN = 'ory_at_positive_cache_integration';
+
+describe('credential lifecycle cache eviction', () => {
+  it('refetches an OAuth context after client eviction', async () => {
+    const introspectOAuth2Token = vi
+      .fn()
+      .mockResolvedValueOnce({
+        active: true,
+        client_id: CLIENT_ID,
+        scope: 'diary:read',
+        sub: CLIENT_ID,
+        ext: {
+          'moltnet:identity_id': IDENTITY_ID,
+          'moltnet:public_key': 'ed25519:first',
+          'moltnet:fingerprint': 'FIRST',
+        },
+      })
+      .mockResolvedValueOnce({
+        active: true,
+        client_id: CLIENT_ID,
+        scope: 'diary:read',
+        sub: CLIENT_ID,
+        ext: {
+          'moltnet:identity_id': IDENTITY_ID,
+          'moltnet:public_key': 'ed25519:second',
+          'moltnet:fingerprint': 'SECOND',
+        },
+      });
+    const validator = createTokenValidator(
+      {
+        introspectOAuth2Token,
+        getOAuth2Client: vi.fn(),
+      } as never,
+      { remoteAuthCache: new RemoteAuthCache({ ttlMs: 60_000 }) },
+    );
+
+    const first = await validator.resolveAuthContext(TOKEN);
+    const cached = await validator.resolveAuthContext(TOKEN);
+
+    expect(first).toMatchObject({ fingerprint: 'FIRST' });
+    expect(cached).toMatchObject({ fingerprint: 'FIRST' });
+    expect(introspectOAuth2Token).toHaveBeenCalledOnce();
+
+    validator.evictOAuthClient(CLIENT_ID);
+    const refreshed = await validator.resolveAuthContext(TOKEN);
+
+    expect(refreshed).toMatchObject({ fingerprint: 'SECOND' });
+    expect(introspectOAuth2Token).toHaveBeenCalledTimes(2);
+  });
+
+  it('refetches a Kratos session after identity eviction', async () => {
+    const toSession = vi
+      .fn()
+      .mockResolvedValueOnce({
+        id: 'session-uuid',
+        active: true,
+        identity: {
+          id: IDENTITY_ID,
+          schema_id: 'moltnet_human',
+          traits: { email: 'human@example.com' },
+          metadata_public: { human_id: FIRST_HUMAN_ID },
+        },
+      })
+      .mockResolvedValueOnce({
+        id: 'session-uuid',
+        active: true,
+        identity: {
+          id: IDENTITY_ID,
+          schema_id: 'moltnet_human',
+          traits: { email: 'human@example.com' },
+          metadata_public: { human_id: SECOND_HUMAN_ID },
+        },
+      });
+    const resolver = createSessionResolver({ toSession } as never, {
+      remoteAuthCache: new RemoteAuthCache({ ttlMs: 60_000 }),
+    });
+
+    const first = await resolver.resolveSession({ sessionToken: TOKEN });
+    const cached = await resolver.resolveSession({ sessionToken: TOKEN });
+
+    expect(first).toMatchObject({ humanId: FIRST_HUMAN_ID });
+    expect(cached).toMatchObject({ humanId: FIRST_HUMAN_ID });
+    expect(toSession).toHaveBeenCalledOnce();
+
+    resolver.evictIdentity(IDENTITY_ID);
+    const refreshed = await resolver.resolveSession({ sessionToken: TOKEN });
+
+    expect(refreshed).toMatchObject({ humanId: SECOND_HUMAN_ID });
+    expect(toSession).toHaveBeenCalledTimes(2);
+  });
+});

--- a/libs/auth/__tests__/remote-auth-cache.test.ts
+++ b/libs/auth/__tests__/remote-auth-cache.test.ts
@@ -1,10 +1,23 @@
-import { describe, expect, it, vi } from 'vitest';
+import { metrics as metricsApi } from '@opentelemetry/api';
+import { MeterProvider, MetricReader } from '@opentelemetry/sdk-metrics';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  createRemoteAuthMetrics,
   RemoteAuthCache,
   type RemoteAuthMetrics,
 } from '../src/remote-auth-cache.js';
 import type { AgentAuthContext } from '../src/types.js';
+
+class TestMetricReader extends MetricReader {
+  protected async onShutdown(): Promise<void> {}
+
+  protected async onForceFlush(): Promise<void> {}
+}
+
+afterEach(() => {
+  metricsApi.disable();
+});
 
 const context: AgentAuthContext = {
   subjectType: 'agent',
@@ -311,5 +324,39 @@ describe('RemoteAuthCache', () => {
     expect(JSON.stringify(metrics.recordCacheAccess.mock.calls)).not.toContain(
       'raw-secret',
     );
+  });
+});
+
+describe('createRemoteAuthMetrics', () => {
+  it('records bounded upstream status buckets', async () => {
+    const reader = new TestMetricReader();
+    const provider = new MeterProvider({ readers: [reader] });
+    metricsApi.setGlobalMeterProvider(provider);
+    const metrics = createRemoteAuthMetrics();
+
+    metrics.recordUpstreamRequest(
+      'oauth2.introspect',
+      'unavailable',
+      undefined,
+    );
+    metrics.recordUpstreamRequest('oauth2.introspect', 'rate_limited', 429);
+    metrics.recordUpstreamRequest('oauth2.introspect', 'invalid', 401);
+    metrics.recordUpstreamRequest('oauth2.introspect', 'unavailable', 503);
+    metrics.recordUpstreamRequest('oauth2.introspect', 'success', 200);
+
+    const { resourceMetrics } = await reader.collect();
+    const metric = resourceMetrics.scopeMetrics
+      .flatMap((scope) => scope.metrics)
+      .find(
+        (candidate) =>
+          candidate.descriptor.name === 'auth.remote.upstream.requests',
+      );
+    const statuses = metric?.dataPoints
+      .map((point) => point.attributes.status)
+      .sort();
+
+    expect(statuses).toEqual(['429', '4xx', '5xx', 'network', 'other']);
+
+    await provider.shutdown();
   });
 });

--- a/libs/auth/package.json
+++ b/libs/auth/package.json
@@ -21,6 +21,8 @@
     "pino": "catalog:"
   },
   "devDependencies": {
+    "@opentelemetry/api": "catalog:",
+    "@opentelemetry/sdk-metrics": "catalog:",
     "@testcontainers/postgresql": "catalog:",
     "fastify": "catalog:",
     "testcontainers": "catalog:",

--- a/libs/auth/src/remote-auth-cache.ts
+++ b/libs/auth/src/remote-auth-cache.ts
@@ -257,6 +257,7 @@ export class RemoteAuthCache {
     // excessive CPU on the authentication hot path. HMAC prevents a leaked
     // cache key from revealing or validating the credential without this
     // process's random key.
+    // codeql[js/insufficient-password-hash]
     return createHmac('sha256', this.hmacKey)
       .update(framed)
       .digest('base64url');

--- a/libs/models/__tests__/schemas.test.ts
+++ b/libs/models/__tests__/schemas.test.ts
@@ -9,6 +9,7 @@ import {
   DiarySearchSchema,
   FingerprintSchema,
   PaginatedResponseSchema,
+  ProblemDetailsSchema,
   PublicKeySchema,
   SignRequestSchema,
   TOOL_ENFORCEMENT_VALUES,
@@ -32,6 +33,27 @@ beforeAll(() => {
 });
 
 describe('Common schemas', () => {
+  describe('ProblemDetailsSchema', () => {
+    const problem = {
+      type: 'https://themolt.net/problems/rate-limit-exceeded',
+      title: 'Rate Limit Exceeded',
+      status: 429,
+      code: 'RATE_LIMIT_EXCEEDED',
+    };
+
+    it('accepts a non-negative Retry-After extension', () => {
+      expect(
+        Value.Check(ProblemDetailsSchema, { ...problem, retryAfter: 17 }),
+      ).toBe(true);
+    });
+
+    it('rejects a negative Retry-After extension', () => {
+      expect(
+        Value.Check(ProblemDetailsSchema, { ...problem, retryAfter: -1 }),
+      ).toBe(false);
+    });
+  });
+
   describe('ToolEnforcementSchema', () => {
     it('accepts every canonical enforcement mode', () => {
       for (const mode of TOOL_ENFORCEMENT_VALUES) {

--- a/libs/models/src/problem-details.ts
+++ b/libs/models/src/problem-details.ts
@@ -43,6 +43,7 @@ export const ProblemDetailsSchema = Type.Object(
     code: ProblemCodeSchema,
     detail: Type.Optional(Type.String()),
     instance: Type.Optional(Type.String()),
+    retryAfter: Type.Optional(Type.Integer({ minimum: 0 })),
   },
   // RFC 9457 §3 — problem details MAY contain extension members beyond the
   // standard fields. Routes that need structured detail (e.g. listing

--- a/libs/models/src/problem-details.ts
+++ b/libs/models/src/problem-details.ts
@@ -43,7 +43,13 @@ export const ProblemDetailsSchema = Type.Object(
     code: ProblemCodeSchema,
     detail: Type.Optional(Type.String()),
     instance: Type.Optional(Type.String()),
-    retryAfter: Type.Optional(Type.Integer({ minimum: 0 })),
+    retryAfter: Type.Optional(
+      Type.Integer({
+        minimum: 0,
+        description:
+          'Non-negative delay in seconds before retrying, matching the Retry-After response header when present.',
+      }),
+    ),
   },
   // RFC 9457 §3 — problem details MAY contain extension members beyond the
   // standard fields. Routes that need structured detail (e.g. listing

--- a/libs/moltnet-api-client/oas_json_gen.go
+++ b/libs/moltnet-api-client/oas_json_gen.go
@@ -4504,6 +4504,12 @@ func (s *BeginRuntimeSlotBadRequest) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -4532,14 +4538,15 @@ func (s *BeginRuntimeSlotBadRequest) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfBeginRuntimeSlotBadRequest = [7]string{
+var jsonFieldsNameOfBeginRuntimeSlotBadRequest = [8]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
-	6: "errors",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
+	7: "errors",
 }
 
 // Decode decodes BeginRuntimeSlotBadRequest from json.
@@ -4582,8 +4589,18 @@ func (s *BeginRuntimeSlotBadRequest) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -4595,7 +4612,7 @@ func (s *BeginRuntimeSlotBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -4607,7 +4624,7 @@ func (s *BeginRuntimeSlotBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -4619,7 +4636,7 @@ func (s *BeginRuntimeSlotBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"type\"")
 			}
 		case "errors":
-			requiredBitSet[0] |= 1 << 6
+			requiredBitSet[0] |= 1 << 7
 			if err := func() error {
 				s.Errors = make([]ValidationError, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -4657,7 +4674,7 @@ func (s *BeginRuntimeSlotBadRequest) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b01111001,
+		0b11110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -4881,6 +4898,12 @@ func (s *BeginRuntimeSlotConflict) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -4905,14 +4928,15 @@ func (s *BeginRuntimeSlotConflict) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfBeginRuntimeSlotConflict = [7]string{
+var jsonFieldsNameOfBeginRuntimeSlotConflict = [8]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
-	6: "conflict",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
+	7: "conflict",
 }
 
 // Decode decodes BeginRuntimeSlotConflict from json.
@@ -4955,8 +4979,18 @@ func (s *BeginRuntimeSlotConflict) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -4968,7 +5002,7 @@ func (s *BeginRuntimeSlotConflict) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -4980,7 +5014,7 @@ func (s *BeginRuntimeSlotConflict) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -4992,7 +5026,7 @@ func (s *BeginRuntimeSlotConflict) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"type\"")
 			}
 		case "conflict":
-			requiredBitSet[0] |= 1 << 6
+			requiredBitSet[0] |= 1 << 7
 			if err := func() error {
 				if err := s.Conflict.Decode(d); err != nil {
 					return err
@@ -5022,7 +5056,7 @@ func (s *BeginRuntimeSlotConflict) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b01111001,
+		0b11110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -5246,6 +5280,12 @@ func (s *BeginRuntimeSlotForbidden) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -5266,13 +5306,14 @@ func (s *BeginRuntimeSlotForbidden) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfBeginRuntimeSlotForbidden = [6]string{
+var jsonFieldsNameOfBeginRuntimeSlotForbidden = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes BeginRuntimeSlotForbidden from json.
@@ -5315,8 +5356,18 @@ func (s *BeginRuntimeSlotForbidden) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -5328,7 +5379,7 @@ func (s *BeginRuntimeSlotForbidden) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -5340,7 +5391,7 @@ func (s *BeginRuntimeSlotForbidden) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -5372,7 +5423,7 @@ func (s *BeginRuntimeSlotForbidden) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -5596,6 +5647,12 @@ func (s *BeginRuntimeSlotNotFound) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -5616,13 +5673,14 @@ func (s *BeginRuntimeSlotNotFound) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfBeginRuntimeSlotNotFound = [6]string{
+var jsonFieldsNameOfBeginRuntimeSlotNotFound = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes BeginRuntimeSlotNotFound from json.
@@ -5665,8 +5723,18 @@ func (s *BeginRuntimeSlotNotFound) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -5678,7 +5746,7 @@ func (s *BeginRuntimeSlotNotFound) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -5690,7 +5758,7 @@ func (s *BeginRuntimeSlotNotFound) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -5722,7 +5790,7 @@ func (s *BeginRuntimeSlotNotFound) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -6782,6 +6850,12 @@ func (s *BeginRuntimeSlotUnauthorized) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -6802,13 +6876,14 @@ func (s *BeginRuntimeSlotUnauthorized) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfBeginRuntimeSlotUnauthorized = [6]string{
+var jsonFieldsNameOfBeginRuntimeSlotUnauthorized = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes BeginRuntimeSlotUnauthorized from json.
@@ -6851,8 +6926,18 @@ func (s *BeginRuntimeSlotUnauthorized) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -6864,7 +6949,7 @@ func (s *BeginRuntimeSlotUnauthorized) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -6876,7 +6961,7 @@ func (s *BeginRuntimeSlotUnauthorized) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -6908,7 +6993,7 @@ func (s *BeginRuntimeSlotUnauthorized) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -10999,6 +11084,12 @@ func (s *ConflictProblemDetails) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -11023,14 +11114,15 @@ func (s *ConflictProblemDetails) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfConflictProblemDetails = [7]string{
+var jsonFieldsNameOfConflictProblemDetails = [8]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
-	6: "conflict",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
+	7: "conflict",
 }
 
 // Decode decodes ConflictProblemDetails from json.
@@ -11073,8 +11165,18 @@ func (s *ConflictProblemDetails) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -11086,7 +11188,7 @@ func (s *ConflictProblemDetails) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -11098,7 +11200,7 @@ func (s *ConflictProblemDetails) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -11110,7 +11212,7 @@ func (s *ConflictProblemDetails) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"type\"")
 			}
 		case "conflict":
-			requiredBitSet[0] |= 1 << 6
+			requiredBitSet[0] |= 1 << 7
 			if err := func() error {
 				if err := s.Conflict.Decode(d); err != nil {
 					return err
@@ -11140,7 +11242,7 @@ func (s *ConflictProblemDetails) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b01111001,
+		0b11110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -30802,6 +30904,12 @@ func (s *DownloadRuntimeSessionBadRequest) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -30830,14 +30938,15 @@ func (s *DownloadRuntimeSessionBadRequest) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfDownloadRuntimeSessionBadRequest = [7]string{
+var jsonFieldsNameOfDownloadRuntimeSessionBadRequest = [8]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
-	6: "errors",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
+	7: "errors",
 }
 
 // Decode decodes DownloadRuntimeSessionBadRequest from json.
@@ -30880,8 +30989,18 @@ func (s *DownloadRuntimeSessionBadRequest) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -30893,7 +31012,7 @@ func (s *DownloadRuntimeSessionBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -30905,7 +31024,7 @@ func (s *DownloadRuntimeSessionBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -30917,7 +31036,7 @@ func (s *DownloadRuntimeSessionBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"type\"")
 			}
 		case "errors":
-			requiredBitSet[0] |= 1 << 6
+			requiredBitSet[0] |= 1 << 7
 			if err := func() error {
 				s.Errors = make([]ValidationError, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -30955,7 +31074,7 @@ func (s *DownloadRuntimeSessionBadRequest) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b01111001,
+		0b11110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -31179,6 +31298,12 @@ func (s *DownloadRuntimeSessionForbidden) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -31199,13 +31324,14 @@ func (s *DownloadRuntimeSessionForbidden) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfDownloadRuntimeSessionForbidden = [6]string{
+var jsonFieldsNameOfDownloadRuntimeSessionForbidden = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes DownloadRuntimeSessionForbidden from json.
@@ -31248,8 +31374,18 @@ func (s *DownloadRuntimeSessionForbidden) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -31261,7 +31397,7 @@ func (s *DownloadRuntimeSessionForbidden) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -31273,7 +31409,7 @@ func (s *DownloadRuntimeSessionForbidden) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -31305,7 +31441,7 @@ func (s *DownloadRuntimeSessionForbidden) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -31529,6 +31665,12 @@ func (s *DownloadRuntimeSessionNotFound) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -31549,13 +31691,14 @@ func (s *DownloadRuntimeSessionNotFound) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfDownloadRuntimeSessionNotFound = [6]string{
+var jsonFieldsNameOfDownloadRuntimeSessionNotFound = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes DownloadRuntimeSessionNotFound from json.
@@ -31598,8 +31741,18 @@ func (s *DownloadRuntimeSessionNotFound) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -31611,7 +31764,7 @@ func (s *DownloadRuntimeSessionNotFound) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -31623,7 +31776,7 @@ func (s *DownloadRuntimeSessionNotFound) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -31655,7 +31808,7 @@ func (s *DownloadRuntimeSessionNotFound) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -31879,6 +32032,12 @@ func (s *DownloadRuntimeSessionServiceUnavailable) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -31899,13 +32058,14 @@ func (s *DownloadRuntimeSessionServiceUnavailable) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfDownloadRuntimeSessionServiceUnavailable = [6]string{
+var jsonFieldsNameOfDownloadRuntimeSessionServiceUnavailable = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes DownloadRuntimeSessionServiceUnavailable from json.
@@ -31948,8 +32108,18 @@ func (s *DownloadRuntimeSessionServiceUnavailable) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -31961,7 +32131,7 @@ func (s *DownloadRuntimeSessionServiceUnavailable) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -31973,7 +32143,7 @@ func (s *DownloadRuntimeSessionServiceUnavailable) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -32005,7 +32175,7 @@ func (s *DownloadRuntimeSessionServiceUnavailable) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -32229,6 +32399,12 @@ func (s *DownloadRuntimeSessionUnauthorized) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -32249,13 +32425,14 @@ func (s *DownloadRuntimeSessionUnauthorized) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfDownloadRuntimeSessionUnauthorized = [6]string{
+var jsonFieldsNameOfDownloadRuntimeSessionUnauthorized = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes DownloadRuntimeSessionUnauthorized from json.
@@ -32298,8 +32475,18 @@ func (s *DownloadRuntimeSessionUnauthorized) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -32311,7 +32498,7 @@ func (s *DownloadRuntimeSessionUnauthorized) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -32323,7 +32510,7 @@ func (s *DownloadRuntimeSessionUnauthorized) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -32355,7 +32542,7 @@ func (s *DownloadRuntimeSessionUnauthorized) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -32579,6 +32766,12 @@ func (s *DownloadTaskArtifactBadRequest) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -32607,14 +32800,15 @@ func (s *DownloadTaskArtifactBadRequest) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfDownloadTaskArtifactBadRequest = [7]string{
+var jsonFieldsNameOfDownloadTaskArtifactBadRequest = [8]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
-	6: "errors",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
+	7: "errors",
 }
 
 // Decode decodes DownloadTaskArtifactBadRequest from json.
@@ -32657,8 +32851,18 @@ func (s *DownloadTaskArtifactBadRequest) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -32670,7 +32874,7 @@ func (s *DownloadTaskArtifactBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -32682,7 +32886,7 @@ func (s *DownloadTaskArtifactBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -32694,7 +32898,7 @@ func (s *DownloadTaskArtifactBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"type\"")
 			}
 		case "errors":
-			requiredBitSet[0] |= 1 << 6
+			requiredBitSet[0] |= 1 << 7
 			if err := func() error {
 				s.Errors = make([]ValidationError, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -32732,7 +32936,7 @@ func (s *DownloadTaskArtifactBadRequest) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b01111001,
+		0b11110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -32956,6 +33160,12 @@ func (s *DownloadTaskArtifactByCidBadRequest) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -32984,14 +33194,15 @@ func (s *DownloadTaskArtifactByCidBadRequest) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfDownloadTaskArtifactByCidBadRequest = [7]string{
+var jsonFieldsNameOfDownloadTaskArtifactByCidBadRequest = [8]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
-	6: "errors",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
+	7: "errors",
 }
 
 // Decode decodes DownloadTaskArtifactByCidBadRequest from json.
@@ -33034,8 +33245,18 @@ func (s *DownloadTaskArtifactByCidBadRequest) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -33047,7 +33268,7 @@ func (s *DownloadTaskArtifactByCidBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -33059,7 +33280,7 @@ func (s *DownloadTaskArtifactByCidBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -33071,7 +33292,7 @@ func (s *DownloadTaskArtifactByCidBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"type\"")
 			}
 		case "errors":
-			requiredBitSet[0] |= 1 << 6
+			requiredBitSet[0] |= 1 << 7
 			if err := func() error {
 				s.Errors = make([]ValidationError, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -33109,7 +33330,7 @@ func (s *DownloadTaskArtifactByCidBadRequest) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b01111001,
+		0b11110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -33333,6 +33554,12 @@ func (s *DownloadTaskArtifactByCidForbidden) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -33353,13 +33580,14 @@ func (s *DownloadTaskArtifactByCidForbidden) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfDownloadTaskArtifactByCidForbidden = [6]string{
+var jsonFieldsNameOfDownloadTaskArtifactByCidForbidden = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes DownloadTaskArtifactByCidForbidden from json.
@@ -33402,8 +33630,18 @@ func (s *DownloadTaskArtifactByCidForbidden) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -33415,7 +33653,7 @@ func (s *DownloadTaskArtifactByCidForbidden) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -33427,7 +33665,7 @@ func (s *DownloadTaskArtifactByCidForbidden) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -33459,7 +33697,7 @@ func (s *DownloadTaskArtifactByCidForbidden) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -33683,6 +33921,12 @@ func (s *DownloadTaskArtifactByCidNotFound) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -33703,13 +33947,14 @@ func (s *DownloadTaskArtifactByCidNotFound) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfDownloadTaskArtifactByCidNotFound = [6]string{
+var jsonFieldsNameOfDownloadTaskArtifactByCidNotFound = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes DownloadTaskArtifactByCidNotFound from json.
@@ -33752,8 +33997,18 @@ func (s *DownloadTaskArtifactByCidNotFound) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -33765,7 +34020,7 @@ func (s *DownloadTaskArtifactByCidNotFound) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -33777,7 +34032,7 @@ func (s *DownloadTaskArtifactByCidNotFound) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -33809,7 +34064,7 @@ func (s *DownloadTaskArtifactByCidNotFound) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -34033,6 +34288,12 @@ func (s *DownloadTaskArtifactByCidServiceUnavailable) encodeFields(e *jx.Encoder
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -34053,13 +34314,14 @@ func (s *DownloadTaskArtifactByCidServiceUnavailable) encodeFields(e *jx.Encoder
 	}
 }
 
-var jsonFieldsNameOfDownloadTaskArtifactByCidServiceUnavailable = [6]string{
+var jsonFieldsNameOfDownloadTaskArtifactByCidServiceUnavailable = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes DownloadTaskArtifactByCidServiceUnavailable from json.
@@ -34102,8 +34364,18 @@ func (s *DownloadTaskArtifactByCidServiceUnavailable) Decode(d *jx.Decoder) erro
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -34115,7 +34387,7 @@ func (s *DownloadTaskArtifactByCidServiceUnavailable) Decode(d *jx.Decoder) erro
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -34127,7 +34399,7 @@ func (s *DownloadTaskArtifactByCidServiceUnavailable) Decode(d *jx.Decoder) erro
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -34159,7 +34431,7 @@ func (s *DownloadTaskArtifactByCidServiceUnavailable) Decode(d *jx.Decoder) erro
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -34383,6 +34655,12 @@ func (s *DownloadTaskArtifactByCidUnauthorized) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -34403,13 +34681,14 @@ func (s *DownloadTaskArtifactByCidUnauthorized) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfDownloadTaskArtifactByCidUnauthorized = [6]string{
+var jsonFieldsNameOfDownloadTaskArtifactByCidUnauthorized = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes DownloadTaskArtifactByCidUnauthorized from json.
@@ -34452,8 +34731,18 @@ func (s *DownloadTaskArtifactByCidUnauthorized) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -34465,7 +34754,7 @@ func (s *DownloadTaskArtifactByCidUnauthorized) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -34477,7 +34766,7 @@ func (s *DownloadTaskArtifactByCidUnauthorized) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -34509,7 +34798,7 @@ func (s *DownloadTaskArtifactByCidUnauthorized) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -34733,6 +35022,12 @@ func (s *DownloadTaskArtifactForbidden) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -34753,13 +35048,14 @@ func (s *DownloadTaskArtifactForbidden) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfDownloadTaskArtifactForbidden = [6]string{
+var jsonFieldsNameOfDownloadTaskArtifactForbidden = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes DownloadTaskArtifactForbidden from json.
@@ -34802,8 +35098,18 @@ func (s *DownloadTaskArtifactForbidden) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -34815,7 +35121,7 @@ func (s *DownloadTaskArtifactForbidden) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -34827,7 +35133,7 @@ func (s *DownloadTaskArtifactForbidden) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -34859,7 +35165,7 @@ func (s *DownloadTaskArtifactForbidden) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -35083,6 +35389,12 @@ func (s *DownloadTaskArtifactNotFound) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -35103,13 +35415,14 @@ func (s *DownloadTaskArtifactNotFound) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfDownloadTaskArtifactNotFound = [6]string{
+var jsonFieldsNameOfDownloadTaskArtifactNotFound = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes DownloadTaskArtifactNotFound from json.
@@ -35152,8 +35465,18 @@ func (s *DownloadTaskArtifactNotFound) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -35165,7 +35488,7 @@ func (s *DownloadTaskArtifactNotFound) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -35177,7 +35500,7 @@ func (s *DownloadTaskArtifactNotFound) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -35209,7 +35532,7 @@ func (s *DownloadTaskArtifactNotFound) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -35433,6 +35756,12 @@ func (s *DownloadTaskArtifactServiceUnavailable) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -35453,13 +35782,14 @@ func (s *DownloadTaskArtifactServiceUnavailable) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfDownloadTaskArtifactServiceUnavailable = [6]string{
+var jsonFieldsNameOfDownloadTaskArtifactServiceUnavailable = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes DownloadTaskArtifactServiceUnavailable from json.
@@ -35502,8 +35832,18 @@ func (s *DownloadTaskArtifactServiceUnavailable) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -35515,7 +35855,7 @@ func (s *DownloadTaskArtifactServiceUnavailable) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -35527,7 +35867,7 @@ func (s *DownloadTaskArtifactServiceUnavailable) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -35559,7 +35899,7 @@ func (s *DownloadTaskArtifactServiceUnavailable) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -35783,6 +36123,12 @@ func (s *DownloadTaskArtifactUnauthorized) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -35803,13 +36149,14 @@ func (s *DownloadTaskArtifactUnauthorized) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfDownloadTaskArtifactUnauthorized = [6]string{
+var jsonFieldsNameOfDownloadTaskArtifactUnauthorized = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes DownloadTaskArtifactUnauthorized from json.
@@ -35852,8 +36199,18 @@ func (s *DownloadTaskArtifactUnauthorized) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -35865,7 +36222,7 @@ func (s *DownloadTaskArtifactUnauthorized) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -35877,7 +36234,7 @@ func (s *DownloadTaskArtifactUnauthorized) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -35909,7 +36266,7 @@ func (s *DownloadTaskArtifactUnauthorized) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -37827,6 +38184,12 @@ func (s *FindLatestRuntimeSlotForAttemptBadRequest) encodeFields(e *jx.Encoder) 
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -37855,14 +38218,15 @@ func (s *FindLatestRuntimeSlotForAttemptBadRequest) encodeFields(e *jx.Encoder) 
 	}
 }
 
-var jsonFieldsNameOfFindLatestRuntimeSlotForAttemptBadRequest = [7]string{
+var jsonFieldsNameOfFindLatestRuntimeSlotForAttemptBadRequest = [8]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
-	6: "errors",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
+	7: "errors",
 }
 
 // Decode decodes FindLatestRuntimeSlotForAttemptBadRequest from json.
@@ -37905,8 +38269,18 @@ func (s *FindLatestRuntimeSlotForAttemptBadRequest) Decode(d *jx.Decoder) error 
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -37918,7 +38292,7 @@ func (s *FindLatestRuntimeSlotForAttemptBadRequest) Decode(d *jx.Decoder) error 
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -37930,7 +38304,7 @@ func (s *FindLatestRuntimeSlotForAttemptBadRequest) Decode(d *jx.Decoder) error 
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -37942,7 +38316,7 @@ func (s *FindLatestRuntimeSlotForAttemptBadRequest) Decode(d *jx.Decoder) error 
 				return errors.Wrap(err, "decode field \"type\"")
 			}
 		case "errors":
-			requiredBitSet[0] |= 1 << 6
+			requiredBitSet[0] |= 1 << 7
 			if err := func() error {
 				s.Errors = make([]ValidationError, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -37980,7 +38354,7 @@ func (s *FindLatestRuntimeSlotForAttemptBadRequest) Decode(d *jx.Decoder) error 
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b01111001,
+		0b11110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -38204,6 +38578,12 @@ func (s *FindLatestRuntimeSlotForAttemptForbidden) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -38224,13 +38604,14 @@ func (s *FindLatestRuntimeSlotForAttemptForbidden) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfFindLatestRuntimeSlotForAttemptForbidden = [6]string{
+var jsonFieldsNameOfFindLatestRuntimeSlotForAttemptForbidden = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes FindLatestRuntimeSlotForAttemptForbidden from json.
@@ -38273,8 +38654,18 @@ func (s *FindLatestRuntimeSlotForAttemptForbidden) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -38286,7 +38677,7 @@ func (s *FindLatestRuntimeSlotForAttemptForbidden) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -38298,7 +38689,7 @@ func (s *FindLatestRuntimeSlotForAttemptForbidden) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -38330,7 +38721,7 @@ func (s *FindLatestRuntimeSlotForAttemptForbidden) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -38554,6 +38945,12 @@ func (s *FindLatestRuntimeSlotForAttemptNotFound) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -38574,13 +38971,14 @@ func (s *FindLatestRuntimeSlotForAttemptNotFound) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfFindLatestRuntimeSlotForAttemptNotFound = [6]string{
+var jsonFieldsNameOfFindLatestRuntimeSlotForAttemptNotFound = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes FindLatestRuntimeSlotForAttemptNotFound from json.
@@ -38623,8 +39021,18 @@ func (s *FindLatestRuntimeSlotForAttemptNotFound) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -38636,7 +39044,7 @@ func (s *FindLatestRuntimeSlotForAttemptNotFound) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -38648,7 +39056,7 @@ func (s *FindLatestRuntimeSlotForAttemptNotFound) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -38680,7 +39088,7 @@ func (s *FindLatestRuntimeSlotForAttemptNotFound) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -39742,6 +40150,12 @@ func (s *FindLatestRuntimeSlotForAttemptUnauthorized) encodeFields(e *jx.Encoder
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -39762,13 +40176,14 @@ func (s *FindLatestRuntimeSlotForAttemptUnauthorized) encodeFields(e *jx.Encoder
 	}
 }
 
-var jsonFieldsNameOfFindLatestRuntimeSlotForAttemptUnauthorized = [6]string{
+var jsonFieldsNameOfFindLatestRuntimeSlotForAttemptUnauthorized = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes FindLatestRuntimeSlotForAttemptUnauthorized from json.
@@ -39811,8 +40226,18 @@ func (s *FindLatestRuntimeSlotForAttemptUnauthorized) Decode(d *jx.Decoder) erro
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -39824,7 +40249,7 @@ func (s *FindLatestRuntimeSlotForAttemptUnauthorized) Decode(d *jx.Decoder) erro
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -39836,7 +40261,7 @@ func (s *FindLatestRuntimeSlotForAttemptUnauthorized) Decode(d *jx.Decoder) erro
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -39868,7 +40293,7 @@ func (s *FindLatestRuntimeSlotForAttemptUnauthorized) Decode(d *jx.Decoder) erro
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -40092,6 +40517,12 @@ func (s *FinishRuntimeSlotBadRequest) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -40120,14 +40551,15 @@ func (s *FinishRuntimeSlotBadRequest) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfFinishRuntimeSlotBadRequest = [7]string{
+var jsonFieldsNameOfFinishRuntimeSlotBadRequest = [8]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
-	6: "errors",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
+	7: "errors",
 }
 
 // Decode decodes FinishRuntimeSlotBadRequest from json.
@@ -40170,8 +40602,18 @@ func (s *FinishRuntimeSlotBadRequest) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -40183,7 +40625,7 @@ func (s *FinishRuntimeSlotBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -40195,7 +40637,7 @@ func (s *FinishRuntimeSlotBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -40207,7 +40649,7 @@ func (s *FinishRuntimeSlotBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"type\"")
 			}
 		case "errors":
-			requiredBitSet[0] |= 1 << 6
+			requiredBitSet[0] |= 1 << 7
 			if err := func() error {
 				s.Errors = make([]ValidationError, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -40245,7 +40687,7 @@ func (s *FinishRuntimeSlotBadRequest) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b01111001,
+		0b11110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -40469,6 +40911,12 @@ func (s *FinishRuntimeSlotConflict) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -40493,14 +40941,15 @@ func (s *FinishRuntimeSlotConflict) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfFinishRuntimeSlotConflict = [7]string{
+var jsonFieldsNameOfFinishRuntimeSlotConflict = [8]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
-	6: "conflict",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
+	7: "conflict",
 }
 
 // Decode decodes FinishRuntimeSlotConflict from json.
@@ -40543,8 +40992,18 @@ func (s *FinishRuntimeSlotConflict) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -40556,7 +41015,7 @@ func (s *FinishRuntimeSlotConflict) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -40568,7 +41027,7 @@ func (s *FinishRuntimeSlotConflict) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -40580,7 +41039,7 @@ func (s *FinishRuntimeSlotConflict) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"type\"")
 			}
 		case "conflict":
-			requiredBitSet[0] |= 1 << 6
+			requiredBitSet[0] |= 1 << 7
 			if err := func() error {
 				if err := s.Conflict.Decode(d); err != nil {
 					return err
@@ -40610,7 +41069,7 @@ func (s *FinishRuntimeSlotConflict) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b01111001,
+		0b11110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -40834,6 +41293,12 @@ func (s *FinishRuntimeSlotForbidden) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -40854,13 +41319,14 @@ func (s *FinishRuntimeSlotForbidden) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfFinishRuntimeSlotForbidden = [6]string{
+var jsonFieldsNameOfFinishRuntimeSlotForbidden = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes FinishRuntimeSlotForbidden from json.
@@ -40903,8 +41369,18 @@ func (s *FinishRuntimeSlotForbidden) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -40916,7 +41392,7 @@ func (s *FinishRuntimeSlotForbidden) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -40928,7 +41404,7 @@ func (s *FinishRuntimeSlotForbidden) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -40960,7 +41436,7 @@ func (s *FinishRuntimeSlotForbidden) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -41184,6 +41660,12 @@ func (s *FinishRuntimeSlotNotFound) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -41204,13 +41686,14 @@ func (s *FinishRuntimeSlotNotFound) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfFinishRuntimeSlotNotFound = [6]string{
+var jsonFieldsNameOfFinishRuntimeSlotNotFound = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes FinishRuntimeSlotNotFound from json.
@@ -41253,8 +41736,18 @@ func (s *FinishRuntimeSlotNotFound) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -41266,7 +41759,7 @@ func (s *FinishRuntimeSlotNotFound) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -41278,7 +41771,7 @@ func (s *FinishRuntimeSlotNotFound) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -41310,7 +41803,7 @@ func (s *FinishRuntimeSlotNotFound) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -42225,6 +42718,12 @@ func (s *FinishRuntimeSlotUnauthorized) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -42245,13 +42744,14 @@ func (s *FinishRuntimeSlotUnauthorized) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfFinishRuntimeSlotUnauthorized = [6]string{
+var jsonFieldsNameOfFinishRuntimeSlotUnauthorized = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes FinishRuntimeSlotUnauthorized from json.
@@ -42294,8 +42794,18 @@ func (s *FinishRuntimeSlotUnauthorized) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -42307,7 +42817,7 @@ func (s *FinishRuntimeSlotUnauthorized) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -42319,7 +42829,7 @@ func (s *FinishRuntimeSlotUnauthorized) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -42351,7 +42861,7 @@ func (s *FinishRuntimeSlotUnauthorized) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -47913,6 +48423,12 @@ func (s *GetRuntimeSessionBadRequest) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -47941,14 +48457,15 @@ func (s *GetRuntimeSessionBadRequest) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfGetRuntimeSessionBadRequest = [7]string{
+var jsonFieldsNameOfGetRuntimeSessionBadRequest = [8]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
-	6: "errors",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
+	7: "errors",
 }
 
 // Decode decodes GetRuntimeSessionBadRequest from json.
@@ -47991,8 +48508,18 @@ func (s *GetRuntimeSessionBadRequest) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -48004,7 +48531,7 @@ func (s *GetRuntimeSessionBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -48016,7 +48543,7 @@ func (s *GetRuntimeSessionBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -48028,7 +48555,7 @@ func (s *GetRuntimeSessionBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"type\"")
 			}
 		case "errors":
-			requiredBitSet[0] |= 1 << 6
+			requiredBitSet[0] |= 1 << 7
 			if err := func() error {
 				s.Errors = make([]ValidationError, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -48066,7 +48593,7 @@ func (s *GetRuntimeSessionBadRequest) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b01111001,
+		0b11110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -48290,6 +48817,12 @@ func (s *GetRuntimeSessionForbidden) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -48310,13 +48843,14 @@ func (s *GetRuntimeSessionForbidden) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfGetRuntimeSessionForbidden = [6]string{
+var jsonFieldsNameOfGetRuntimeSessionForbidden = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes GetRuntimeSessionForbidden from json.
@@ -48359,8 +48893,18 @@ func (s *GetRuntimeSessionForbidden) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -48372,7 +48916,7 @@ func (s *GetRuntimeSessionForbidden) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -48384,7 +48928,7 @@ func (s *GetRuntimeSessionForbidden) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -48416,7 +48960,7 @@ func (s *GetRuntimeSessionForbidden) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -48640,6 +49184,12 @@ func (s *GetRuntimeSessionNotFound) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -48660,13 +49210,14 @@ func (s *GetRuntimeSessionNotFound) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfGetRuntimeSessionNotFound = [6]string{
+var jsonFieldsNameOfGetRuntimeSessionNotFound = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes GetRuntimeSessionNotFound from json.
@@ -48709,8 +49260,18 @@ func (s *GetRuntimeSessionNotFound) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -48722,7 +49283,7 @@ func (s *GetRuntimeSessionNotFound) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -48734,7 +49295,7 @@ func (s *GetRuntimeSessionNotFound) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -48766,7 +49327,7 @@ func (s *GetRuntimeSessionNotFound) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -49508,6 +50069,12 @@ func (s *GetRuntimeSessionUnauthorized) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -49528,13 +50095,14 @@ func (s *GetRuntimeSessionUnauthorized) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfGetRuntimeSessionUnauthorized = [6]string{
+var jsonFieldsNameOfGetRuntimeSessionUnauthorized = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes GetRuntimeSessionUnauthorized from json.
@@ -49577,8 +50145,18 @@ func (s *GetRuntimeSessionUnauthorized) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -49590,7 +50168,7 @@ func (s *GetRuntimeSessionUnauthorized) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -49602,7 +50180,7 @@ func (s *GetRuntimeSessionUnauthorized) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -49634,7 +50212,7 @@ func (s *GetRuntimeSessionUnauthorized) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -52645,6 +53223,12 @@ func (s *InjectionConflictProblemDetails) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -52679,15 +53263,16 @@ func (s *InjectionConflictProblemDetails) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfInjectionConflictProblemDetails = [8]string{
+var jsonFieldsNameOfInjectionConflictProblemDetails = [9]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
-	6: "conflict",
-	7: "flagged",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
+	7: "conflict",
+	8: "flagged",
 }
 
 // Decode decodes InjectionConflictProblemDetails from json.
@@ -52695,7 +53280,7 @@ func (s *InjectionConflictProblemDetails) Decode(d *jx.Decoder) error {
 	if s == nil {
 		return errors.New("invalid: unable to decode InjectionConflictProblemDetails to nil")
 	}
-	var requiredBitSet [1]uint8
+	var requiredBitSet [2]uint8
 	s.AdditionalProps = map[string]jx.Raw{}
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
@@ -52730,8 +53315,18 @@ func (s *InjectionConflictProblemDetails) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -52743,7 +53338,7 @@ func (s *InjectionConflictProblemDetails) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -52755,7 +53350,7 @@ func (s *InjectionConflictProblemDetails) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -52767,7 +53362,7 @@ func (s *InjectionConflictProblemDetails) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"type\"")
 			}
 		case "conflict":
-			requiredBitSet[0] |= 1 << 6
+			requiredBitSet[0] |= 1 << 7
 			if err := func() error {
 				if err := s.Conflict.Decode(d); err != nil {
 					return err
@@ -52813,8 +53408,9 @@ func (s *InjectionConflictProblemDetails) Decode(d *jx.Decoder) error {
 	}
 	// Validate required fields.
 	var failures []validate.FieldError
-	for i, mask := range [1]uint8{
-		0b01111001,
+	for i, mask := range [2]uint8{
+		0b11110001,
+		0b00000000,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -58619,6 +59215,12 @@ func (s *ListRuntimeSlotsBadRequest) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -58647,14 +59249,15 @@ func (s *ListRuntimeSlotsBadRequest) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfListRuntimeSlotsBadRequest = [7]string{
+var jsonFieldsNameOfListRuntimeSlotsBadRequest = [8]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
-	6: "errors",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
+	7: "errors",
 }
 
 // Decode decodes ListRuntimeSlotsBadRequest from json.
@@ -58697,8 +59300,18 @@ func (s *ListRuntimeSlotsBadRequest) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -58710,7 +59323,7 @@ func (s *ListRuntimeSlotsBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -58722,7 +59335,7 @@ func (s *ListRuntimeSlotsBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -58734,7 +59347,7 @@ func (s *ListRuntimeSlotsBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"type\"")
 			}
 		case "errors":
-			requiredBitSet[0] |= 1 << 6
+			requiredBitSet[0] |= 1 << 7
 			if err := func() error {
 				s.Errors = make([]ValidationError, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -58772,7 +59385,7 @@ func (s *ListRuntimeSlotsBadRequest) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b01111001,
+		0b11110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -58996,6 +59609,12 @@ func (s *ListRuntimeSlotsForbidden) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -59016,13 +59635,14 @@ func (s *ListRuntimeSlotsForbidden) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfListRuntimeSlotsForbidden = [6]string{
+var jsonFieldsNameOfListRuntimeSlotsForbidden = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes ListRuntimeSlotsForbidden from json.
@@ -59065,8 +59685,18 @@ func (s *ListRuntimeSlotsForbidden) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -59078,7 +59708,7 @@ func (s *ListRuntimeSlotsForbidden) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -59090,7 +59720,7 @@ func (s *ListRuntimeSlotsForbidden) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -59122,7 +59752,7 @@ func (s *ListRuntimeSlotsForbidden) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -59346,6 +59976,12 @@ func (s *ListRuntimeSlotsNotFound) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -59366,13 +60002,14 @@ func (s *ListRuntimeSlotsNotFound) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfListRuntimeSlotsNotFound = [6]string{
+var jsonFieldsNameOfListRuntimeSlotsNotFound = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes ListRuntimeSlotsNotFound from json.
@@ -59415,8 +60052,18 @@ func (s *ListRuntimeSlotsNotFound) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -59428,7 +60075,7 @@ func (s *ListRuntimeSlotsNotFound) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -59440,7 +60087,7 @@ func (s *ListRuntimeSlotsNotFound) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -59472,7 +60119,7 @@ func (s *ListRuntimeSlotsNotFound) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -60640,6 +61287,12 @@ func (s *ListRuntimeSlotsUnauthorized) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -60660,13 +61313,14 @@ func (s *ListRuntimeSlotsUnauthorized) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfListRuntimeSlotsUnauthorized = [6]string{
+var jsonFieldsNameOfListRuntimeSlotsUnauthorized = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes ListRuntimeSlotsUnauthorized from json.
@@ -60709,8 +61363,18 @@ func (s *ListRuntimeSlotsUnauthorized) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -60722,7 +61386,7 @@ func (s *ListRuntimeSlotsUnauthorized) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -60734,7 +61398,7 @@ func (s *ListRuntimeSlotsUnauthorized) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -60766,7 +61430,7 @@ func (s *ListRuntimeSlotsUnauthorized) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -61332,6 +61996,12 @@ func (s *ListTaskArtifactsBadRequest) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -61360,14 +62030,15 @@ func (s *ListTaskArtifactsBadRequest) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfListTaskArtifactsBadRequest = [7]string{
+var jsonFieldsNameOfListTaskArtifactsBadRequest = [8]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
-	6: "errors",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
+	7: "errors",
 }
 
 // Decode decodes ListTaskArtifactsBadRequest from json.
@@ -61410,8 +62081,18 @@ func (s *ListTaskArtifactsBadRequest) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -61423,7 +62104,7 @@ func (s *ListTaskArtifactsBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -61435,7 +62116,7 @@ func (s *ListTaskArtifactsBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -61447,7 +62128,7 @@ func (s *ListTaskArtifactsBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"type\"")
 			}
 		case "errors":
-			requiredBitSet[0] |= 1 << 6
+			requiredBitSet[0] |= 1 << 7
 			if err := func() error {
 				s.Errors = make([]ValidationError, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -61485,7 +62166,7 @@ func (s *ListTaskArtifactsBadRequest) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b01111001,
+		0b11110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -61709,6 +62390,12 @@ func (s *ListTaskArtifactsForbidden) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -61729,13 +62416,14 @@ func (s *ListTaskArtifactsForbidden) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfListTaskArtifactsForbidden = [6]string{
+var jsonFieldsNameOfListTaskArtifactsForbidden = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes ListTaskArtifactsForbidden from json.
@@ -61778,8 +62466,18 @@ func (s *ListTaskArtifactsForbidden) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -61791,7 +62489,7 @@ func (s *ListTaskArtifactsForbidden) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -61803,7 +62501,7 @@ func (s *ListTaskArtifactsForbidden) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -61835,7 +62533,7 @@ func (s *ListTaskArtifactsForbidden) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -62059,6 +62757,12 @@ func (s *ListTaskArtifactsNotFound) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -62079,13 +62783,14 @@ func (s *ListTaskArtifactsNotFound) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfListTaskArtifactsNotFound = [6]string{
+var jsonFieldsNameOfListTaskArtifactsNotFound = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes ListTaskArtifactsNotFound from json.
@@ -62128,8 +62833,18 @@ func (s *ListTaskArtifactsNotFound) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -62141,7 +62856,7 @@ func (s *ListTaskArtifactsNotFound) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -62153,7 +62868,7 @@ func (s *ListTaskArtifactsNotFound) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -62185,7 +62900,7 @@ func (s *ListTaskArtifactsNotFound) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -62899,6 +63614,12 @@ func (s *ListTaskArtifactsUnauthorized) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -62919,13 +63640,14 @@ func (s *ListTaskArtifactsUnauthorized) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfListTaskArtifactsUnauthorized = [6]string{
+var jsonFieldsNameOfListTaskArtifactsUnauthorized = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes ListTaskArtifactsUnauthorized from json.
@@ -62968,8 +63690,18 @@ func (s *ListTaskArtifactsUnauthorized) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -62981,7 +63713,7 @@ func (s *ListTaskArtifactsUnauthorized) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -62993,7 +63725,7 @@ func (s *ListTaskArtifactsUnauthorized) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -63025,7 +63757,7 @@ func (s *ListTaskArtifactsUnauthorized) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -79028,6 +79760,12 @@ func (s *ProblemDetails) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -79048,13 +79786,14 @@ func (s *ProblemDetails) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfProblemDetails = [6]string{
+var jsonFieldsNameOfProblemDetails = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes ProblemDetails from json.
@@ -79097,8 +79836,18 @@ func (s *ProblemDetails) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -79110,7 +79859,7 @@ func (s *ProblemDetails) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -79122,7 +79871,7 @@ func (s *ProblemDetails) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -79154,7 +79903,7 @@ func (s *ProblemDetails) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -98536,6 +99285,12 @@ func (s *StageTaskArtifactBadRequest) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -98564,14 +99319,15 @@ func (s *StageTaskArtifactBadRequest) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfStageTaskArtifactBadRequest = [7]string{
+var jsonFieldsNameOfStageTaskArtifactBadRequest = [8]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
-	6: "errors",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
+	7: "errors",
 }
 
 // Decode decodes StageTaskArtifactBadRequest from json.
@@ -98614,8 +99370,18 @@ func (s *StageTaskArtifactBadRequest) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -98627,7 +99393,7 @@ func (s *StageTaskArtifactBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -98639,7 +99405,7 @@ func (s *StageTaskArtifactBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -98651,7 +99417,7 @@ func (s *StageTaskArtifactBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"type\"")
 			}
 		case "errors":
-			requiredBitSet[0] |= 1 << 6
+			requiredBitSet[0] |= 1 << 7
 			if err := func() error {
 				s.Errors = make([]ValidationError, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -98689,7 +99455,7 @@ func (s *StageTaskArtifactBadRequest) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b01111001,
+		0b11110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -98913,6 +99679,12 @@ func (s *StageTaskArtifactForbidden) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -98933,13 +99705,14 @@ func (s *StageTaskArtifactForbidden) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfStageTaskArtifactForbidden = [6]string{
+var jsonFieldsNameOfStageTaskArtifactForbidden = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes StageTaskArtifactForbidden from json.
@@ -98982,8 +99755,18 @@ func (s *StageTaskArtifactForbidden) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -98995,7 +99778,7 @@ func (s *StageTaskArtifactForbidden) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -99007,7 +99790,7 @@ func (s *StageTaskArtifactForbidden) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -99039,7 +99822,7 @@ func (s *StageTaskArtifactForbidden) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -99263,6 +100046,12 @@ func (s *StageTaskArtifactNotFound) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -99283,13 +100072,14 @@ func (s *StageTaskArtifactNotFound) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfStageTaskArtifactNotFound = [6]string{
+var jsonFieldsNameOfStageTaskArtifactNotFound = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes StageTaskArtifactNotFound from json.
@@ -99332,8 +100122,18 @@ func (s *StageTaskArtifactNotFound) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -99345,7 +100145,7 @@ func (s *StageTaskArtifactNotFound) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -99357,7 +100157,7 @@ func (s *StageTaskArtifactNotFound) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -99389,7 +100189,7 @@ func (s *StageTaskArtifactNotFound) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -99743,6 +100543,12 @@ func (s *StageTaskArtifactServiceUnavailable) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -99763,13 +100569,14 @@ func (s *StageTaskArtifactServiceUnavailable) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfStageTaskArtifactServiceUnavailable = [6]string{
+var jsonFieldsNameOfStageTaskArtifactServiceUnavailable = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes StageTaskArtifactServiceUnavailable from json.
@@ -99812,8 +100619,18 @@ func (s *StageTaskArtifactServiceUnavailable) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -99825,7 +100642,7 @@ func (s *StageTaskArtifactServiceUnavailable) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -99837,7 +100654,7 @@ func (s *StageTaskArtifactServiceUnavailable) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -99869,7 +100686,7 @@ func (s *StageTaskArtifactServiceUnavailable) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -100093,6 +100910,12 @@ func (s *StageTaskArtifactUnauthorized) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -100113,13 +100936,14 @@ func (s *StageTaskArtifactUnauthorized) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfStageTaskArtifactUnauthorized = [6]string{
+var jsonFieldsNameOfStageTaskArtifactUnauthorized = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes StageTaskArtifactUnauthorized from json.
@@ -100162,8 +100986,18 @@ func (s *StageTaskArtifactUnauthorized) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -100175,7 +101009,7 @@ func (s *StageTaskArtifactUnauthorized) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -100187,7 +101021,7 @@ func (s *StageTaskArtifactUnauthorized) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -100219,7 +101053,7 @@ func (s *StageTaskArtifactUnauthorized) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -113547,6 +114381,12 @@ func (s *UploadRuntimeSessionBadRequest) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -113575,14 +114415,15 @@ func (s *UploadRuntimeSessionBadRequest) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfUploadRuntimeSessionBadRequest = [7]string{
+var jsonFieldsNameOfUploadRuntimeSessionBadRequest = [8]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
-	6: "errors",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
+	7: "errors",
 }
 
 // Decode decodes UploadRuntimeSessionBadRequest from json.
@@ -113625,8 +114466,18 @@ func (s *UploadRuntimeSessionBadRequest) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -113638,7 +114489,7 @@ func (s *UploadRuntimeSessionBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -113650,7 +114501,7 @@ func (s *UploadRuntimeSessionBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -113662,7 +114513,7 @@ func (s *UploadRuntimeSessionBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"type\"")
 			}
 		case "errors":
-			requiredBitSet[0] |= 1 << 6
+			requiredBitSet[0] |= 1 << 7
 			if err := func() error {
 				s.Errors = make([]ValidationError, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -113700,7 +114551,7 @@ func (s *UploadRuntimeSessionBadRequest) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b01111001,
+		0b11110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -113924,6 +114775,12 @@ func (s *UploadRuntimeSessionConflict) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -113944,13 +114801,14 @@ func (s *UploadRuntimeSessionConflict) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfUploadRuntimeSessionConflict = [6]string{
+var jsonFieldsNameOfUploadRuntimeSessionConflict = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes UploadRuntimeSessionConflict from json.
@@ -113993,8 +114851,18 @@ func (s *UploadRuntimeSessionConflict) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -114006,7 +114874,7 @@ func (s *UploadRuntimeSessionConflict) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -114018,7 +114886,7 @@ func (s *UploadRuntimeSessionConflict) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -114050,7 +114918,7 @@ func (s *UploadRuntimeSessionConflict) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -114274,6 +115142,12 @@ func (s *UploadRuntimeSessionForbidden) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -114294,13 +115168,14 @@ func (s *UploadRuntimeSessionForbidden) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfUploadRuntimeSessionForbidden = [6]string{
+var jsonFieldsNameOfUploadRuntimeSessionForbidden = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes UploadRuntimeSessionForbidden from json.
@@ -114343,8 +115218,18 @@ func (s *UploadRuntimeSessionForbidden) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -114356,7 +115241,7 @@ func (s *UploadRuntimeSessionForbidden) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -114368,7 +115253,7 @@ func (s *UploadRuntimeSessionForbidden) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -114400,7 +115285,7 @@ func (s *UploadRuntimeSessionForbidden) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -114624,6 +115509,12 @@ func (s *UploadRuntimeSessionNotFound) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -114644,13 +115535,14 @@ func (s *UploadRuntimeSessionNotFound) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfUploadRuntimeSessionNotFound = [6]string{
+var jsonFieldsNameOfUploadRuntimeSessionNotFound = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes UploadRuntimeSessionNotFound from json.
@@ -114693,8 +115585,18 @@ func (s *UploadRuntimeSessionNotFound) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -114706,7 +115608,7 @@ func (s *UploadRuntimeSessionNotFound) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -114718,7 +115620,7 @@ func (s *UploadRuntimeSessionNotFound) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -114750,7 +115652,7 @@ func (s *UploadRuntimeSessionNotFound) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -115416,6 +116318,12 @@ func (s *UploadRuntimeSessionServiceUnavailable) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -115436,13 +116344,14 @@ func (s *UploadRuntimeSessionServiceUnavailable) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfUploadRuntimeSessionServiceUnavailable = [6]string{
+var jsonFieldsNameOfUploadRuntimeSessionServiceUnavailable = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes UploadRuntimeSessionServiceUnavailable from json.
@@ -115485,8 +116394,18 @@ func (s *UploadRuntimeSessionServiceUnavailable) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -115498,7 +116417,7 @@ func (s *UploadRuntimeSessionServiceUnavailable) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -115510,7 +116429,7 @@ func (s *UploadRuntimeSessionServiceUnavailable) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -115542,7 +116461,7 @@ func (s *UploadRuntimeSessionServiceUnavailable) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -115766,6 +116685,12 @@ func (s *UploadRuntimeSessionUnauthorized) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -115786,13 +116711,14 @@ func (s *UploadRuntimeSessionUnauthorized) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfUploadRuntimeSessionUnauthorized = [6]string{
+var jsonFieldsNameOfUploadRuntimeSessionUnauthorized = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes UploadRuntimeSessionUnauthorized from json.
@@ -115835,8 +116761,18 @@ func (s *UploadRuntimeSessionUnauthorized) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -115848,7 +116784,7 @@ func (s *UploadRuntimeSessionUnauthorized) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -115860,7 +116796,7 @@ func (s *UploadRuntimeSessionUnauthorized) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -115892,7 +116828,7 @@ func (s *UploadRuntimeSessionUnauthorized) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -116116,6 +117052,12 @@ func (s *UploadTaskArtifactBadRequest) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -116144,14 +117086,15 @@ func (s *UploadTaskArtifactBadRequest) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfUploadTaskArtifactBadRequest = [7]string{
+var jsonFieldsNameOfUploadTaskArtifactBadRequest = [8]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
-	6: "errors",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
+	7: "errors",
 }
 
 // Decode decodes UploadTaskArtifactBadRequest from json.
@@ -116194,8 +117137,18 @@ func (s *UploadTaskArtifactBadRequest) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -116207,7 +117160,7 @@ func (s *UploadTaskArtifactBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -116219,7 +117172,7 @@ func (s *UploadTaskArtifactBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -116231,7 +117184,7 @@ func (s *UploadTaskArtifactBadRequest) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"type\"")
 			}
 		case "errors":
-			requiredBitSet[0] |= 1 << 6
+			requiredBitSet[0] |= 1 << 7
 			if err := func() error {
 				s.Errors = make([]ValidationError, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -116269,7 +117222,7 @@ func (s *UploadTaskArtifactBadRequest) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b01111001,
+		0b11110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -116493,6 +117446,12 @@ func (s *UploadTaskArtifactForbidden) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -116513,13 +117472,14 @@ func (s *UploadTaskArtifactForbidden) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfUploadTaskArtifactForbidden = [6]string{
+var jsonFieldsNameOfUploadTaskArtifactForbidden = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes UploadTaskArtifactForbidden from json.
@@ -116562,8 +117522,18 @@ func (s *UploadTaskArtifactForbidden) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -116575,7 +117545,7 @@ func (s *UploadTaskArtifactForbidden) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -116587,7 +117557,7 @@ func (s *UploadTaskArtifactForbidden) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -116619,7 +117589,7 @@ func (s *UploadTaskArtifactForbidden) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -116843,6 +117813,12 @@ func (s *UploadTaskArtifactNotFound) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -116863,13 +117839,14 @@ func (s *UploadTaskArtifactNotFound) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfUploadTaskArtifactNotFound = [6]string{
+var jsonFieldsNameOfUploadTaskArtifactNotFound = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes UploadTaskArtifactNotFound from json.
@@ -116912,8 +117889,18 @@ func (s *UploadTaskArtifactNotFound) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -116925,7 +117912,7 @@ func (s *UploadTaskArtifactNotFound) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -116937,7 +117924,7 @@ func (s *UploadTaskArtifactNotFound) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -116969,7 +117956,7 @@ func (s *UploadTaskArtifactNotFound) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -117486,6 +118473,12 @@ func (s *UploadTaskArtifactServiceUnavailable) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -117506,13 +118499,14 @@ func (s *UploadTaskArtifactServiceUnavailable) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfUploadTaskArtifactServiceUnavailable = [6]string{
+var jsonFieldsNameOfUploadTaskArtifactServiceUnavailable = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes UploadTaskArtifactServiceUnavailable from json.
@@ -117555,8 +118549,18 @@ func (s *UploadTaskArtifactServiceUnavailable) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -117568,7 +118572,7 @@ func (s *UploadTaskArtifactServiceUnavailable) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -117580,7 +118584,7 @@ func (s *UploadTaskArtifactServiceUnavailable) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -117612,7 +118616,7 @@ func (s *UploadTaskArtifactServiceUnavailable) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -117836,6 +118840,12 @@ func (s *UploadTaskArtifactUnauthorized) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -117856,13 +118866,14 @@ func (s *UploadTaskArtifactUnauthorized) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfUploadTaskArtifactUnauthorized = [6]string{
+var jsonFieldsNameOfUploadTaskArtifactUnauthorized = [7]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
 }
 
 // Decode decodes UploadTaskArtifactUnauthorized from json.
@@ -117905,8 +118916,18 @@ func (s *UploadTaskArtifactUnauthorized) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -117918,7 +118939,7 @@ func (s *UploadTaskArtifactUnauthorized) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -117930,7 +118951,7 @@ func (s *UploadTaskArtifactUnauthorized) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -117962,7 +118983,7 @@ func (s *UploadTaskArtifactUnauthorized) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00111001,
+		0b01110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -118603,6 +119624,12 @@ func (s *ValidationProblemDetails) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RetryAfter.Set {
+			e.FieldStart("retryAfter")
+			s.RetryAfter.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("status")
 		e.Int(s.Status)
 	}
@@ -118631,14 +119658,15 @@ func (s *ValidationProblemDetails) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfValidationProblemDetails = [7]string{
+var jsonFieldsNameOfValidationProblemDetails = [8]string{
 	0: "code",
 	1: "detail",
 	2: "instance",
-	3: "status",
-	4: "title",
-	5: "type",
-	6: "errors",
+	3: "retryAfter",
+	4: "status",
+	5: "title",
+	6: "type",
+	7: "errors",
 }
 
 // Decode decodes ValidationProblemDetails from json.
@@ -118681,8 +119709,18 @@ func (s *ValidationProblemDetails) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance\"")
 			}
+		case "retryAfter":
+			if err := func() error {
+				s.RetryAfter.Reset()
+				if err := s.RetryAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retryAfter\"")
+			}
 		case "status":
-			requiredBitSet[0] |= 1 << 3
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				v, err := d.Int()
 				s.Status = int(v)
@@ -118694,7 +119732,7 @@ func (s *ValidationProblemDetails) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "title":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.Title = string(v)
@@ -118706,7 +119744,7 @@ func (s *ValidationProblemDetails) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"title\"")
 			}
 		case "type":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.Type = v
@@ -118718,7 +119756,7 @@ func (s *ValidationProblemDetails) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"type\"")
 			}
 		case "errors":
-			requiredBitSet[0] |= 1 << 6
+			requiredBitSet[0] |= 1 << 7
 			if err := func() error {
 				s.Errors = make([]ValidationError, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -118756,7 +119794,7 @@ func (s *ValidationProblemDetails) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b01111001,
+		0b11110001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.

--- a/libs/moltnet-api-client/oas_schemas_gen.go
+++ b/libs/moltnet-api-client/oas_schemas_gen.go
@@ -1163,14 +1163,16 @@ func (s *BearerAuth) SetRoles(val []string) {
 
 // Merged schema.
 type BeginRuntimeSlotBadRequest struct {
-	Code            BeginRuntimeSlotBadRequestCode `json:"code"`
-	Detail          OptString                      `json:"detail"`
-	Instance        OptString                      `json:"instance"`
-	RetryAfter      OptInt                         `json:"retryAfter"`
-	Status          int                            `json:"status"`
-	Title           string                         `json:"title"`
-	Type            url.URL                        `json:"type"`
-	Errors          []ValidationError              `json:"errors"`
+	Code     BeginRuntimeSlotBadRequestCode `json:"code"`
+	Detail   OptString                      `json:"detail"`
+	Instance OptString                      `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt            `json:"retryAfter"`
+	Status          int               `json:"status"`
+	Title           string            `json:"title"`
+	Type            url.URL           `json:"type"`
+	Errors          []ValidationError `json:"errors"`
 	AdditionalProps BeginRuntimeSlotBadRequestAdditional
 }
 
@@ -1509,14 +1511,16 @@ func (s *BeginRuntimeSlotBadRequestCode) UnmarshalText(data []byte) error {
 
 // Merged schema.
 type BeginRuntimeSlotConflict struct {
-	Code            BeginRuntimeSlotConflictCode `json:"code"`
-	Detail          OptString                    `json:"detail"`
-	Instance        OptString                    `json:"instance"`
-	RetryAfter      OptInt                       `json:"retryAfter"`
-	Status          int                          `json:"status"`
-	Title           string                       `json:"title"`
-	Type            url.URL                      `json:"type"`
-	Conflict        ConflictError                `json:"conflict"`
+	Code     BeginRuntimeSlotConflictCode `json:"code"`
+	Detail   OptString                    `json:"detail"`
+	Instance OptString                    `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt        `json:"retryAfter"`
+	Status          int           `json:"status"`
+	Title           string        `json:"title"`
+	Type            url.URL       `json:"type"`
+	Conflict        ConflictError `json:"conflict"`
 	AdditionalProps BeginRuntimeSlotConflictAdditional
 }
 
@@ -1854,13 +1858,15 @@ func (s *BeginRuntimeSlotConflictCode) UnmarshalText(data []byte) error {
 }
 
 type BeginRuntimeSlotForbidden struct {
-	Code            BeginRuntimeSlotForbiddenCode `json:"code"`
-	Detail          OptString                     `json:"detail"`
-	Instance        OptString                     `json:"instance"`
-	RetryAfter      OptInt                        `json:"retryAfter"`
-	Status          int                           `json:"status"`
-	Title           string                        `json:"title"`
-	Type            url.URL                       `json:"type"`
+	Code     BeginRuntimeSlotForbiddenCode `json:"code"`
+	Detail   OptString                     `json:"detail"`
+	Instance OptString                     `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps BeginRuntimeSlotForbiddenAdditional
 }
 
@@ -2188,13 +2194,15 @@ func (s *BeginRuntimeSlotForbiddenCode) UnmarshalText(data []byte) error {
 }
 
 type BeginRuntimeSlotNotFound struct {
-	Code            BeginRuntimeSlotNotFoundCode `json:"code"`
-	Detail          OptString                    `json:"detail"`
-	Instance        OptString                    `json:"instance"`
-	RetryAfter      OptInt                       `json:"retryAfter"`
-	Status          int                          `json:"status"`
-	Title           string                       `json:"title"`
-	Type            url.URL                      `json:"type"`
+	Code     BeginRuntimeSlotNotFoundCode `json:"code"`
+	Detail   OptString                    `json:"detail"`
+	Instance OptString                    `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps BeginRuntimeSlotNotFoundAdditional
 }
 
@@ -2968,13 +2976,15 @@ type BeginRuntimeSlotTooManyRequests ProblemDetails
 func (*BeginRuntimeSlotTooManyRequests) beginRuntimeSlotRes() {}
 
 type BeginRuntimeSlotUnauthorized struct {
-	Code            BeginRuntimeSlotUnauthorizedCode `json:"code"`
-	Detail          OptString                        `json:"detail"`
-	Instance        OptString                        `json:"instance"`
-	RetryAfter      OptInt                           `json:"retryAfter"`
-	Status          int                              `json:"status"`
-	Title           string                           `json:"title"`
-	Type            url.URL                          `json:"type"`
+	Code     BeginRuntimeSlotUnauthorizedCode `json:"code"`
+	Detail   OptString                        `json:"detail"`
+	Instance OptString                        `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps BeginRuntimeSlotUnauthorizedAdditional
 }
 
@@ -4411,14 +4421,16 @@ func (s *ConflictError) SetTarget(val OptConflictTarget) {
 // Merged schema.
 // Ref: #/components/schemas/ConflictProblemDetails
 type ConflictProblemDetails struct {
-	Code            ConflictProblemDetailsCode `json:"code"`
-	Detail          OptString                  `json:"detail"`
-	Instance        OptString                  `json:"instance"`
-	RetryAfter      OptInt                     `json:"retryAfter"`
-	Status          int                        `json:"status"`
-	Title           string                     `json:"title"`
-	Type            url.URL                    `json:"type"`
-	Conflict        ConflictError              `json:"conflict"`
+	Code     ConflictProblemDetailsCode `json:"code"`
+	Detail   OptString                  `json:"detail"`
+	Instance OptString                  `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt        `json:"retryAfter"`
+	Status          int           `json:"status"`
+	Title           string        `json:"title"`
+	Type            url.URL       `json:"type"`
+	Conflict        ConflictError `json:"conflict"`
 	AdditionalProps ConflictProblemDetailsAdditional
 }
 
@@ -11978,14 +11990,16 @@ func (*DiffContextPacksByIdUnauthorized) diffContextPacksByIdRes() {}
 
 // Merged schema.
 type DownloadRuntimeSessionBadRequest struct {
-	Code            DownloadRuntimeSessionBadRequestCode `json:"code"`
-	Detail          OptString                            `json:"detail"`
-	Instance        OptString                            `json:"instance"`
-	RetryAfter      OptInt                               `json:"retryAfter"`
-	Status          int                                  `json:"status"`
-	Title           string                               `json:"title"`
-	Type            url.URL                              `json:"type"`
-	Errors          []ValidationError                    `json:"errors"`
+	Code     DownloadRuntimeSessionBadRequestCode `json:"code"`
+	Detail   OptString                            `json:"detail"`
+	Instance OptString                            `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt            `json:"retryAfter"`
+	Status          int               `json:"status"`
+	Title           string            `json:"title"`
+	Type            url.URL           `json:"type"`
+	Errors          []ValidationError `json:"errors"`
 	AdditionalProps DownloadRuntimeSessionBadRequestAdditional
 }
 
@@ -12323,13 +12337,15 @@ func (s *DownloadRuntimeSessionBadRequestCode) UnmarshalText(data []byte) error 
 }
 
 type DownloadRuntimeSessionForbidden struct {
-	Code            DownloadRuntimeSessionForbiddenCode `json:"code"`
-	Detail          OptString                           `json:"detail"`
-	Instance        OptString                           `json:"instance"`
-	RetryAfter      OptInt                              `json:"retryAfter"`
-	Status          int                                 `json:"status"`
-	Title           string                              `json:"title"`
-	Type            url.URL                             `json:"type"`
+	Code     DownloadRuntimeSessionForbiddenCode `json:"code"`
+	Detail   OptString                           `json:"detail"`
+	Instance OptString                           `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps DownloadRuntimeSessionForbiddenAdditional
 }
 
@@ -12657,13 +12673,15 @@ func (s *DownloadRuntimeSessionForbiddenCode) UnmarshalText(data []byte) error {
 }
 
 type DownloadRuntimeSessionNotFound struct {
-	Code            DownloadRuntimeSessionNotFoundCode `json:"code"`
-	Detail          OptString                          `json:"detail"`
-	Instance        OptString                          `json:"instance"`
-	RetryAfter      OptInt                             `json:"retryAfter"`
-	Status          int                                `json:"status"`
-	Title           string                             `json:"title"`
-	Type            url.URL                            `json:"type"`
+	Code     DownloadRuntimeSessionNotFoundCode `json:"code"`
+	Detail   OptString                          `json:"detail"`
+	Instance OptString                          `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps DownloadRuntimeSessionNotFoundAdditional
 }
 
@@ -13008,13 +13026,15 @@ func (s DownloadRuntimeSessionOK) Read(p []byte) (n int, err error) {
 func (*DownloadRuntimeSessionOK) downloadRuntimeSessionRes() {}
 
 type DownloadRuntimeSessionServiceUnavailable struct {
-	Code            DownloadRuntimeSessionServiceUnavailableCode `json:"code"`
-	Detail          OptString                                    `json:"detail"`
-	Instance        OptString                                    `json:"instance"`
-	RetryAfter      OptInt                                       `json:"retryAfter"`
-	Status          int                                          `json:"status"`
-	Title           string                                       `json:"title"`
-	Type            url.URL                                      `json:"type"`
+	Code     DownloadRuntimeSessionServiceUnavailableCode `json:"code"`
+	Detail   OptString                                    `json:"detail"`
+	Instance OptString                                    `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps DownloadRuntimeSessionServiceUnavailableAdditional
 }
 
@@ -13342,13 +13362,15 @@ func (s *DownloadRuntimeSessionServiceUnavailableCode) UnmarshalText(data []byte
 }
 
 type DownloadRuntimeSessionUnauthorized struct {
-	Code            DownloadRuntimeSessionUnauthorizedCode `json:"code"`
-	Detail          OptString                              `json:"detail"`
-	Instance        OptString                              `json:"instance"`
-	RetryAfter      OptInt                                 `json:"retryAfter"`
-	Status          int                                    `json:"status"`
-	Title           string                                 `json:"title"`
-	Type            url.URL                                `json:"type"`
+	Code     DownloadRuntimeSessionUnauthorizedCode `json:"code"`
+	Detail   OptString                              `json:"detail"`
+	Instance OptString                              `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps DownloadRuntimeSessionUnauthorizedAdditional
 }
 
@@ -13677,14 +13699,16 @@ func (s *DownloadRuntimeSessionUnauthorizedCode) UnmarshalText(data []byte) erro
 
 // Merged schema.
 type DownloadTaskArtifactBadRequest struct {
-	Code            DownloadTaskArtifactBadRequestCode `json:"code"`
-	Detail          OptString                          `json:"detail"`
-	Instance        OptString                          `json:"instance"`
-	RetryAfter      OptInt                             `json:"retryAfter"`
-	Status          int                                `json:"status"`
-	Title           string                             `json:"title"`
-	Type            url.URL                            `json:"type"`
-	Errors          []ValidationError                  `json:"errors"`
+	Code     DownloadTaskArtifactBadRequestCode `json:"code"`
+	Detail   OptString                          `json:"detail"`
+	Instance OptString                          `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt            `json:"retryAfter"`
+	Status          int               `json:"status"`
+	Title           string            `json:"title"`
+	Type            url.URL           `json:"type"`
+	Errors          []ValidationError `json:"errors"`
 	AdditionalProps DownloadTaskArtifactBadRequestAdditional
 }
 
@@ -14023,14 +14047,16 @@ func (s *DownloadTaskArtifactBadRequestCode) UnmarshalText(data []byte) error {
 
 // Merged schema.
 type DownloadTaskArtifactByCidBadRequest struct {
-	Code            DownloadTaskArtifactByCidBadRequestCode `json:"code"`
-	Detail          OptString                               `json:"detail"`
-	Instance        OptString                               `json:"instance"`
-	RetryAfter      OptInt                                  `json:"retryAfter"`
-	Status          int                                     `json:"status"`
-	Title           string                                  `json:"title"`
-	Type            url.URL                                 `json:"type"`
-	Errors          []ValidationError                       `json:"errors"`
+	Code     DownloadTaskArtifactByCidBadRequestCode `json:"code"`
+	Detail   OptString                               `json:"detail"`
+	Instance OptString                               `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt            `json:"retryAfter"`
+	Status          int               `json:"status"`
+	Title           string            `json:"title"`
+	Type            url.URL           `json:"type"`
+	Errors          []ValidationError `json:"errors"`
 	AdditionalProps DownloadTaskArtifactByCidBadRequestAdditional
 }
 
@@ -14368,13 +14394,15 @@ func (s *DownloadTaskArtifactByCidBadRequestCode) UnmarshalText(data []byte) err
 }
 
 type DownloadTaskArtifactByCidForbidden struct {
-	Code            DownloadTaskArtifactByCidForbiddenCode `json:"code"`
-	Detail          OptString                              `json:"detail"`
-	Instance        OptString                              `json:"instance"`
-	RetryAfter      OptInt                                 `json:"retryAfter"`
-	Status          int                                    `json:"status"`
-	Title           string                                 `json:"title"`
-	Type            url.URL                                `json:"type"`
+	Code     DownloadTaskArtifactByCidForbiddenCode `json:"code"`
+	Detail   OptString                              `json:"detail"`
+	Instance OptString                              `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps DownloadTaskArtifactByCidForbiddenAdditional
 }
 
@@ -14702,13 +14730,15 @@ func (s *DownloadTaskArtifactByCidForbiddenCode) UnmarshalText(data []byte) erro
 }
 
 type DownloadTaskArtifactByCidNotFound struct {
-	Code            DownloadTaskArtifactByCidNotFoundCode `json:"code"`
-	Detail          OptString                             `json:"detail"`
-	Instance        OptString                             `json:"instance"`
-	RetryAfter      OptInt                                `json:"retryAfter"`
-	Status          int                                   `json:"status"`
-	Title           string                                `json:"title"`
-	Type            url.URL                               `json:"type"`
+	Code     DownloadTaskArtifactByCidNotFoundCode `json:"code"`
+	Detail   OptString                             `json:"detail"`
+	Instance OptString                             `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps DownloadTaskArtifactByCidNotFoundAdditional
 }
 
@@ -15112,13 +15142,15 @@ func (s *DownloadTaskArtifactByCidOKHeaders) SetResponse(val DownloadTaskArtifac
 func (*DownloadTaskArtifactByCidOKHeaders) downloadTaskArtifactByCidRes() {}
 
 type DownloadTaskArtifactByCidServiceUnavailable struct {
-	Code            DownloadTaskArtifactByCidServiceUnavailableCode `json:"code"`
-	Detail          OptString                                       `json:"detail"`
-	Instance        OptString                                       `json:"instance"`
-	RetryAfter      OptInt                                          `json:"retryAfter"`
-	Status          int                                             `json:"status"`
-	Title           string                                          `json:"title"`
-	Type            url.URL                                         `json:"type"`
+	Code     DownloadTaskArtifactByCidServiceUnavailableCode `json:"code"`
+	Detail   OptString                                       `json:"detail"`
+	Instance OptString                                       `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps DownloadTaskArtifactByCidServiceUnavailableAdditional
 }
 
@@ -15446,13 +15478,15 @@ func (s *DownloadTaskArtifactByCidServiceUnavailableCode) UnmarshalText(data []b
 }
 
 type DownloadTaskArtifactByCidUnauthorized struct {
-	Code            DownloadTaskArtifactByCidUnauthorizedCode `json:"code"`
-	Detail          OptString                                 `json:"detail"`
-	Instance        OptString                                 `json:"instance"`
-	RetryAfter      OptInt                                    `json:"retryAfter"`
-	Status          int                                       `json:"status"`
-	Title           string                                    `json:"title"`
-	Type            url.URL                                   `json:"type"`
+	Code     DownloadTaskArtifactByCidUnauthorizedCode `json:"code"`
+	Detail   OptString                                 `json:"detail"`
+	Instance OptString                                 `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps DownloadTaskArtifactByCidUnauthorizedAdditional
 }
 
@@ -15780,13 +15814,15 @@ func (s *DownloadTaskArtifactByCidUnauthorizedCode) UnmarshalText(data []byte) e
 }
 
 type DownloadTaskArtifactForbidden struct {
-	Code            DownloadTaskArtifactForbiddenCode `json:"code"`
-	Detail          OptString                         `json:"detail"`
-	Instance        OptString                         `json:"instance"`
-	RetryAfter      OptInt                            `json:"retryAfter"`
-	Status          int                               `json:"status"`
-	Title           string                            `json:"title"`
-	Type            url.URL                           `json:"type"`
+	Code     DownloadTaskArtifactForbiddenCode `json:"code"`
+	Detail   OptString                         `json:"detail"`
+	Instance OptString                         `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps DownloadTaskArtifactForbiddenAdditional
 }
 
@@ -16114,13 +16150,15 @@ func (s *DownloadTaskArtifactForbiddenCode) UnmarshalText(data []byte) error {
 }
 
 type DownloadTaskArtifactNotFound struct {
-	Code            DownloadTaskArtifactNotFoundCode `json:"code"`
-	Detail          OptString                        `json:"detail"`
-	Instance        OptString                        `json:"instance"`
-	RetryAfter      OptInt                           `json:"retryAfter"`
-	Status          int                              `json:"status"`
-	Title           string                           `json:"title"`
-	Type            url.URL                          `json:"type"`
+	Code     DownloadTaskArtifactNotFoundCode `json:"code"`
+	Detail   OptString                        `json:"detail"`
+	Instance OptString                        `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps DownloadTaskArtifactNotFoundAdditional
 }
 
@@ -16524,13 +16562,15 @@ func (s *DownloadTaskArtifactOKHeaders) SetResponse(val DownloadTaskArtifactOK) 
 func (*DownloadTaskArtifactOKHeaders) downloadTaskArtifactRes() {}
 
 type DownloadTaskArtifactServiceUnavailable struct {
-	Code            DownloadTaskArtifactServiceUnavailableCode `json:"code"`
-	Detail          OptString                                  `json:"detail"`
-	Instance        OptString                                  `json:"instance"`
-	RetryAfter      OptInt                                     `json:"retryAfter"`
-	Status          int                                        `json:"status"`
-	Title           string                                     `json:"title"`
-	Type            url.URL                                    `json:"type"`
+	Code     DownloadTaskArtifactServiceUnavailableCode `json:"code"`
+	Detail   OptString                                  `json:"detail"`
+	Instance OptString                                  `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps DownloadTaskArtifactServiceUnavailableAdditional
 }
 
@@ -16858,13 +16898,15 @@ func (s *DownloadTaskArtifactServiceUnavailableCode) UnmarshalText(data []byte) 
 }
 
 type DownloadTaskArtifactUnauthorized struct {
-	Code            DownloadTaskArtifactUnauthorizedCode `json:"code"`
-	Detail          OptString                            `json:"detail"`
-	Instance        OptString                            `json:"instance"`
-	RetryAfter      OptInt                               `json:"retryAfter"`
-	Status          int                                  `json:"status"`
-	Title           string                               `json:"title"`
-	Type            url.URL                              `json:"type"`
+	Code     DownloadTaskArtifactUnauthorizedCode `json:"code"`
+	Detail   OptString                            `json:"detail"`
+	Instance OptString                            `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps DownloadTaskArtifactUnauthorizedAdditional
 }
 
@@ -17911,14 +17953,16 @@ func (*FailTaskAttemptUnauthorized) failTaskAttemptRes() {}
 
 // Merged schema.
 type FindLatestRuntimeSlotForAttemptBadRequest struct {
-	Code            FindLatestRuntimeSlotForAttemptBadRequestCode `json:"code"`
-	Detail          OptString                                     `json:"detail"`
-	Instance        OptString                                     `json:"instance"`
-	RetryAfter      OptInt                                        `json:"retryAfter"`
-	Status          int                                           `json:"status"`
-	Title           string                                        `json:"title"`
-	Type            url.URL                                       `json:"type"`
-	Errors          []ValidationError                             `json:"errors"`
+	Code     FindLatestRuntimeSlotForAttemptBadRequestCode `json:"code"`
+	Detail   OptString                                     `json:"detail"`
+	Instance OptString                                     `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt            `json:"retryAfter"`
+	Status          int               `json:"status"`
+	Title           string            `json:"title"`
+	Type            url.URL           `json:"type"`
+	Errors          []ValidationError `json:"errors"`
 	AdditionalProps FindLatestRuntimeSlotForAttemptBadRequestAdditional
 }
 
@@ -18256,13 +18300,15 @@ func (s *FindLatestRuntimeSlotForAttemptBadRequestCode) UnmarshalText(data []byt
 }
 
 type FindLatestRuntimeSlotForAttemptForbidden struct {
-	Code            FindLatestRuntimeSlotForAttemptForbiddenCode `json:"code"`
-	Detail          OptString                                    `json:"detail"`
-	Instance        OptString                                    `json:"instance"`
-	RetryAfter      OptInt                                       `json:"retryAfter"`
-	Status          int                                          `json:"status"`
-	Title           string                                       `json:"title"`
-	Type            url.URL                                      `json:"type"`
+	Code     FindLatestRuntimeSlotForAttemptForbiddenCode `json:"code"`
+	Detail   OptString                                    `json:"detail"`
+	Instance OptString                                    `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps FindLatestRuntimeSlotForAttemptForbiddenAdditional
 }
 
@@ -18590,13 +18636,15 @@ func (s *FindLatestRuntimeSlotForAttemptForbiddenCode) UnmarshalText(data []byte
 }
 
 type FindLatestRuntimeSlotForAttemptNotFound struct {
-	Code            FindLatestRuntimeSlotForAttemptNotFoundCode `json:"code"`
-	Detail          OptString                                   `json:"detail"`
-	Instance        OptString                                   `json:"instance"`
-	RetryAfter      OptInt                                      `json:"retryAfter"`
-	Status          int                                         `json:"status"`
-	Title           string                                      `json:"title"`
-	Type            url.URL                                     `json:"type"`
+	Code     FindLatestRuntimeSlotForAttemptNotFoundCode `json:"code"`
+	Detail   OptString                                   `json:"detail"`
+	Instance OptString                                   `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps FindLatestRuntimeSlotForAttemptNotFoundAdditional
 }
 
@@ -19329,13 +19377,15 @@ type FindLatestRuntimeSlotForAttemptTooManyRequests ProblemDetails
 func (*FindLatestRuntimeSlotForAttemptTooManyRequests) findLatestRuntimeSlotForAttemptRes() {}
 
 type FindLatestRuntimeSlotForAttemptUnauthorized struct {
-	Code            FindLatestRuntimeSlotForAttemptUnauthorizedCode `json:"code"`
-	Detail          OptString                                       `json:"detail"`
-	Instance        OptString                                       `json:"instance"`
-	RetryAfter      OptInt                                          `json:"retryAfter"`
-	Status          int                                             `json:"status"`
-	Title           string                                          `json:"title"`
-	Type            url.URL                                         `json:"type"`
+	Code     FindLatestRuntimeSlotForAttemptUnauthorizedCode `json:"code"`
+	Detail   OptString                                       `json:"detail"`
+	Instance OptString                                       `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps FindLatestRuntimeSlotForAttemptUnauthorizedAdditional
 }
 
@@ -19664,14 +19714,16 @@ func (s *FindLatestRuntimeSlotForAttemptUnauthorizedCode) UnmarshalText(data []b
 
 // Merged schema.
 type FinishRuntimeSlotBadRequest struct {
-	Code            FinishRuntimeSlotBadRequestCode `json:"code"`
-	Detail          OptString                       `json:"detail"`
-	Instance        OptString                       `json:"instance"`
-	RetryAfter      OptInt                          `json:"retryAfter"`
-	Status          int                             `json:"status"`
-	Title           string                          `json:"title"`
-	Type            url.URL                         `json:"type"`
-	Errors          []ValidationError               `json:"errors"`
+	Code     FinishRuntimeSlotBadRequestCode `json:"code"`
+	Detail   OptString                       `json:"detail"`
+	Instance OptString                       `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt            `json:"retryAfter"`
+	Status          int               `json:"status"`
+	Title           string            `json:"title"`
+	Type            url.URL           `json:"type"`
+	Errors          []ValidationError `json:"errors"`
 	AdditionalProps FinishRuntimeSlotBadRequestAdditional
 }
 
@@ -20010,14 +20062,16 @@ func (s *FinishRuntimeSlotBadRequestCode) UnmarshalText(data []byte) error {
 
 // Merged schema.
 type FinishRuntimeSlotConflict struct {
-	Code            FinishRuntimeSlotConflictCode `json:"code"`
-	Detail          OptString                     `json:"detail"`
-	Instance        OptString                     `json:"instance"`
-	RetryAfter      OptInt                        `json:"retryAfter"`
-	Status          int                           `json:"status"`
-	Title           string                        `json:"title"`
-	Type            url.URL                       `json:"type"`
-	Conflict        ConflictError                 `json:"conflict"`
+	Code     FinishRuntimeSlotConflictCode `json:"code"`
+	Detail   OptString                     `json:"detail"`
+	Instance OptString                     `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt        `json:"retryAfter"`
+	Status          int           `json:"status"`
+	Title           string        `json:"title"`
+	Type            url.URL       `json:"type"`
+	Conflict        ConflictError `json:"conflict"`
 	AdditionalProps FinishRuntimeSlotConflictAdditional
 }
 
@@ -20355,13 +20409,15 @@ func (s *FinishRuntimeSlotConflictCode) UnmarshalText(data []byte) error {
 }
 
 type FinishRuntimeSlotForbidden struct {
-	Code            FinishRuntimeSlotForbiddenCode `json:"code"`
-	Detail          OptString                      `json:"detail"`
-	Instance        OptString                      `json:"instance"`
-	RetryAfter      OptInt                         `json:"retryAfter"`
-	Status          int                            `json:"status"`
-	Title           string                         `json:"title"`
-	Type            url.URL                        `json:"type"`
+	Code     FinishRuntimeSlotForbiddenCode `json:"code"`
+	Detail   OptString                      `json:"detail"`
+	Instance OptString                      `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps FinishRuntimeSlotForbiddenAdditional
 }
 
@@ -20689,13 +20745,15 @@ func (s *FinishRuntimeSlotForbiddenCode) UnmarshalText(data []byte) error {
 }
 
 type FinishRuntimeSlotNotFound struct {
-	Code            FinishRuntimeSlotNotFoundCode `json:"code"`
-	Detail          OptString                     `json:"detail"`
-	Instance        OptString                     `json:"instance"`
-	RetryAfter      OptInt                        `json:"retryAfter"`
-	Status          int                           `json:"status"`
-	Title           string                        `json:"title"`
-	Type            url.URL                       `json:"type"`
+	Code     FinishRuntimeSlotNotFoundCode `json:"code"`
+	Detail   OptString                     `json:"detail"`
+	Instance OptString                     `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps FinishRuntimeSlotNotFoundAdditional
 }
 
@@ -21355,13 +21413,15 @@ type FinishRuntimeSlotTooManyRequests ProblemDetails
 func (*FinishRuntimeSlotTooManyRequests) finishRuntimeSlotRes() {}
 
 type FinishRuntimeSlotUnauthorized struct {
-	Code            FinishRuntimeSlotUnauthorizedCode `json:"code"`
-	Detail          OptString                         `json:"detail"`
-	Instance        OptString                         `json:"instance"`
-	RetryAfter      OptInt                            `json:"retryAfter"`
-	Status          int                               `json:"status"`
-	Title           string                            `json:"title"`
-	Type            url.URL                           `json:"type"`
+	Code     FinishRuntimeSlotUnauthorizedCode `json:"code"`
+	Detail   OptString                         `json:"detail"`
+	Instance OptString                         `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps FinishRuntimeSlotUnauthorizedAdditional
 }
 
@@ -23161,14 +23221,16 @@ func (*GetRuntimeProfileUnauthorized) getRuntimeProfileRes() {}
 
 // Merged schema.
 type GetRuntimeSessionBadRequest struct {
-	Code            GetRuntimeSessionBadRequestCode `json:"code"`
-	Detail          OptString                       `json:"detail"`
-	Instance        OptString                       `json:"instance"`
-	RetryAfter      OptInt                          `json:"retryAfter"`
-	Status          int                             `json:"status"`
-	Title           string                          `json:"title"`
-	Type            url.URL                         `json:"type"`
-	Errors          []ValidationError               `json:"errors"`
+	Code     GetRuntimeSessionBadRequestCode `json:"code"`
+	Detail   OptString                       `json:"detail"`
+	Instance OptString                       `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt            `json:"retryAfter"`
+	Status          int               `json:"status"`
+	Title           string            `json:"title"`
+	Type            url.URL           `json:"type"`
+	Errors          []ValidationError `json:"errors"`
 	AdditionalProps GetRuntimeSessionBadRequestAdditional
 }
 
@@ -23506,13 +23568,15 @@ func (s *GetRuntimeSessionBadRequestCode) UnmarshalText(data []byte) error {
 }
 
 type GetRuntimeSessionForbidden struct {
-	Code            GetRuntimeSessionForbiddenCode `json:"code"`
-	Detail          OptString                      `json:"detail"`
-	Instance        OptString                      `json:"instance"`
-	RetryAfter      OptInt                         `json:"retryAfter"`
-	Status          int                            `json:"status"`
-	Title           string                         `json:"title"`
-	Type            url.URL                        `json:"type"`
+	Code     GetRuntimeSessionForbiddenCode `json:"code"`
+	Detail   OptString                      `json:"detail"`
+	Instance OptString                      `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps GetRuntimeSessionForbiddenAdditional
 }
 
@@ -23840,13 +23904,15 @@ func (s *GetRuntimeSessionForbiddenCode) UnmarshalText(data []byte) error {
 }
 
 type GetRuntimeSessionNotFound struct {
-	Code            GetRuntimeSessionNotFoundCode `json:"code"`
-	Detail          OptString                     `json:"detail"`
-	Instance        OptString                     `json:"instance"`
-	RetryAfter      OptInt                        `json:"retryAfter"`
-	Status          int                           `json:"status"`
-	Title           string                        `json:"title"`
-	Type            url.URL                       `json:"type"`
+	Code     GetRuntimeSessionNotFoundCode `json:"code"`
+	Detail   OptString                     `json:"detail"`
+	Instance OptString                     `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps GetRuntimeSessionNotFoundAdditional
 }
 
@@ -24475,13 +24541,15 @@ type GetRuntimeSessionTooManyRequests ProblemDetails
 func (*GetRuntimeSessionTooManyRequests) getRuntimeSessionRes() {}
 
 type GetRuntimeSessionUnauthorized struct {
-	Code            GetRuntimeSessionUnauthorizedCode `json:"code"`
-	Detail          OptString                         `json:"detail"`
-	Instance        OptString                         `json:"instance"`
-	RetryAfter      OptInt                            `json:"retryAfter"`
-	Status          int                               `json:"status"`
-	Title           string                            `json:"title"`
-	Type            url.URL                           `json:"type"`
+	Code     GetRuntimeSessionUnauthorizedCode `json:"code"`
+	Detail   OptString                         `json:"detail"`
+	Instance OptString                         `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps GetRuntimeSessionUnauthorizedAdditional
 }
 
@@ -25585,9 +25653,11 @@ func (*InitiateTransferUnauthorized) initiateTransferRes() {}
 // Merged schema.
 // Ref: #/components/schemas/InjectionConflictProblemDetails
 type InjectionConflictProblemDetails struct {
-	Code            InjectionConflictProblemDetailsCode          `json:"code"`
-	Detail          OptString                                    `json:"detail"`
-	Instance        OptString                                    `json:"instance"`
+	Code     InjectionConflictProblemDetailsCode `json:"code"`
+	Detail   OptString                           `json:"detail"`
+	Instance OptString                           `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
 	RetryAfter      OptInt                                       `json:"retryAfter"`
 	Status          int                                          `json:"status"`
 	Title           string                                       `json:"title"`
@@ -27188,14 +27258,16 @@ func (*ListRuntimeProfilesUnauthorized) listRuntimeProfilesRes() {}
 
 // Merged schema.
 type ListRuntimeSlotsBadRequest struct {
-	Code            ListRuntimeSlotsBadRequestCode `json:"code"`
-	Detail          OptString                      `json:"detail"`
-	Instance        OptString                      `json:"instance"`
-	RetryAfter      OptInt                         `json:"retryAfter"`
-	Status          int                            `json:"status"`
-	Title           string                         `json:"title"`
-	Type            url.URL                        `json:"type"`
-	Errors          []ValidationError              `json:"errors"`
+	Code     ListRuntimeSlotsBadRequestCode `json:"code"`
+	Detail   OptString                      `json:"detail"`
+	Instance OptString                      `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt            `json:"retryAfter"`
+	Status          int               `json:"status"`
+	Title           string            `json:"title"`
+	Type            url.URL           `json:"type"`
+	Errors          []ValidationError `json:"errors"`
 	AdditionalProps ListRuntimeSlotsBadRequestAdditional
 }
 
@@ -27533,13 +27605,15 @@ func (s *ListRuntimeSlotsBadRequestCode) UnmarshalText(data []byte) error {
 }
 
 type ListRuntimeSlotsForbidden struct {
-	Code            ListRuntimeSlotsForbiddenCode `json:"code"`
-	Detail          OptString                     `json:"detail"`
-	Instance        OptString                     `json:"instance"`
-	RetryAfter      OptInt                        `json:"retryAfter"`
-	Status          int                           `json:"status"`
-	Title           string                        `json:"title"`
-	Type            url.URL                       `json:"type"`
+	Code     ListRuntimeSlotsForbiddenCode `json:"code"`
+	Detail   OptString                     `json:"detail"`
+	Instance OptString                     `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps ListRuntimeSlotsForbiddenAdditional
 }
 
@@ -27867,13 +27941,15 @@ func (s *ListRuntimeSlotsForbiddenCode) UnmarshalText(data []byte) error {
 }
 
 type ListRuntimeSlotsNotFound struct {
-	Code            ListRuntimeSlotsNotFoundCode `json:"code"`
-	Detail          OptString                    `json:"detail"`
-	Instance        OptString                    `json:"instance"`
-	RetryAfter      OptInt                       `json:"retryAfter"`
-	Status          int                          `json:"status"`
-	Title           string                       `json:"title"`
-	Type            url.URL                      `json:"type"`
+	Code     ListRuntimeSlotsNotFoundCode `json:"code"`
+	Detail   OptString                    `json:"detail"`
+	Instance OptString                    `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps ListRuntimeSlotsNotFoundAdditional
 }
 
@@ -28661,13 +28737,15 @@ type ListRuntimeSlotsTooManyRequests ProblemDetails
 func (*ListRuntimeSlotsTooManyRequests) listRuntimeSlotsRes() {}
 
 type ListRuntimeSlotsUnauthorized struct {
-	Code            ListRuntimeSlotsUnauthorizedCode `json:"code"`
-	Detail          OptString                        `json:"detail"`
-	Instance        OptString                        `json:"instance"`
-	RetryAfter      OptInt                           `json:"retryAfter"`
-	Status          int                              `json:"status"`
-	Title           string                           `json:"title"`
-	Type            url.URL                          `json:"type"`
+	Code     ListRuntimeSlotsUnauthorizedCode `json:"code"`
+	Detail   OptString                        `json:"detail"`
+	Instance OptString                        `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps ListRuntimeSlotsUnauthorizedAdditional
 }
 
@@ -29135,14 +29213,16 @@ func (*ListSigningRequestsUnauthorized) listSigningRequestsRes() {}
 
 // Merged schema.
 type ListTaskArtifactsBadRequest struct {
-	Code            ListTaskArtifactsBadRequestCode `json:"code"`
-	Detail          OptString                       `json:"detail"`
-	Instance        OptString                       `json:"instance"`
-	RetryAfter      OptInt                          `json:"retryAfter"`
-	Status          int                             `json:"status"`
-	Title           string                          `json:"title"`
-	Type            url.URL                         `json:"type"`
-	Errors          []ValidationError               `json:"errors"`
+	Code     ListTaskArtifactsBadRequestCode `json:"code"`
+	Detail   OptString                       `json:"detail"`
+	Instance OptString                       `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt            `json:"retryAfter"`
+	Status          int               `json:"status"`
+	Title           string            `json:"title"`
+	Type            url.URL           `json:"type"`
+	Errors          []ValidationError `json:"errors"`
 	AdditionalProps ListTaskArtifactsBadRequestAdditional
 }
 
@@ -29480,13 +29560,15 @@ func (s *ListTaskArtifactsBadRequestCode) UnmarshalText(data []byte) error {
 }
 
 type ListTaskArtifactsForbidden struct {
-	Code            ListTaskArtifactsForbiddenCode `json:"code"`
-	Detail          OptString                      `json:"detail"`
-	Instance        OptString                      `json:"instance"`
-	RetryAfter      OptInt                         `json:"retryAfter"`
-	Status          int                            `json:"status"`
-	Title           string                         `json:"title"`
-	Type            url.URL                        `json:"type"`
+	Code     ListTaskArtifactsForbiddenCode `json:"code"`
+	Detail   OptString                      `json:"detail"`
+	Instance OptString                      `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps ListTaskArtifactsForbiddenAdditional
 }
 
@@ -29814,13 +29896,15 @@ func (s *ListTaskArtifactsForbiddenCode) UnmarshalText(data []byte) error {
 }
 
 type ListTaskArtifactsNotFound struct {
-	Code            ListTaskArtifactsNotFoundCode `json:"code"`
-	Detail          OptString                     `json:"detail"`
-	Instance        OptString                     `json:"instance"`
-	RetryAfter      OptInt                        `json:"retryAfter"`
-	Status          int                           `json:"status"`
-	Title           string                        `json:"title"`
-	Type            url.URL                       `json:"type"`
+	Code     ListTaskArtifactsNotFoundCode `json:"code"`
+	Detail   OptString                     `json:"detail"`
+	Instance OptString                     `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps ListTaskArtifactsNotFoundAdditional
 }
 
@@ -30329,13 +30413,15 @@ type ListTaskArtifactsTooManyRequests ProblemDetails
 func (*ListTaskArtifactsTooManyRequests) listTaskArtifactsRes() {}
 
 type ListTaskArtifactsUnauthorized struct {
-	Code            ListTaskArtifactsUnauthorizedCode `json:"code"`
-	Detail          OptString                         `json:"detail"`
-	Instance        OptString                         `json:"instance"`
-	RetryAfter      OptInt                            `json:"retryAfter"`
-	Status          int                               `json:"status"`
-	Title           string                            `json:"title"`
-	Type            url.URL                           `json:"type"`
+	Code     ListTaskArtifactsUnauthorizedCode `json:"code"`
+	Detail   OptString                         `json:"detail"`
+	Instance OptString                         `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps ListTaskArtifactsUnauthorizedAdditional
 }
 
@@ -41058,13 +41144,15 @@ type PreviewSignSha256Base64Url string
 
 // Ref: #/components/schemas/ProblemDetails
 type ProblemDetails struct {
-	Code            ProblemDetailsCode `json:"code"`
-	Detail          OptString          `json:"detail"`
-	Instance        OptString          `json:"instance"`
-	RetryAfter      OptInt             `json:"retryAfter"`
-	Status          int                `json:"status"`
-	Title           string             `json:"title"`
-	Type            url.URL            `json:"type"`
+	Code     ProblemDetailsCode `json:"code"`
+	Detail   OptString          `json:"detail"`
+	Instance OptString          `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps ProblemDetailsAdditional
 }
 
@@ -49640,14 +49728,16 @@ func (s *SigningRequestVerificationMethod) UnmarshalText(data []byte) error {
 
 // Merged schema.
 type StageTaskArtifactBadRequest struct {
-	Code            StageTaskArtifactBadRequestCode `json:"code"`
-	Detail          OptString                       `json:"detail"`
-	Instance        OptString                       `json:"instance"`
-	RetryAfter      OptInt                          `json:"retryAfter"`
-	Status          int                             `json:"status"`
-	Title           string                          `json:"title"`
-	Type            url.URL                         `json:"type"`
-	Errors          []ValidationError               `json:"errors"`
+	Code     StageTaskArtifactBadRequestCode `json:"code"`
+	Detail   OptString                       `json:"detail"`
+	Instance OptString                       `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt            `json:"retryAfter"`
+	Status          int               `json:"status"`
+	Title           string            `json:"title"`
+	Type            url.URL           `json:"type"`
+	Errors          []ValidationError `json:"errors"`
 	AdditionalProps StageTaskArtifactBadRequestAdditional
 }
 
@@ -49985,13 +50075,15 @@ func (s *StageTaskArtifactBadRequestCode) UnmarshalText(data []byte) error {
 }
 
 type StageTaskArtifactForbidden struct {
-	Code            StageTaskArtifactForbiddenCode `json:"code"`
-	Detail          OptString                      `json:"detail"`
-	Instance        OptString                      `json:"instance"`
-	RetryAfter      OptInt                         `json:"retryAfter"`
-	Status          int                            `json:"status"`
-	Title           string                         `json:"title"`
-	Type            url.URL                        `json:"type"`
+	Code     StageTaskArtifactForbiddenCode `json:"code"`
+	Detail   OptString                      `json:"detail"`
+	Instance OptString                      `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps StageTaskArtifactForbiddenAdditional
 }
 
@@ -50319,13 +50411,15 @@ func (s *StageTaskArtifactForbiddenCode) UnmarshalText(data []byte) error {
 }
 
 type StageTaskArtifactNotFound struct {
-	Code            StageTaskArtifactNotFoundCode `json:"code"`
-	Detail          OptString                     `json:"detail"`
-	Instance        OptString                     `json:"instance"`
-	RetryAfter      OptInt                        `json:"retryAfter"`
-	Status          int                           `json:"status"`
-	Title           string                        `json:"title"`
-	Type            url.URL                       `json:"type"`
+	Code     StageTaskArtifactNotFoundCode `json:"code"`
+	Detail   OptString                     `json:"detail"`
+	Instance OptString                     `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps StageTaskArtifactNotFoundAdditional
 }
 
@@ -50706,13 +50800,15 @@ func (s StageTaskArtifactReq) Read(p []byte) (n int, err error) {
 }
 
 type StageTaskArtifactServiceUnavailable struct {
-	Code            StageTaskArtifactServiceUnavailableCode `json:"code"`
-	Detail          OptString                               `json:"detail"`
-	Instance        OptString                               `json:"instance"`
-	RetryAfter      OptInt                                  `json:"retryAfter"`
-	Status          int                                     `json:"status"`
-	Title           string                                  `json:"title"`
-	Type            url.URL                                 `json:"type"`
+	Code     StageTaskArtifactServiceUnavailableCode `json:"code"`
+	Detail   OptString                               `json:"detail"`
+	Instance OptString                               `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps StageTaskArtifactServiceUnavailableAdditional
 }
 
@@ -51040,13 +51136,15 @@ func (s *StageTaskArtifactServiceUnavailableCode) UnmarshalText(data []byte) err
 }
 
 type StageTaskArtifactUnauthorized struct {
-	Code            StageTaskArtifactUnauthorizedCode `json:"code"`
-	Detail          OptString                         `json:"detail"`
-	Instance        OptString                         `json:"instance"`
-	RetryAfter      OptInt                            `json:"retryAfter"`
-	Status          int                               `json:"status"`
-	Title           string                            `json:"title"`
-	Type            url.URL                           `json:"type"`
+	Code     StageTaskArtifactUnauthorizedCode `json:"code"`
+	Detail   OptString                         `json:"detail"`
+	Instance OptString                         `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps StageTaskArtifactUnauthorizedAdditional
 }
 
@@ -56502,14 +56600,16 @@ func (*UpdateTeamMemberRoleUnauthorized) updateTeamMemberRoleRes() {}
 
 // Merged schema.
 type UploadRuntimeSessionBadRequest struct {
-	Code            UploadRuntimeSessionBadRequestCode `json:"code"`
-	Detail          OptString                          `json:"detail"`
-	Instance        OptString                          `json:"instance"`
-	RetryAfter      OptInt                             `json:"retryAfter"`
-	Status          int                                `json:"status"`
-	Title           string                             `json:"title"`
-	Type            url.URL                            `json:"type"`
-	Errors          []ValidationError                  `json:"errors"`
+	Code     UploadRuntimeSessionBadRequestCode `json:"code"`
+	Detail   OptString                          `json:"detail"`
+	Instance OptString                          `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt            `json:"retryAfter"`
+	Status          int               `json:"status"`
+	Title           string            `json:"title"`
+	Type            url.URL           `json:"type"`
+	Errors          []ValidationError `json:"errors"`
 	AdditionalProps UploadRuntimeSessionBadRequestAdditional
 }
 
@@ -56847,13 +56947,15 @@ func (s *UploadRuntimeSessionBadRequestCode) UnmarshalText(data []byte) error {
 }
 
 type UploadRuntimeSessionConflict struct {
-	Code            UploadRuntimeSessionConflictCode `json:"code"`
-	Detail          OptString                        `json:"detail"`
-	Instance        OptString                        `json:"instance"`
-	RetryAfter      OptInt                           `json:"retryAfter"`
-	Status          int                              `json:"status"`
-	Title           string                           `json:"title"`
-	Type            url.URL                          `json:"type"`
+	Code     UploadRuntimeSessionConflictCode `json:"code"`
+	Detail   OptString                        `json:"detail"`
+	Instance OptString                        `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps UploadRuntimeSessionConflictAdditional
 }
 
@@ -57181,13 +57283,15 @@ func (s *UploadRuntimeSessionConflictCode) UnmarshalText(data []byte) error {
 }
 
 type UploadRuntimeSessionForbidden struct {
-	Code            UploadRuntimeSessionForbiddenCode `json:"code"`
-	Detail          OptString                         `json:"detail"`
-	Instance        OptString                         `json:"instance"`
-	RetryAfter      OptInt                            `json:"retryAfter"`
-	Status          int                               `json:"status"`
-	Title           string                            `json:"title"`
-	Type            url.URL                           `json:"type"`
+	Code     UploadRuntimeSessionForbiddenCode `json:"code"`
+	Detail   OptString                         `json:"detail"`
+	Instance OptString                         `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps UploadRuntimeSessionForbiddenAdditional
 }
 
@@ -57515,13 +57619,15 @@ func (s *UploadRuntimeSessionForbiddenCode) UnmarshalText(data []byte) error {
 }
 
 type UploadRuntimeSessionNotFound struct {
-	Code            UploadRuntimeSessionNotFoundCode `json:"code"`
-	Detail          OptString                        `json:"detail"`
-	Instance        OptString                        `json:"instance"`
-	RetryAfter      OptInt                           `json:"retryAfter"`
-	Status          int                              `json:"status"`
-	Title           string                           `json:"title"`
-	Type            url.URL                          `json:"type"`
+	Code     UploadRuntimeSessionNotFoundCode `json:"code"`
+	Detail   OptString                        `json:"detail"`
+	Instance OptString                        `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps UploadRuntimeSessionNotFoundAdditional
 }
 
@@ -58157,13 +58263,15 @@ func (s UploadRuntimeSessionReq) Read(p []byte) (n int, err error) {
 }
 
 type UploadRuntimeSessionServiceUnavailable struct {
-	Code            UploadRuntimeSessionServiceUnavailableCode `json:"code"`
-	Detail          OptString                                  `json:"detail"`
-	Instance        OptString                                  `json:"instance"`
-	RetryAfter      OptInt                                     `json:"retryAfter"`
-	Status          int                                        `json:"status"`
-	Title           string                                     `json:"title"`
-	Type            url.URL                                    `json:"type"`
+	Code     UploadRuntimeSessionServiceUnavailableCode `json:"code"`
+	Detail   OptString                                  `json:"detail"`
+	Instance OptString                                  `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps UploadRuntimeSessionServiceUnavailableAdditional
 }
 
@@ -58539,13 +58647,15 @@ func (s *UploadRuntimeSessionSessionKind) UnmarshalText(data []byte) error {
 }
 
 type UploadRuntimeSessionUnauthorized struct {
-	Code            UploadRuntimeSessionUnauthorizedCode `json:"code"`
-	Detail          OptString                            `json:"detail"`
-	Instance        OptString                            `json:"instance"`
-	RetryAfter      OptInt                               `json:"retryAfter"`
-	Status          int                                  `json:"status"`
-	Title           string                               `json:"title"`
-	Type            url.URL                              `json:"type"`
+	Code     UploadRuntimeSessionUnauthorizedCode `json:"code"`
+	Detail   OptString                            `json:"detail"`
+	Instance OptString                            `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps UploadRuntimeSessionUnauthorizedAdditional
 }
 
@@ -58874,14 +58984,16 @@ func (s *UploadRuntimeSessionUnauthorizedCode) UnmarshalText(data []byte) error 
 
 // Merged schema.
 type UploadTaskArtifactBadRequest struct {
-	Code            UploadTaskArtifactBadRequestCode `json:"code"`
-	Detail          OptString                        `json:"detail"`
-	Instance        OptString                        `json:"instance"`
-	RetryAfter      OptInt                           `json:"retryAfter"`
-	Status          int                              `json:"status"`
-	Title           string                           `json:"title"`
-	Type            url.URL                          `json:"type"`
-	Errors          []ValidationError                `json:"errors"`
+	Code     UploadTaskArtifactBadRequestCode `json:"code"`
+	Detail   OptString                        `json:"detail"`
+	Instance OptString                        `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt            `json:"retryAfter"`
+	Status          int               `json:"status"`
+	Title           string            `json:"title"`
+	Type            url.URL           `json:"type"`
+	Errors          []ValidationError `json:"errors"`
 	AdditionalProps UploadTaskArtifactBadRequestAdditional
 }
 
@@ -59219,13 +59331,15 @@ func (s *UploadTaskArtifactBadRequestCode) UnmarshalText(data []byte) error {
 }
 
 type UploadTaskArtifactForbidden struct {
-	Code            UploadTaskArtifactForbiddenCode `json:"code"`
-	Detail          OptString                       `json:"detail"`
-	Instance        OptString                       `json:"instance"`
-	RetryAfter      OptInt                          `json:"retryAfter"`
-	Status          int                             `json:"status"`
-	Title           string                          `json:"title"`
-	Type            url.URL                         `json:"type"`
+	Code     UploadTaskArtifactForbiddenCode `json:"code"`
+	Detail   OptString                       `json:"detail"`
+	Instance OptString                       `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps UploadTaskArtifactForbiddenAdditional
 }
 
@@ -59553,13 +59667,15 @@ func (s *UploadTaskArtifactForbiddenCode) UnmarshalText(data []byte) error {
 }
 
 type UploadTaskArtifactNotFound struct {
-	Code            UploadTaskArtifactNotFoundCode `json:"code"`
-	Detail          OptString                      `json:"detail"`
-	Instance        OptString                      `json:"instance"`
-	RetryAfter      OptInt                         `json:"retryAfter"`
-	Status          int                            `json:"status"`
-	Title           string                         `json:"title"`
-	Type            url.URL                        `json:"type"`
+	Code     UploadTaskArtifactNotFoundCode `json:"code"`
+	Detail   OptString                      `json:"detail"`
+	Instance OptString                      `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps UploadTaskArtifactNotFoundAdditional
 }
 
@@ -60050,13 +60166,15 @@ func (s UploadTaskArtifactReq) Read(p []byte) (n int, err error) {
 }
 
 type UploadTaskArtifactServiceUnavailable struct {
-	Code            UploadTaskArtifactServiceUnavailableCode `json:"code"`
-	Detail          OptString                                `json:"detail"`
-	Instance        OptString                                `json:"instance"`
-	RetryAfter      OptInt                                   `json:"retryAfter"`
-	Status          int                                      `json:"status"`
-	Title           string                                   `json:"title"`
-	Type            url.URL                                  `json:"type"`
+	Code     UploadTaskArtifactServiceUnavailableCode `json:"code"`
+	Detail   OptString                                `json:"detail"`
+	Instance OptString                                `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps UploadTaskArtifactServiceUnavailableAdditional
 }
 
@@ -60384,13 +60502,15 @@ func (s *UploadTaskArtifactServiceUnavailableCode) UnmarshalText(data []byte) er
 }
 
 type UploadTaskArtifactUnauthorized struct {
-	Code            UploadTaskArtifactUnauthorizedCode `json:"code"`
-	Detail          OptString                          `json:"detail"`
-	Instance        OptString                          `json:"instance"`
-	RetryAfter      OptInt                             `json:"retryAfter"`
-	Status          int                                `json:"status"`
-	Title           string                             `json:"title"`
-	Type            url.URL                            `json:"type"`
+	Code     UploadTaskArtifactUnauthorizedCode `json:"code"`
+	Detail   OptString                          `json:"detail"`
+	Instance OptString                          `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt  `json:"retryAfter"`
+	Status          int     `json:"status"`
+	Title           string  `json:"title"`
+	Type            url.URL `json:"type"`
 	AdditionalProps UploadTaskArtifactUnauthorizedAdditional
 }
 
@@ -60830,14 +60950,16 @@ func (s *ValidationError) SetMessage(val string) {
 // Merged schema.
 // Ref: #/components/schemas/ValidationProblemDetails
 type ValidationProblemDetails struct {
-	Code            ValidationProblemDetailsCode `json:"code"`
-	Detail          OptString                    `json:"detail"`
-	Instance        OptString                    `json:"instance"`
-	RetryAfter      OptInt                       `json:"retryAfter"`
-	Status          int                          `json:"status"`
-	Title           string                       `json:"title"`
-	Type            url.URL                      `json:"type"`
-	Errors          []ValidationError            `json:"errors"`
+	Code     ValidationProblemDetailsCode `json:"code"`
+	Detail   OptString                    `json:"detail"`
+	Instance OptString                    `json:"instance"`
+	// Non-negative delay in seconds before retrying, matching the Retry-After response header when
+	// present.
+	RetryAfter      OptInt            `json:"retryAfter"`
+	Status          int               `json:"status"`
+	Title           string            `json:"title"`
+	Type            url.URL           `json:"type"`
+	Errors          []ValidationError `json:"errors"`
 	AdditionalProps ValidationProblemDetailsAdditional
 }
 

--- a/libs/moltnet-api-client/oas_schemas_gen.go
+++ b/libs/moltnet-api-client/oas_schemas_gen.go
@@ -1166,6 +1166,7 @@ type BeginRuntimeSlotBadRequest struct {
 	Code            BeginRuntimeSlotBadRequestCode `json:"code"`
 	Detail          OptString                      `json:"detail"`
 	Instance        OptString                      `json:"instance"`
+	RetryAfter      OptInt                         `json:"retryAfter"`
 	Status          int                            `json:"status"`
 	Title           string                         `json:"title"`
 	Type            url.URL                        `json:"type"`
@@ -1186,6 +1187,11 @@ func (s *BeginRuntimeSlotBadRequest) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *BeginRuntimeSlotBadRequest) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *BeginRuntimeSlotBadRequest) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -1226,6 +1232,11 @@ func (s *BeginRuntimeSlotBadRequest) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *BeginRuntimeSlotBadRequest) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *BeginRuntimeSlotBadRequest) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -1501,6 +1512,7 @@ type BeginRuntimeSlotConflict struct {
 	Code            BeginRuntimeSlotConflictCode `json:"code"`
 	Detail          OptString                    `json:"detail"`
 	Instance        OptString                    `json:"instance"`
+	RetryAfter      OptInt                       `json:"retryAfter"`
 	Status          int                          `json:"status"`
 	Title           string                       `json:"title"`
 	Type            url.URL                      `json:"type"`
@@ -1521,6 +1533,11 @@ func (s *BeginRuntimeSlotConflict) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *BeginRuntimeSlotConflict) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *BeginRuntimeSlotConflict) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -1561,6 +1578,11 @@ func (s *BeginRuntimeSlotConflict) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *BeginRuntimeSlotConflict) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *BeginRuntimeSlotConflict) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -1835,6 +1857,7 @@ type BeginRuntimeSlotForbidden struct {
 	Code            BeginRuntimeSlotForbiddenCode `json:"code"`
 	Detail          OptString                     `json:"detail"`
 	Instance        OptString                     `json:"instance"`
+	RetryAfter      OptInt                        `json:"retryAfter"`
 	Status          int                           `json:"status"`
 	Title           string                        `json:"title"`
 	Type            url.URL                       `json:"type"`
@@ -1854,6 +1877,11 @@ func (s *BeginRuntimeSlotForbidden) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *BeginRuntimeSlotForbidden) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *BeginRuntimeSlotForbidden) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -1889,6 +1917,11 @@ func (s *BeginRuntimeSlotForbidden) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *BeginRuntimeSlotForbidden) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *BeginRuntimeSlotForbidden) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -2158,6 +2191,7 @@ type BeginRuntimeSlotNotFound struct {
 	Code            BeginRuntimeSlotNotFoundCode `json:"code"`
 	Detail          OptString                    `json:"detail"`
 	Instance        OptString                    `json:"instance"`
+	RetryAfter      OptInt                       `json:"retryAfter"`
 	Status          int                          `json:"status"`
 	Title           string                       `json:"title"`
 	Type            url.URL                      `json:"type"`
@@ -2177,6 +2211,11 @@ func (s *BeginRuntimeSlotNotFound) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *BeginRuntimeSlotNotFound) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *BeginRuntimeSlotNotFound) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -2212,6 +2251,11 @@ func (s *BeginRuntimeSlotNotFound) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *BeginRuntimeSlotNotFound) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *BeginRuntimeSlotNotFound) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -2927,6 +2971,7 @@ type BeginRuntimeSlotUnauthorized struct {
 	Code            BeginRuntimeSlotUnauthorizedCode `json:"code"`
 	Detail          OptString                        `json:"detail"`
 	Instance        OptString                        `json:"instance"`
+	RetryAfter      OptInt                           `json:"retryAfter"`
 	Status          int                              `json:"status"`
 	Title           string                           `json:"title"`
 	Type            url.URL                          `json:"type"`
@@ -2946,6 +2991,11 @@ func (s *BeginRuntimeSlotUnauthorized) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *BeginRuntimeSlotUnauthorized) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *BeginRuntimeSlotUnauthorized) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -2981,6 +3031,11 @@ func (s *BeginRuntimeSlotUnauthorized) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *BeginRuntimeSlotUnauthorized) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *BeginRuntimeSlotUnauthorized) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -4359,6 +4414,7 @@ type ConflictProblemDetails struct {
 	Code            ConflictProblemDetailsCode `json:"code"`
 	Detail          OptString                  `json:"detail"`
 	Instance        OptString                  `json:"instance"`
+	RetryAfter      OptInt                     `json:"retryAfter"`
 	Status          int                        `json:"status"`
 	Title           string                     `json:"title"`
 	Type            url.URL                    `json:"type"`
@@ -4379,6 +4435,11 @@ func (s *ConflictProblemDetails) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *ConflictProblemDetails) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *ConflictProblemDetails) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -4419,6 +4480,11 @@ func (s *ConflictProblemDetails) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *ConflictProblemDetails) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *ConflictProblemDetails) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -11915,6 +11981,7 @@ type DownloadRuntimeSessionBadRequest struct {
 	Code            DownloadRuntimeSessionBadRequestCode `json:"code"`
 	Detail          OptString                            `json:"detail"`
 	Instance        OptString                            `json:"instance"`
+	RetryAfter      OptInt                               `json:"retryAfter"`
 	Status          int                                  `json:"status"`
 	Title           string                               `json:"title"`
 	Type            url.URL                              `json:"type"`
@@ -11935,6 +12002,11 @@ func (s *DownloadRuntimeSessionBadRequest) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *DownloadRuntimeSessionBadRequest) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *DownloadRuntimeSessionBadRequest) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -11975,6 +12047,11 @@ func (s *DownloadRuntimeSessionBadRequest) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *DownloadRuntimeSessionBadRequest) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *DownloadRuntimeSessionBadRequest) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -12249,6 +12326,7 @@ type DownloadRuntimeSessionForbidden struct {
 	Code            DownloadRuntimeSessionForbiddenCode `json:"code"`
 	Detail          OptString                           `json:"detail"`
 	Instance        OptString                           `json:"instance"`
+	RetryAfter      OptInt                              `json:"retryAfter"`
 	Status          int                                 `json:"status"`
 	Title           string                              `json:"title"`
 	Type            url.URL                             `json:"type"`
@@ -12268,6 +12346,11 @@ func (s *DownloadRuntimeSessionForbidden) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *DownloadRuntimeSessionForbidden) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *DownloadRuntimeSessionForbidden) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -12303,6 +12386,11 @@ func (s *DownloadRuntimeSessionForbidden) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *DownloadRuntimeSessionForbidden) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *DownloadRuntimeSessionForbidden) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -12572,6 +12660,7 @@ type DownloadRuntimeSessionNotFound struct {
 	Code            DownloadRuntimeSessionNotFoundCode `json:"code"`
 	Detail          OptString                          `json:"detail"`
 	Instance        OptString                          `json:"instance"`
+	RetryAfter      OptInt                             `json:"retryAfter"`
 	Status          int                                `json:"status"`
 	Title           string                             `json:"title"`
 	Type            url.URL                            `json:"type"`
@@ -12591,6 +12680,11 @@ func (s *DownloadRuntimeSessionNotFound) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *DownloadRuntimeSessionNotFound) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *DownloadRuntimeSessionNotFound) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -12626,6 +12720,11 @@ func (s *DownloadRuntimeSessionNotFound) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *DownloadRuntimeSessionNotFound) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *DownloadRuntimeSessionNotFound) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -12912,6 +13011,7 @@ type DownloadRuntimeSessionServiceUnavailable struct {
 	Code            DownloadRuntimeSessionServiceUnavailableCode `json:"code"`
 	Detail          OptString                                    `json:"detail"`
 	Instance        OptString                                    `json:"instance"`
+	RetryAfter      OptInt                                       `json:"retryAfter"`
 	Status          int                                          `json:"status"`
 	Title           string                                       `json:"title"`
 	Type            url.URL                                      `json:"type"`
@@ -12931,6 +13031,11 @@ func (s *DownloadRuntimeSessionServiceUnavailable) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *DownloadRuntimeSessionServiceUnavailable) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *DownloadRuntimeSessionServiceUnavailable) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -12966,6 +13071,11 @@ func (s *DownloadRuntimeSessionServiceUnavailable) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *DownloadRuntimeSessionServiceUnavailable) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *DownloadRuntimeSessionServiceUnavailable) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -13235,6 +13345,7 @@ type DownloadRuntimeSessionUnauthorized struct {
 	Code            DownloadRuntimeSessionUnauthorizedCode `json:"code"`
 	Detail          OptString                              `json:"detail"`
 	Instance        OptString                              `json:"instance"`
+	RetryAfter      OptInt                                 `json:"retryAfter"`
 	Status          int                                    `json:"status"`
 	Title           string                                 `json:"title"`
 	Type            url.URL                                `json:"type"`
@@ -13254,6 +13365,11 @@ func (s *DownloadRuntimeSessionUnauthorized) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *DownloadRuntimeSessionUnauthorized) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *DownloadRuntimeSessionUnauthorized) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -13289,6 +13405,11 @@ func (s *DownloadRuntimeSessionUnauthorized) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *DownloadRuntimeSessionUnauthorized) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *DownloadRuntimeSessionUnauthorized) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -13559,6 +13680,7 @@ type DownloadTaskArtifactBadRequest struct {
 	Code            DownloadTaskArtifactBadRequestCode `json:"code"`
 	Detail          OptString                          `json:"detail"`
 	Instance        OptString                          `json:"instance"`
+	RetryAfter      OptInt                             `json:"retryAfter"`
 	Status          int                                `json:"status"`
 	Title           string                             `json:"title"`
 	Type            url.URL                            `json:"type"`
@@ -13579,6 +13701,11 @@ func (s *DownloadTaskArtifactBadRequest) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *DownloadTaskArtifactBadRequest) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *DownloadTaskArtifactBadRequest) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -13619,6 +13746,11 @@ func (s *DownloadTaskArtifactBadRequest) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *DownloadTaskArtifactBadRequest) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *DownloadTaskArtifactBadRequest) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -13894,6 +14026,7 @@ type DownloadTaskArtifactByCidBadRequest struct {
 	Code            DownloadTaskArtifactByCidBadRequestCode `json:"code"`
 	Detail          OptString                               `json:"detail"`
 	Instance        OptString                               `json:"instance"`
+	RetryAfter      OptInt                                  `json:"retryAfter"`
 	Status          int                                     `json:"status"`
 	Title           string                                  `json:"title"`
 	Type            url.URL                                 `json:"type"`
@@ -13914,6 +14047,11 @@ func (s *DownloadTaskArtifactByCidBadRequest) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *DownloadTaskArtifactByCidBadRequest) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *DownloadTaskArtifactByCidBadRequest) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -13954,6 +14092,11 @@ func (s *DownloadTaskArtifactByCidBadRequest) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *DownloadTaskArtifactByCidBadRequest) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *DownloadTaskArtifactByCidBadRequest) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -14228,6 +14371,7 @@ type DownloadTaskArtifactByCidForbidden struct {
 	Code            DownloadTaskArtifactByCidForbiddenCode `json:"code"`
 	Detail          OptString                              `json:"detail"`
 	Instance        OptString                              `json:"instance"`
+	RetryAfter      OptInt                                 `json:"retryAfter"`
 	Status          int                                    `json:"status"`
 	Title           string                                 `json:"title"`
 	Type            url.URL                                `json:"type"`
@@ -14247,6 +14391,11 @@ func (s *DownloadTaskArtifactByCidForbidden) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *DownloadTaskArtifactByCidForbidden) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *DownloadTaskArtifactByCidForbidden) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -14282,6 +14431,11 @@ func (s *DownloadTaskArtifactByCidForbidden) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *DownloadTaskArtifactByCidForbidden) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *DownloadTaskArtifactByCidForbidden) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -14551,6 +14705,7 @@ type DownloadTaskArtifactByCidNotFound struct {
 	Code            DownloadTaskArtifactByCidNotFoundCode `json:"code"`
 	Detail          OptString                             `json:"detail"`
 	Instance        OptString                             `json:"instance"`
+	RetryAfter      OptInt                                `json:"retryAfter"`
 	Status          int                                   `json:"status"`
 	Title           string                                `json:"title"`
 	Type            url.URL                               `json:"type"`
@@ -14570,6 +14725,11 @@ func (s *DownloadTaskArtifactByCidNotFound) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *DownloadTaskArtifactByCidNotFound) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *DownloadTaskArtifactByCidNotFound) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -14605,6 +14765,11 @@ func (s *DownloadTaskArtifactByCidNotFound) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *DownloadTaskArtifactByCidNotFound) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *DownloadTaskArtifactByCidNotFound) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -14950,6 +15115,7 @@ type DownloadTaskArtifactByCidServiceUnavailable struct {
 	Code            DownloadTaskArtifactByCidServiceUnavailableCode `json:"code"`
 	Detail          OptString                                       `json:"detail"`
 	Instance        OptString                                       `json:"instance"`
+	RetryAfter      OptInt                                          `json:"retryAfter"`
 	Status          int                                             `json:"status"`
 	Title           string                                          `json:"title"`
 	Type            url.URL                                         `json:"type"`
@@ -14969,6 +15135,11 @@ func (s *DownloadTaskArtifactByCidServiceUnavailable) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *DownloadTaskArtifactByCidServiceUnavailable) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *DownloadTaskArtifactByCidServiceUnavailable) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -15004,6 +15175,11 @@ func (s *DownloadTaskArtifactByCidServiceUnavailable) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *DownloadTaskArtifactByCidServiceUnavailable) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *DownloadTaskArtifactByCidServiceUnavailable) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -15273,6 +15449,7 @@ type DownloadTaskArtifactByCidUnauthorized struct {
 	Code            DownloadTaskArtifactByCidUnauthorizedCode `json:"code"`
 	Detail          OptString                                 `json:"detail"`
 	Instance        OptString                                 `json:"instance"`
+	RetryAfter      OptInt                                    `json:"retryAfter"`
 	Status          int                                       `json:"status"`
 	Title           string                                    `json:"title"`
 	Type            url.URL                                   `json:"type"`
@@ -15292,6 +15469,11 @@ func (s *DownloadTaskArtifactByCidUnauthorized) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *DownloadTaskArtifactByCidUnauthorized) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *DownloadTaskArtifactByCidUnauthorized) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -15327,6 +15509,11 @@ func (s *DownloadTaskArtifactByCidUnauthorized) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *DownloadTaskArtifactByCidUnauthorized) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *DownloadTaskArtifactByCidUnauthorized) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -15596,6 +15783,7 @@ type DownloadTaskArtifactForbidden struct {
 	Code            DownloadTaskArtifactForbiddenCode `json:"code"`
 	Detail          OptString                         `json:"detail"`
 	Instance        OptString                         `json:"instance"`
+	RetryAfter      OptInt                            `json:"retryAfter"`
 	Status          int                               `json:"status"`
 	Title           string                            `json:"title"`
 	Type            url.URL                           `json:"type"`
@@ -15615,6 +15803,11 @@ func (s *DownloadTaskArtifactForbidden) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *DownloadTaskArtifactForbidden) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *DownloadTaskArtifactForbidden) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -15650,6 +15843,11 @@ func (s *DownloadTaskArtifactForbidden) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *DownloadTaskArtifactForbidden) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *DownloadTaskArtifactForbidden) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -15919,6 +16117,7 @@ type DownloadTaskArtifactNotFound struct {
 	Code            DownloadTaskArtifactNotFoundCode `json:"code"`
 	Detail          OptString                        `json:"detail"`
 	Instance        OptString                        `json:"instance"`
+	RetryAfter      OptInt                           `json:"retryAfter"`
 	Status          int                              `json:"status"`
 	Title           string                           `json:"title"`
 	Type            url.URL                          `json:"type"`
@@ -15938,6 +16137,11 @@ func (s *DownloadTaskArtifactNotFound) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *DownloadTaskArtifactNotFound) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *DownloadTaskArtifactNotFound) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -15973,6 +16177,11 @@ func (s *DownloadTaskArtifactNotFound) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *DownloadTaskArtifactNotFound) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *DownloadTaskArtifactNotFound) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -16318,6 +16527,7 @@ type DownloadTaskArtifactServiceUnavailable struct {
 	Code            DownloadTaskArtifactServiceUnavailableCode `json:"code"`
 	Detail          OptString                                  `json:"detail"`
 	Instance        OptString                                  `json:"instance"`
+	RetryAfter      OptInt                                     `json:"retryAfter"`
 	Status          int                                        `json:"status"`
 	Title           string                                     `json:"title"`
 	Type            url.URL                                    `json:"type"`
@@ -16337,6 +16547,11 @@ func (s *DownloadTaskArtifactServiceUnavailable) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *DownloadTaskArtifactServiceUnavailable) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *DownloadTaskArtifactServiceUnavailable) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -16372,6 +16587,11 @@ func (s *DownloadTaskArtifactServiceUnavailable) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *DownloadTaskArtifactServiceUnavailable) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *DownloadTaskArtifactServiceUnavailable) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -16641,6 +16861,7 @@ type DownloadTaskArtifactUnauthorized struct {
 	Code            DownloadTaskArtifactUnauthorizedCode `json:"code"`
 	Detail          OptString                            `json:"detail"`
 	Instance        OptString                            `json:"instance"`
+	RetryAfter      OptInt                               `json:"retryAfter"`
 	Status          int                                  `json:"status"`
 	Title           string                               `json:"title"`
 	Type            url.URL                              `json:"type"`
@@ -16660,6 +16881,11 @@ func (s *DownloadTaskArtifactUnauthorized) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *DownloadTaskArtifactUnauthorized) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *DownloadTaskArtifactUnauthorized) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -16695,6 +16921,11 @@ func (s *DownloadTaskArtifactUnauthorized) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *DownloadTaskArtifactUnauthorized) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *DownloadTaskArtifactUnauthorized) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -17683,6 +17914,7 @@ type FindLatestRuntimeSlotForAttemptBadRequest struct {
 	Code            FindLatestRuntimeSlotForAttemptBadRequestCode `json:"code"`
 	Detail          OptString                                     `json:"detail"`
 	Instance        OptString                                     `json:"instance"`
+	RetryAfter      OptInt                                        `json:"retryAfter"`
 	Status          int                                           `json:"status"`
 	Title           string                                        `json:"title"`
 	Type            url.URL                                       `json:"type"`
@@ -17703,6 +17935,11 @@ func (s *FindLatestRuntimeSlotForAttemptBadRequest) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *FindLatestRuntimeSlotForAttemptBadRequest) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *FindLatestRuntimeSlotForAttemptBadRequest) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -17743,6 +17980,11 @@ func (s *FindLatestRuntimeSlotForAttemptBadRequest) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *FindLatestRuntimeSlotForAttemptBadRequest) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *FindLatestRuntimeSlotForAttemptBadRequest) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -18017,6 +18259,7 @@ type FindLatestRuntimeSlotForAttemptForbidden struct {
 	Code            FindLatestRuntimeSlotForAttemptForbiddenCode `json:"code"`
 	Detail          OptString                                    `json:"detail"`
 	Instance        OptString                                    `json:"instance"`
+	RetryAfter      OptInt                                       `json:"retryAfter"`
 	Status          int                                          `json:"status"`
 	Title           string                                       `json:"title"`
 	Type            url.URL                                      `json:"type"`
@@ -18036,6 +18279,11 @@ func (s *FindLatestRuntimeSlotForAttemptForbidden) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *FindLatestRuntimeSlotForAttemptForbidden) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *FindLatestRuntimeSlotForAttemptForbidden) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -18071,6 +18319,11 @@ func (s *FindLatestRuntimeSlotForAttemptForbidden) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *FindLatestRuntimeSlotForAttemptForbidden) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *FindLatestRuntimeSlotForAttemptForbidden) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -18340,6 +18593,7 @@ type FindLatestRuntimeSlotForAttemptNotFound struct {
 	Code            FindLatestRuntimeSlotForAttemptNotFoundCode `json:"code"`
 	Detail          OptString                                   `json:"detail"`
 	Instance        OptString                                   `json:"instance"`
+	RetryAfter      OptInt                                      `json:"retryAfter"`
 	Status          int                                         `json:"status"`
 	Title           string                                      `json:"title"`
 	Type            url.URL                                     `json:"type"`
@@ -18359,6 +18613,11 @@ func (s *FindLatestRuntimeSlotForAttemptNotFound) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *FindLatestRuntimeSlotForAttemptNotFound) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *FindLatestRuntimeSlotForAttemptNotFound) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -18394,6 +18653,11 @@ func (s *FindLatestRuntimeSlotForAttemptNotFound) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *FindLatestRuntimeSlotForAttemptNotFound) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *FindLatestRuntimeSlotForAttemptNotFound) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -19068,6 +19332,7 @@ type FindLatestRuntimeSlotForAttemptUnauthorized struct {
 	Code            FindLatestRuntimeSlotForAttemptUnauthorizedCode `json:"code"`
 	Detail          OptString                                       `json:"detail"`
 	Instance        OptString                                       `json:"instance"`
+	RetryAfter      OptInt                                          `json:"retryAfter"`
 	Status          int                                             `json:"status"`
 	Title           string                                          `json:"title"`
 	Type            url.URL                                         `json:"type"`
@@ -19087,6 +19352,11 @@ func (s *FindLatestRuntimeSlotForAttemptUnauthorized) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *FindLatestRuntimeSlotForAttemptUnauthorized) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *FindLatestRuntimeSlotForAttemptUnauthorized) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -19122,6 +19392,11 @@ func (s *FindLatestRuntimeSlotForAttemptUnauthorized) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *FindLatestRuntimeSlotForAttemptUnauthorized) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *FindLatestRuntimeSlotForAttemptUnauthorized) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -19392,6 +19667,7 @@ type FinishRuntimeSlotBadRequest struct {
 	Code            FinishRuntimeSlotBadRequestCode `json:"code"`
 	Detail          OptString                       `json:"detail"`
 	Instance        OptString                       `json:"instance"`
+	RetryAfter      OptInt                          `json:"retryAfter"`
 	Status          int                             `json:"status"`
 	Title           string                          `json:"title"`
 	Type            url.URL                         `json:"type"`
@@ -19412,6 +19688,11 @@ func (s *FinishRuntimeSlotBadRequest) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *FinishRuntimeSlotBadRequest) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *FinishRuntimeSlotBadRequest) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -19452,6 +19733,11 @@ func (s *FinishRuntimeSlotBadRequest) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *FinishRuntimeSlotBadRequest) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *FinishRuntimeSlotBadRequest) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -19727,6 +20013,7 @@ type FinishRuntimeSlotConflict struct {
 	Code            FinishRuntimeSlotConflictCode `json:"code"`
 	Detail          OptString                     `json:"detail"`
 	Instance        OptString                     `json:"instance"`
+	RetryAfter      OptInt                        `json:"retryAfter"`
 	Status          int                           `json:"status"`
 	Title           string                        `json:"title"`
 	Type            url.URL                       `json:"type"`
@@ -19747,6 +20034,11 @@ func (s *FinishRuntimeSlotConflict) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *FinishRuntimeSlotConflict) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *FinishRuntimeSlotConflict) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -19787,6 +20079,11 @@ func (s *FinishRuntimeSlotConflict) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *FinishRuntimeSlotConflict) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *FinishRuntimeSlotConflict) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -20061,6 +20358,7 @@ type FinishRuntimeSlotForbidden struct {
 	Code            FinishRuntimeSlotForbiddenCode `json:"code"`
 	Detail          OptString                      `json:"detail"`
 	Instance        OptString                      `json:"instance"`
+	RetryAfter      OptInt                         `json:"retryAfter"`
 	Status          int                            `json:"status"`
 	Title           string                         `json:"title"`
 	Type            url.URL                        `json:"type"`
@@ -20080,6 +20378,11 @@ func (s *FinishRuntimeSlotForbidden) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *FinishRuntimeSlotForbidden) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *FinishRuntimeSlotForbidden) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -20115,6 +20418,11 @@ func (s *FinishRuntimeSlotForbidden) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *FinishRuntimeSlotForbidden) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *FinishRuntimeSlotForbidden) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -20384,6 +20692,7 @@ type FinishRuntimeSlotNotFound struct {
 	Code            FinishRuntimeSlotNotFoundCode `json:"code"`
 	Detail          OptString                     `json:"detail"`
 	Instance        OptString                     `json:"instance"`
+	RetryAfter      OptInt                        `json:"retryAfter"`
 	Status          int                           `json:"status"`
 	Title           string                        `json:"title"`
 	Type            url.URL                       `json:"type"`
@@ -20403,6 +20712,11 @@ func (s *FinishRuntimeSlotNotFound) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *FinishRuntimeSlotNotFound) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *FinishRuntimeSlotNotFound) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -20438,6 +20752,11 @@ func (s *FinishRuntimeSlotNotFound) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *FinishRuntimeSlotNotFound) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *FinishRuntimeSlotNotFound) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -21039,6 +21358,7 @@ type FinishRuntimeSlotUnauthorized struct {
 	Code            FinishRuntimeSlotUnauthorizedCode `json:"code"`
 	Detail          OptString                         `json:"detail"`
 	Instance        OptString                         `json:"instance"`
+	RetryAfter      OptInt                            `json:"retryAfter"`
 	Status          int                               `json:"status"`
 	Title           string                            `json:"title"`
 	Type            url.URL                           `json:"type"`
@@ -21058,6 +21378,11 @@ func (s *FinishRuntimeSlotUnauthorized) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *FinishRuntimeSlotUnauthorized) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *FinishRuntimeSlotUnauthorized) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -21093,6 +21418,11 @@ func (s *FinishRuntimeSlotUnauthorized) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *FinishRuntimeSlotUnauthorized) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *FinishRuntimeSlotUnauthorized) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -22834,6 +23164,7 @@ type GetRuntimeSessionBadRequest struct {
 	Code            GetRuntimeSessionBadRequestCode `json:"code"`
 	Detail          OptString                       `json:"detail"`
 	Instance        OptString                       `json:"instance"`
+	RetryAfter      OptInt                          `json:"retryAfter"`
 	Status          int                             `json:"status"`
 	Title           string                          `json:"title"`
 	Type            url.URL                         `json:"type"`
@@ -22854,6 +23185,11 @@ func (s *GetRuntimeSessionBadRequest) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *GetRuntimeSessionBadRequest) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *GetRuntimeSessionBadRequest) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -22894,6 +23230,11 @@ func (s *GetRuntimeSessionBadRequest) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *GetRuntimeSessionBadRequest) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *GetRuntimeSessionBadRequest) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -23168,6 +23509,7 @@ type GetRuntimeSessionForbidden struct {
 	Code            GetRuntimeSessionForbiddenCode `json:"code"`
 	Detail          OptString                      `json:"detail"`
 	Instance        OptString                      `json:"instance"`
+	RetryAfter      OptInt                         `json:"retryAfter"`
 	Status          int                            `json:"status"`
 	Title           string                         `json:"title"`
 	Type            url.URL                        `json:"type"`
@@ -23187,6 +23529,11 @@ func (s *GetRuntimeSessionForbidden) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *GetRuntimeSessionForbidden) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *GetRuntimeSessionForbidden) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -23222,6 +23569,11 @@ func (s *GetRuntimeSessionForbidden) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *GetRuntimeSessionForbidden) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *GetRuntimeSessionForbidden) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -23491,6 +23843,7 @@ type GetRuntimeSessionNotFound struct {
 	Code            GetRuntimeSessionNotFoundCode `json:"code"`
 	Detail          OptString                     `json:"detail"`
 	Instance        OptString                     `json:"instance"`
+	RetryAfter      OptInt                        `json:"retryAfter"`
 	Status          int                           `json:"status"`
 	Title           string                        `json:"title"`
 	Type            url.URL                       `json:"type"`
@@ -23510,6 +23863,11 @@ func (s *GetRuntimeSessionNotFound) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *GetRuntimeSessionNotFound) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *GetRuntimeSessionNotFound) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -23545,6 +23903,11 @@ func (s *GetRuntimeSessionNotFound) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *GetRuntimeSessionNotFound) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *GetRuntimeSessionNotFound) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -24115,6 +24478,7 @@ type GetRuntimeSessionUnauthorized struct {
 	Code            GetRuntimeSessionUnauthorizedCode `json:"code"`
 	Detail          OptString                         `json:"detail"`
 	Instance        OptString                         `json:"instance"`
+	RetryAfter      OptInt                            `json:"retryAfter"`
 	Status          int                               `json:"status"`
 	Title           string                            `json:"title"`
 	Type            url.URL                           `json:"type"`
@@ -24134,6 +24498,11 @@ func (s *GetRuntimeSessionUnauthorized) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *GetRuntimeSessionUnauthorized) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *GetRuntimeSessionUnauthorized) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -24169,6 +24538,11 @@ func (s *GetRuntimeSessionUnauthorized) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *GetRuntimeSessionUnauthorized) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *GetRuntimeSessionUnauthorized) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -25214,6 +25588,7 @@ type InjectionConflictProblemDetails struct {
 	Code            InjectionConflictProblemDetailsCode          `json:"code"`
 	Detail          OptString                                    `json:"detail"`
 	Instance        OptString                                    `json:"instance"`
+	RetryAfter      OptInt                                       `json:"retryAfter"`
 	Status          int                                          `json:"status"`
 	Title           string                                       `json:"title"`
 	Type            url.URL                                      `json:"type"`
@@ -25235,6 +25610,11 @@ func (s *InjectionConflictProblemDetails) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *InjectionConflictProblemDetails) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *InjectionConflictProblemDetails) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -25280,6 +25660,11 @@ func (s *InjectionConflictProblemDetails) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *InjectionConflictProblemDetails) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *InjectionConflictProblemDetails) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -26806,6 +27191,7 @@ type ListRuntimeSlotsBadRequest struct {
 	Code            ListRuntimeSlotsBadRequestCode `json:"code"`
 	Detail          OptString                      `json:"detail"`
 	Instance        OptString                      `json:"instance"`
+	RetryAfter      OptInt                         `json:"retryAfter"`
 	Status          int                            `json:"status"`
 	Title           string                         `json:"title"`
 	Type            url.URL                        `json:"type"`
@@ -26826,6 +27212,11 @@ func (s *ListRuntimeSlotsBadRequest) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *ListRuntimeSlotsBadRequest) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *ListRuntimeSlotsBadRequest) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -26866,6 +27257,11 @@ func (s *ListRuntimeSlotsBadRequest) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *ListRuntimeSlotsBadRequest) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *ListRuntimeSlotsBadRequest) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -27140,6 +27536,7 @@ type ListRuntimeSlotsForbidden struct {
 	Code            ListRuntimeSlotsForbiddenCode `json:"code"`
 	Detail          OptString                     `json:"detail"`
 	Instance        OptString                     `json:"instance"`
+	RetryAfter      OptInt                        `json:"retryAfter"`
 	Status          int                           `json:"status"`
 	Title           string                        `json:"title"`
 	Type            url.URL                       `json:"type"`
@@ -27159,6 +27556,11 @@ func (s *ListRuntimeSlotsForbidden) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *ListRuntimeSlotsForbidden) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *ListRuntimeSlotsForbidden) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -27194,6 +27596,11 @@ func (s *ListRuntimeSlotsForbidden) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *ListRuntimeSlotsForbidden) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *ListRuntimeSlotsForbidden) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -27463,6 +27870,7 @@ type ListRuntimeSlotsNotFound struct {
 	Code            ListRuntimeSlotsNotFoundCode `json:"code"`
 	Detail          OptString                    `json:"detail"`
 	Instance        OptString                    `json:"instance"`
+	RetryAfter      OptInt                       `json:"retryAfter"`
 	Status          int                          `json:"status"`
 	Title           string                       `json:"title"`
 	Type            url.URL                      `json:"type"`
@@ -27482,6 +27890,11 @@ func (s *ListRuntimeSlotsNotFound) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *ListRuntimeSlotsNotFound) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *ListRuntimeSlotsNotFound) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -27517,6 +27930,11 @@ func (s *ListRuntimeSlotsNotFound) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *ListRuntimeSlotsNotFound) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *ListRuntimeSlotsNotFound) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -28246,6 +28664,7 @@ type ListRuntimeSlotsUnauthorized struct {
 	Code            ListRuntimeSlotsUnauthorizedCode `json:"code"`
 	Detail          OptString                        `json:"detail"`
 	Instance        OptString                        `json:"instance"`
+	RetryAfter      OptInt                           `json:"retryAfter"`
 	Status          int                              `json:"status"`
 	Title           string                           `json:"title"`
 	Type            url.URL                          `json:"type"`
@@ -28265,6 +28684,11 @@ func (s *ListRuntimeSlotsUnauthorized) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *ListRuntimeSlotsUnauthorized) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *ListRuntimeSlotsUnauthorized) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -28300,6 +28724,11 @@ func (s *ListRuntimeSlotsUnauthorized) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *ListRuntimeSlotsUnauthorized) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *ListRuntimeSlotsUnauthorized) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -28709,6 +29138,7 @@ type ListTaskArtifactsBadRequest struct {
 	Code            ListTaskArtifactsBadRequestCode `json:"code"`
 	Detail          OptString                       `json:"detail"`
 	Instance        OptString                       `json:"instance"`
+	RetryAfter      OptInt                          `json:"retryAfter"`
 	Status          int                             `json:"status"`
 	Title           string                          `json:"title"`
 	Type            url.URL                         `json:"type"`
@@ -28729,6 +29159,11 @@ func (s *ListTaskArtifactsBadRequest) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *ListTaskArtifactsBadRequest) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *ListTaskArtifactsBadRequest) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -28769,6 +29204,11 @@ func (s *ListTaskArtifactsBadRequest) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *ListTaskArtifactsBadRequest) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *ListTaskArtifactsBadRequest) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -29043,6 +29483,7 @@ type ListTaskArtifactsForbidden struct {
 	Code            ListTaskArtifactsForbiddenCode `json:"code"`
 	Detail          OptString                      `json:"detail"`
 	Instance        OptString                      `json:"instance"`
+	RetryAfter      OptInt                         `json:"retryAfter"`
 	Status          int                            `json:"status"`
 	Title           string                         `json:"title"`
 	Type            url.URL                        `json:"type"`
@@ -29062,6 +29503,11 @@ func (s *ListTaskArtifactsForbidden) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *ListTaskArtifactsForbidden) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *ListTaskArtifactsForbidden) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -29097,6 +29543,11 @@ func (s *ListTaskArtifactsForbidden) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *ListTaskArtifactsForbidden) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *ListTaskArtifactsForbidden) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -29366,6 +29817,7 @@ type ListTaskArtifactsNotFound struct {
 	Code            ListTaskArtifactsNotFoundCode `json:"code"`
 	Detail          OptString                     `json:"detail"`
 	Instance        OptString                     `json:"instance"`
+	RetryAfter      OptInt                        `json:"retryAfter"`
 	Status          int                           `json:"status"`
 	Title           string                        `json:"title"`
 	Type            url.URL                       `json:"type"`
@@ -29385,6 +29837,11 @@ func (s *ListTaskArtifactsNotFound) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *ListTaskArtifactsNotFound) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *ListTaskArtifactsNotFound) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -29420,6 +29877,11 @@ func (s *ListTaskArtifactsNotFound) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *ListTaskArtifactsNotFound) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *ListTaskArtifactsNotFound) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -29870,6 +30332,7 @@ type ListTaskArtifactsUnauthorized struct {
 	Code            ListTaskArtifactsUnauthorizedCode `json:"code"`
 	Detail          OptString                         `json:"detail"`
 	Instance        OptString                         `json:"instance"`
+	RetryAfter      OptInt                            `json:"retryAfter"`
 	Status          int                               `json:"status"`
 	Title           string                            `json:"title"`
 	Type            url.URL                           `json:"type"`
@@ -29889,6 +30352,11 @@ func (s *ListTaskArtifactsUnauthorized) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *ListTaskArtifactsUnauthorized) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *ListTaskArtifactsUnauthorized) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -29924,6 +30392,11 @@ func (s *ListTaskArtifactsUnauthorized) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *ListTaskArtifactsUnauthorized) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *ListTaskArtifactsUnauthorized) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -40588,6 +41061,7 @@ type ProblemDetails struct {
 	Code            ProblemDetailsCode `json:"code"`
 	Detail          OptString          `json:"detail"`
 	Instance        OptString          `json:"instance"`
+	RetryAfter      OptInt             `json:"retryAfter"`
 	Status          int                `json:"status"`
 	Title           string             `json:"title"`
 	Type            url.URL            `json:"type"`
@@ -40607,6 +41081,11 @@ func (s *ProblemDetails) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *ProblemDetails) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *ProblemDetails) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -40642,6 +41121,11 @@ func (s *ProblemDetails) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *ProblemDetails) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *ProblemDetails) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -49159,6 +49643,7 @@ type StageTaskArtifactBadRequest struct {
 	Code            StageTaskArtifactBadRequestCode `json:"code"`
 	Detail          OptString                       `json:"detail"`
 	Instance        OptString                       `json:"instance"`
+	RetryAfter      OptInt                          `json:"retryAfter"`
 	Status          int                             `json:"status"`
 	Title           string                          `json:"title"`
 	Type            url.URL                         `json:"type"`
@@ -49179,6 +49664,11 @@ func (s *StageTaskArtifactBadRequest) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *StageTaskArtifactBadRequest) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *StageTaskArtifactBadRequest) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -49219,6 +49709,11 @@ func (s *StageTaskArtifactBadRequest) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *StageTaskArtifactBadRequest) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *StageTaskArtifactBadRequest) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -49493,6 +49988,7 @@ type StageTaskArtifactForbidden struct {
 	Code            StageTaskArtifactForbiddenCode `json:"code"`
 	Detail          OptString                      `json:"detail"`
 	Instance        OptString                      `json:"instance"`
+	RetryAfter      OptInt                         `json:"retryAfter"`
 	Status          int                            `json:"status"`
 	Title           string                         `json:"title"`
 	Type            url.URL                        `json:"type"`
@@ -49512,6 +50008,11 @@ func (s *StageTaskArtifactForbidden) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *StageTaskArtifactForbidden) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *StageTaskArtifactForbidden) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -49547,6 +50048,11 @@ func (s *StageTaskArtifactForbidden) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *StageTaskArtifactForbidden) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *StageTaskArtifactForbidden) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -49816,6 +50322,7 @@ type StageTaskArtifactNotFound struct {
 	Code            StageTaskArtifactNotFoundCode `json:"code"`
 	Detail          OptString                     `json:"detail"`
 	Instance        OptString                     `json:"instance"`
+	RetryAfter      OptInt                        `json:"retryAfter"`
 	Status          int                           `json:"status"`
 	Title           string                        `json:"title"`
 	Type            url.URL                       `json:"type"`
@@ -49835,6 +50342,11 @@ func (s *StageTaskArtifactNotFound) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *StageTaskArtifactNotFound) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *StageTaskArtifactNotFound) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -49870,6 +50382,11 @@ func (s *StageTaskArtifactNotFound) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *StageTaskArtifactNotFound) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *StageTaskArtifactNotFound) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -50192,6 +50709,7 @@ type StageTaskArtifactServiceUnavailable struct {
 	Code            StageTaskArtifactServiceUnavailableCode `json:"code"`
 	Detail          OptString                               `json:"detail"`
 	Instance        OptString                               `json:"instance"`
+	RetryAfter      OptInt                                  `json:"retryAfter"`
 	Status          int                                     `json:"status"`
 	Title           string                                  `json:"title"`
 	Type            url.URL                                 `json:"type"`
@@ -50211,6 +50729,11 @@ func (s *StageTaskArtifactServiceUnavailable) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *StageTaskArtifactServiceUnavailable) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *StageTaskArtifactServiceUnavailable) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -50246,6 +50769,11 @@ func (s *StageTaskArtifactServiceUnavailable) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *StageTaskArtifactServiceUnavailable) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *StageTaskArtifactServiceUnavailable) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -50515,6 +51043,7 @@ type StageTaskArtifactUnauthorized struct {
 	Code            StageTaskArtifactUnauthorizedCode `json:"code"`
 	Detail          OptString                         `json:"detail"`
 	Instance        OptString                         `json:"instance"`
+	RetryAfter      OptInt                            `json:"retryAfter"`
 	Status          int                               `json:"status"`
 	Title           string                            `json:"title"`
 	Type            url.URL                           `json:"type"`
@@ -50534,6 +51063,11 @@ func (s *StageTaskArtifactUnauthorized) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *StageTaskArtifactUnauthorized) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *StageTaskArtifactUnauthorized) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -50569,6 +51103,11 @@ func (s *StageTaskArtifactUnauthorized) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *StageTaskArtifactUnauthorized) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *StageTaskArtifactUnauthorized) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -55966,6 +56505,7 @@ type UploadRuntimeSessionBadRequest struct {
 	Code            UploadRuntimeSessionBadRequestCode `json:"code"`
 	Detail          OptString                          `json:"detail"`
 	Instance        OptString                          `json:"instance"`
+	RetryAfter      OptInt                             `json:"retryAfter"`
 	Status          int                                `json:"status"`
 	Title           string                             `json:"title"`
 	Type            url.URL                            `json:"type"`
@@ -55986,6 +56526,11 @@ func (s *UploadRuntimeSessionBadRequest) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *UploadRuntimeSessionBadRequest) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *UploadRuntimeSessionBadRequest) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -56026,6 +56571,11 @@ func (s *UploadRuntimeSessionBadRequest) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *UploadRuntimeSessionBadRequest) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *UploadRuntimeSessionBadRequest) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -56300,6 +56850,7 @@ type UploadRuntimeSessionConflict struct {
 	Code            UploadRuntimeSessionConflictCode `json:"code"`
 	Detail          OptString                        `json:"detail"`
 	Instance        OptString                        `json:"instance"`
+	RetryAfter      OptInt                           `json:"retryAfter"`
 	Status          int                              `json:"status"`
 	Title           string                           `json:"title"`
 	Type            url.URL                          `json:"type"`
@@ -56319,6 +56870,11 @@ func (s *UploadRuntimeSessionConflict) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *UploadRuntimeSessionConflict) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *UploadRuntimeSessionConflict) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -56354,6 +56910,11 @@ func (s *UploadRuntimeSessionConflict) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *UploadRuntimeSessionConflict) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *UploadRuntimeSessionConflict) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -56623,6 +57184,7 @@ type UploadRuntimeSessionForbidden struct {
 	Code            UploadRuntimeSessionForbiddenCode `json:"code"`
 	Detail          OptString                         `json:"detail"`
 	Instance        OptString                         `json:"instance"`
+	RetryAfter      OptInt                            `json:"retryAfter"`
 	Status          int                               `json:"status"`
 	Title           string                            `json:"title"`
 	Type            url.URL                           `json:"type"`
@@ -56642,6 +57204,11 @@ func (s *UploadRuntimeSessionForbidden) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *UploadRuntimeSessionForbidden) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *UploadRuntimeSessionForbidden) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -56677,6 +57244,11 @@ func (s *UploadRuntimeSessionForbidden) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *UploadRuntimeSessionForbidden) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *UploadRuntimeSessionForbidden) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -56946,6 +57518,7 @@ type UploadRuntimeSessionNotFound struct {
 	Code            UploadRuntimeSessionNotFoundCode `json:"code"`
 	Detail          OptString                        `json:"detail"`
 	Instance        OptString                        `json:"instance"`
+	RetryAfter      OptInt                           `json:"retryAfter"`
 	Status          int                              `json:"status"`
 	Title           string                           `json:"title"`
 	Type            url.URL                          `json:"type"`
@@ -56965,6 +57538,11 @@ func (s *UploadRuntimeSessionNotFound) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *UploadRuntimeSessionNotFound) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *UploadRuntimeSessionNotFound) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -57000,6 +57578,11 @@ func (s *UploadRuntimeSessionNotFound) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *UploadRuntimeSessionNotFound) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *UploadRuntimeSessionNotFound) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -57577,6 +58160,7 @@ type UploadRuntimeSessionServiceUnavailable struct {
 	Code            UploadRuntimeSessionServiceUnavailableCode `json:"code"`
 	Detail          OptString                                  `json:"detail"`
 	Instance        OptString                                  `json:"instance"`
+	RetryAfter      OptInt                                     `json:"retryAfter"`
 	Status          int                                        `json:"status"`
 	Title           string                                     `json:"title"`
 	Type            url.URL                                    `json:"type"`
@@ -57596,6 +58180,11 @@ func (s *UploadRuntimeSessionServiceUnavailable) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *UploadRuntimeSessionServiceUnavailable) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *UploadRuntimeSessionServiceUnavailable) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -57631,6 +58220,11 @@ func (s *UploadRuntimeSessionServiceUnavailable) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *UploadRuntimeSessionServiceUnavailable) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *UploadRuntimeSessionServiceUnavailable) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -57948,6 +58542,7 @@ type UploadRuntimeSessionUnauthorized struct {
 	Code            UploadRuntimeSessionUnauthorizedCode `json:"code"`
 	Detail          OptString                            `json:"detail"`
 	Instance        OptString                            `json:"instance"`
+	RetryAfter      OptInt                               `json:"retryAfter"`
 	Status          int                                  `json:"status"`
 	Title           string                               `json:"title"`
 	Type            url.URL                              `json:"type"`
@@ -57967,6 +58562,11 @@ func (s *UploadRuntimeSessionUnauthorized) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *UploadRuntimeSessionUnauthorized) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *UploadRuntimeSessionUnauthorized) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -58002,6 +58602,11 @@ func (s *UploadRuntimeSessionUnauthorized) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *UploadRuntimeSessionUnauthorized) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *UploadRuntimeSessionUnauthorized) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -58272,6 +58877,7 @@ type UploadTaskArtifactBadRequest struct {
 	Code            UploadTaskArtifactBadRequestCode `json:"code"`
 	Detail          OptString                        `json:"detail"`
 	Instance        OptString                        `json:"instance"`
+	RetryAfter      OptInt                           `json:"retryAfter"`
 	Status          int                              `json:"status"`
 	Title           string                           `json:"title"`
 	Type            url.URL                          `json:"type"`
@@ -58292,6 +58898,11 @@ func (s *UploadTaskArtifactBadRequest) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *UploadTaskArtifactBadRequest) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *UploadTaskArtifactBadRequest) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -58332,6 +58943,11 @@ func (s *UploadTaskArtifactBadRequest) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *UploadTaskArtifactBadRequest) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *UploadTaskArtifactBadRequest) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -58606,6 +59222,7 @@ type UploadTaskArtifactForbidden struct {
 	Code            UploadTaskArtifactForbiddenCode `json:"code"`
 	Detail          OptString                       `json:"detail"`
 	Instance        OptString                       `json:"instance"`
+	RetryAfter      OptInt                          `json:"retryAfter"`
 	Status          int                             `json:"status"`
 	Title           string                          `json:"title"`
 	Type            url.URL                         `json:"type"`
@@ -58625,6 +59242,11 @@ func (s *UploadTaskArtifactForbidden) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *UploadTaskArtifactForbidden) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *UploadTaskArtifactForbidden) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -58660,6 +59282,11 @@ func (s *UploadTaskArtifactForbidden) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *UploadTaskArtifactForbidden) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *UploadTaskArtifactForbidden) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -58929,6 +59556,7 @@ type UploadTaskArtifactNotFound struct {
 	Code            UploadTaskArtifactNotFoundCode `json:"code"`
 	Detail          OptString                      `json:"detail"`
 	Instance        OptString                      `json:"instance"`
+	RetryAfter      OptInt                         `json:"retryAfter"`
 	Status          int                            `json:"status"`
 	Title           string                         `json:"title"`
 	Type            url.URL                        `json:"type"`
@@ -58948,6 +59576,11 @@ func (s *UploadTaskArtifactNotFound) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *UploadTaskArtifactNotFound) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *UploadTaskArtifactNotFound) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -58983,6 +59616,11 @@ func (s *UploadTaskArtifactNotFound) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *UploadTaskArtifactNotFound) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *UploadTaskArtifactNotFound) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -59415,6 +60053,7 @@ type UploadTaskArtifactServiceUnavailable struct {
 	Code            UploadTaskArtifactServiceUnavailableCode `json:"code"`
 	Detail          OptString                                `json:"detail"`
 	Instance        OptString                                `json:"instance"`
+	RetryAfter      OptInt                                   `json:"retryAfter"`
 	Status          int                                      `json:"status"`
 	Title           string                                   `json:"title"`
 	Type            url.URL                                  `json:"type"`
@@ -59434,6 +60073,11 @@ func (s *UploadTaskArtifactServiceUnavailable) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *UploadTaskArtifactServiceUnavailable) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *UploadTaskArtifactServiceUnavailable) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -59469,6 +60113,11 @@ func (s *UploadTaskArtifactServiceUnavailable) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *UploadTaskArtifactServiceUnavailable) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *UploadTaskArtifactServiceUnavailable) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -59738,6 +60387,7 @@ type UploadTaskArtifactUnauthorized struct {
 	Code            UploadTaskArtifactUnauthorizedCode `json:"code"`
 	Detail          OptString                          `json:"detail"`
 	Instance        OptString                          `json:"instance"`
+	RetryAfter      OptInt                             `json:"retryAfter"`
 	Status          int                                `json:"status"`
 	Title           string                             `json:"title"`
 	Type            url.URL                            `json:"type"`
@@ -59757,6 +60407,11 @@ func (s *UploadTaskArtifactUnauthorized) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *UploadTaskArtifactUnauthorized) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *UploadTaskArtifactUnauthorized) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -59792,6 +60447,11 @@ func (s *UploadTaskArtifactUnauthorized) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *UploadTaskArtifactUnauthorized) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *UploadTaskArtifactUnauthorized) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.
@@ -60173,6 +60833,7 @@ type ValidationProblemDetails struct {
 	Code            ValidationProblemDetailsCode `json:"code"`
 	Detail          OptString                    `json:"detail"`
 	Instance        OptString                    `json:"instance"`
+	RetryAfter      OptInt                       `json:"retryAfter"`
 	Status          int                          `json:"status"`
 	Title           string                       `json:"title"`
 	Type            url.URL                      `json:"type"`
@@ -60193,6 +60854,11 @@ func (s *ValidationProblemDetails) GetDetail() OptString {
 // GetInstance returns the value of Instance.
 func (s *ValidationProblemDetails) GetInstance() OptString {
 	return s.Instance
+}
+
+// GetRetryAfter returns the value of RetryAfter.
+func (s *ValidationProblemDetails) GetRetryAfter() OptInt {
+	return s.RetryAfter
 }
 
 // GetStatus returns the value of Status.
@@ -60233,6 +60899,11 @@ func (s *ValidationProblemDetails) SetDetail(val OptString) {
 // SetInstance sets the value of Instance.
 func (s *ValidationProblemDetails) SetInstance(val OptString) {
 	s.Instance = val
+}
+
+// SetRetryAfter sets the value of RetryAfter.
+func (s *ValidationProblemDetails) SetRetryAfter(val OptInt) {
+	s.RetryAfter = val
 }
 
 // SetStatus sets the value of Status.

--- a/libs/moltnet-api-client/oas_validators_gen.go
+++ b/libs/moltnet-api-client/oas_validators_gen.go
@@ -1079,6 +1079,34 @@ func (s *BeginRuntimeSlotBadRequest) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -1199,6 +1227,34 @@ func (s *BeginRuntimeSlotConflict) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -1308,6 +1364,34 @@ func (s *BeginRuntimeSlotForbidden) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -1413,6 +1497,34 @@ func (s *BeginRuntimeSlotNotFound) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "code",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
 			Error: err,
 		})
 	}
@@ -2160,6 +2272,34 @@ func (s *BeginRuntimeSlotUnauthorized) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "code",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
 			Error: err,
 		})
 	}
@@ -3391,6 +3531,34 @@ func (s *ConflictProblemDetails) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "code",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
 			Error: err,
 		})
 	}
@@ -9601,6 +9769,34 @@ func (s *DownloadRuntimeSessionBadRequest) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -9721,6 +9917,34 @@ func (s *DownloadRuntimeSessionForbidden) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -9826,6 +10050,34 @@ func (s *DownloadRuntimeSessionNotFound) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "code",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
 			Error: err,
 		})
 	}
@@ -9939,6 +10191,34 @@ func (s *DownloadRuntimeSessionServiceUnavailable) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -10048,6 +10328,34 @@ func (s *DownloadRuntimeSessionUnauthorized) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -10153,6 +10461,34 @@ func (s *DownloadTaskArtifactBadRequest) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "code",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
 			Error: err,
 		})
 	}
@@ -10277,6 +10613,34 @@ func (s *DownloadTaskArtifactByCidBadRequest) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -10397,6 +10761,34 @@ func (s *DownloadTaskArtifactByCidForbidden) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -10502,6 +10894,34 @@ func (s *DownloadTaskArtifactByCidNotFound) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "code",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
 			Error: err,
 		})
 	}
@@ -10615,6 +11035,34 @@ func (s *DownloadTaskArtifactByCidServiceUnavailable) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -10720,6 +11168,34 @@ func (s *DownloadTaskArtifactByCidUnauthorized) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "code",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
 			Error: err,
 		})
 	}
@@ -10833,6 +11309,34 @@ func (s *DownloadTaskArtifactForbidden) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -10938,6 +11442,34 @@ func (s *DownloadTaskArtifactNotFound) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "code",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
 			Error: err,
 		})
 	}
@@ -11051,6 +11583,34 @@ func (s *DownloadTaskArtifactServiceUnavailable) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -11156,6 +11716,34 @@ func (s *DownloadTaskArtifactUnauthorized) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "code",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
 			Error: err,
 		})
 	}
@@ -11754,6 +12342,34 @@ func (s *FindLatestRuntimeSlotForAttemptBadRequest) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -11874,6 +12490,34 @@ func (s *FindLatestRuntimeSlotForAttemptForbidden) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -11979,6 +12623,34 @@ func (s *FindLatestRuntimeSlotForAttemptNotFound) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "code",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
 			Error: err,
 		})
 	}
@@ -12596,6 +13268,34 @@ func (s *FindLatestRuntimeSlotForAttemptUnauthorized) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -12701,6 +13401,34 @@ func (s *FinishRuntimeSlotBadRequest) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "code",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
 			Error: err,
 		})
 	}
@@ -12825,6 +13553,34 @@ func (s *FinishRuntimeSlotConflict) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -12934,6 +13690,34 @@ func (s *FinishRuntimeSlotForbidden) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -13039,6 +13823,34 @@ func (s *FinishRuntimeSlotNotFound) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "code",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
 			Error: err,
 		})
 	}
@@ -13612,6 +14424,34 @@ func (s *FinishRuntimeSlotUnauthorized) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "code",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
 			Error: err,
 		})
 	}
@@ -14872,6 +15712,34 @@ func (s *GetRuntimeSessionBadRequest) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -14992,6 +15860,34 @@ func (s *GetRuntimeSessionForbidden) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -15097,6 +15993,34 @@ func (s *GetRuntimeSessionNotFound) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "code",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
 			Error: err,
 		})
 	}
@@ -15431,6 +16355,34 @@ func (s *GetRuntimeSessionUnauthorized) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "code",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
 			Error: err,
 		})
 	}
@@ -16004,6 +16956,34 @@ func (s *InjectionConflictProblemDetails) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "code",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
 			Error: err,
 		})
 	}
@@ -17322,6 +18302,34 @@ func (s *ListRuntimeSlotsBadRequest) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -17442,6 +18450,34 @@ func (s *ListRuntimeSlotsForbidden) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -17547,6 +18583,34 @@ func (s *ListRuntimeSlotsNotFound) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "code",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
 			Error: err,
 		})
 	}
@@ -18215,6 +19279,34 @@ func (s *ListRuntimeSlotsUnauthorized) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -18424,6 +19516,34 @@ func (s *ListTaskArtifactsBadRequest) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -18544,6 +19664,34 @@ func (s *ListTaskArtifactsForbidden) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -18649,6 +19797,34 @@ func (s *ListTaskArtifactsNotFound) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "code",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
 			Error: err,
 		})
 	}
@@ -19027,6 +20203,34 @@ func (s *ListTaskArtifactsUnauthorized) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "code",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
 			Error: err,
 		})
 	}
@@ -21512,6 +22716,34 @@ func (s *ProblemDetails) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "code",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
 			Error: err,
 		})
 	}
@@ -28156,6 +29388,34 @@ func (s *StageTaskArtifactBadRequest) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -28276,6 +29536,34 @@ func (s *StageTaskArtifactForbidden) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -28381,6 +29669,34 @@ func (s *StageTaskArtifactNotFound) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "code",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
 			Error: err,
 		})
 	}
@@ -28573,6 +29889,34 @@ func (s *StageTaskArtifactServiceUnavailable) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -28678,6 +30022,34 @@ func (s *StageTaskArtifactUnauthorized) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "code",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
 			Error: err,
 		})
 	}
@@ -34907,6 +36279,34 @@ func (s *UploadRuntimeSessionBadRequest) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -35027,6 +36427,34 @@ func (s *UploadRuntimeSessionConflict) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -35136,6 +36564,34 @@ func (s *UploadRuntimeSessionForbidden) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -35241,6 +36697,34 @@ func (s *UploadRuntimeSessionNotFound) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "code",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
 			Error: err,
 		})
 	}
@@ -35563,6 +37047,34 @@ func (s *UploadRuntimeSessionServiceUnavailable) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -35685,6 +37197,34 @@ func (s *UploadRuntimeSessionUnauthorized) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -35790,6 +37330,34 @@ func (s *UploadTaskArtifactBadRequest) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "code",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
 			Error: err,
 		})
 	}
@@ -35914,6 +37482,34 @@ func (s *UploadTaskArtifactForbidden) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -36019,6 +37615,34 @@ func (s *UploadTaskArtifactNotFound) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "code",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
 			Error: err,
 		})
 	}
@@ -36315,6 +37939,34 @@ func (s *UploadTaskArtifactServiceUnavailable) Validate() error {
 		})
 	}
 	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := (validate.Int{
 			MinSet:        true,
 			Min:           100,
@@ -36420,6 +38072,34 @@ func (s *UploadTaskArtifactUnauthorized) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "code",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
 			Error: err,
 		})
 	}
@@ -36607,6 +38287,34 @@ func (s *ValidationProblemDetails) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "code",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.RetryAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "retryAfter",
 			Error: err,
 		})
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1549,6 +1549,12 @@ importers:
         specifier: 'catalog:'
         version: 10.3.1
     devDependencies:
+      '@opentelemetry/api':
+        specifier: 'catalog:'
+        version: 1.9.0
+      '@opentelemetry/sdk-metrics':
+        specifier: 'catalog:'
+        version: 2.5.1(@opentelemetry/api@1.9.0)
       '@testcontainers/postgresql':
         specifier: 'catalog:'
         version: 11.12.0


### PR DESCRIPTION
Closes #1749

## What changed

- evict cached OAuth contexts after successful Hydra client-secret rotation
- evict cached Kratos identities from both password and profile after-settings hooks
- keep agent public-key projection conditional while accepting human/password settings payloads
- add positive-TTL integration coverage with real TokenValidator, SessionResolver, and RemoteAuthCache instances plus controlled Ory clients
- test bounded remote-auth status metrics and document the intentional HMAC construction for CodeQL
- type `ProblemDetails.retryAfter` and regenerate OpenAPI, TypeScript, and Go clients

## Why

The positive remote-auth cache introduced bounded staleness, but credential lifecycle mutations were not wired to the existing client/identity eviction APIs. That could leave the current REST replica using stale OAuth or Kratos authentication context until TTL expiry. The error schema also emitted `retryAfter` without exposing it in generated clients.

## Impact

Client-secret rotations and Kratos password/profile updates now invalidate the current replica immediately. Other replicas retain the documented bounded TTL behavior. The default E2E cache TTL remains `0`; positive-cache semantics are covered in-process without another Docker stack.

## Validation

- REST API: 645 tests
- Auth: 190 tests, including existing Testcontainers integration tests
- Models: 41 tests
- TypeScript API client: 12 tests
- Go API client tests
- REST production build
- Docker Compose configuration validation
- generated OpenAPI, TypeScript, and Go artifacts
- signed commit and signed LeGreffier diary entries

<!-- legreffier-correlation: eadfe84b-f803-434c-8cf1-9fe8281f5dcb -->
