### PR TITLE
fix(console): send aal1 sessions pending 2FA to an aal2 login flow

### DIFF
--- a/apps/console-e2e/src/auth-second-factor-loop.e2e.ts
+++ b/apps/console-e2e/src/auth-second-factor-loop.e2e.ts
@@ -1,0 +1,143 @@
+/**
+ * Regression: infinite redirect loop when a second factor is
+ * pending.
+ *
+ * Reported from a phone: signing in with the GitHub OIDC provider, abandoning
+ * the two-factor step, then navigating back to the console. The session cookie
+ * exists but sits at aal1, so:
+ *
+ *   1. `/sessions/whoami` answers 403 (session_aal2_required)
+ *   2. the console read that as "logged out" and sent the browser to a plain
+ *      login flow
+ *   3. Kratos evaluated the aal1 session against a requested aal1, concluded
+ *      the user was already logged in, and 302'd to `return_to`
+ *   4. back to step 1, forever
+ *
+ * Each bounce also pushed a history entry, so Back walked backwards *through*
+ * the loop. On mobile, with no way to clear cookies for a single domain, that
+ * left no escape.
+ *
+ * The provider is not the trigger — any aal1 session is — so this drives the
+ * same state with password + TOTP, which needs no external identity provider.
+ */
+
+import { expect, test } from '@playwright/test';
+
+import {
+  CONSOLE_URL,
+  createTestUser,
+  enrollTotp,
+  expectConsoleOverview,
+  generateTotpCode,
+  KRATOS_PUBLIC_URL,
+  loginViaBrowser,
+  logoutViaBrowser,
+  registerViaBrowser,
+  submitKratosForm,
+  waitForFreshTotpWindow,
+} from './helpers/index.js';
+
+/**
+ * How long we let the browser settle before deciding it is not looping.
+ *
+ * Every hop is local, so an unfixed console racks up dozens of console loads
+ * in this window; a fixed one loads it at most twice (the initial navigation
+ * plus one redirect away).
+ */
+const SETTLE_MS = 5_000;
+const MAX_CONSOLE_LOADS = 2;
+
+test.describe.serial('console auth with a pending second factor', () => {
+  const user = createTestUser({ prefix: 'console-2fa' });
+  // Kratos only exposes the TOTP secret during enrolment, so the first test
+  // hands it to the rest of the suite.
+  let totpSecret = '';
+
+  test('enrols an authenticator app', async ({ page }) => {
+    await registerViaBrowser(page, user);
+    await expectConsoleOverview(page);
+
+    totpSecret = await enrollTotp(page);
+    expect(totpSecret).not.toHaveLength(0);
+
+    // Completing TOTP setup upgrades the current session to aal2, so the
+    // console still works — the loop needs a *fresh* aal1 session.
+    await page.goto(`${CONSOLE_URL}/`);
+    await expectConsoleOverview(page);
+  });
+
+  test('does not loop when the user abandons the second-factor step', async ({
+    page,
+  }) => {
+    await logoutViaBrowser(page);
+
+    // First factor only. Kratos issues the session cookie here and then asks
+    // for the second factor — this is the state the reporter was in.
+    await loginViaBrowser(page, user);
+
+    const consoleLoads: string[] = [];
+    page.on('framenavigated', (frame) => {
+      if (frame === page.mainFrame() && frame.url().startsWith(CONSOLE_URL)) {
+        consoleLoads.push(frame.url());
+      }
+    });
+
+    // "I tried to go back on the previous page": walk straight into the
+    // console instead of finishing the 2FA form.
+    await page.goto(`${CONSOLE_URL}/tasks`);
+    await page.waitForTimeout(SETTLE_MS);
+
+    expect(
+      consoleLoads.length,
+      `console reloaded ${consoleLoads.length} times — redirect loop`,
+    ).toBeLessThanOrEqual(MAX_CONSOLE_LOADS);
+
+    // Landed on the second-factor form, not back on the console.
+    await expect(page.locator('input[name="totp_code"]')).toBeVisible();
+    expect(page.url()).not.toContain(CONSOLE_URL);
+  });
+
+  test('sends the second-factor challenge to an aal2 login flow', async ({
+    page,
+  }) => {
+    await logoutViaBrowser(page);
+    await loginViaBrowser(page, user);
+
+    const kratosLoginRequests: string[] = [];
+    page.on('request', (request) => {
+      if (
+        request.isNavigationRequest() &&
+        request.url().startsWith(`${KRATOS_PUBLIC_URL}/self-service/login`)
+      ) {
+        kratosLoginRequests.push(request.url());
+      }
+    });
+
+    await page.goto(`${CONSOLE_URL}/`);
+    await expect(page.locator('input[name="totp_code"]')).toBeVisible();
+
+    // Without aal=aal2 Kratos treats the existing aal1 session as sufficient
+    // and bounces back to return_to. This assertion is the loop's root cause.
+    expect(kratosLoginRequests.some((url) => url.includes('aal=aal2'))).toBe(
+      true,
+    );
+  });
+
+  test('completing the second factor lands back on the requested page', async ({
+    page,
+  }) => {
+    await logoutViaBrowser(page);
+    await loginViaBrowser(page, user);
+
+    await page.goto(`${CONSOLE_URL}/tasks`);
+    const totpInput = page.locator('input[name="totp_code"]');
+    await expect(totpInput).toBeVisible();
+
+    await waitForFreshTotpWindow();
+    await totpInput.fill(generateTotpCode(totpSecret));
+    await submitKratosForm(page);
+
+    // return_to must survive the aal2 hop, otherwise the deep link is lost.
+    await expect(page).toHaveURL(`${CONSOLE_URL}/tasks`);
+  });
+});

--- a/apps/console-e2e/src/helpers/index.ts
+++ b/apps/console-e2e/src/helpers/index.ts
@@ -4,3 +4,4 @@ export * from './env.js';
 export * from './kratos.js';
 export * from './mailslurper.js';
 export * from './test-user.js';
+export * from './totp.js';

--- a/apps/console-e2e/src/helpers/kratos.ts
+++ b/apps/console-e2e/src/helpers/kratos.ts
@@ -180,15 +180,35 @@ export async function enrollTotp(page: Page): Promise<string> {
   return secret;
 }
 
-/** Ends the browser session through the Kratos logout flow. */
+/**
+ * Ends the browser session through the Kratos logout flow.
+ *
+ * No-op when there is nothing to end. Playwright hands every test its own
+ * browser context — `test.describe.serial` orders tests, it does not share
+ * cookies between them — so a suite that logs out before logging in usually
+ * starts from an empty jar. Kratos answers that with 401 `session_inactive`
+ * and no `logout_url`, and the caller's postcondition ("signed out") already
+ * holds. Any other non-2xx is a real failure and is surfaced.
+ */
 export async function logoutViaBrowser(page: Page): Promise<void> {
   const response = await page.request.get(
     `${KRATOS_PUBLIC_URL}/self-service/logout/browser`,
     { headers: { accept: 'application/json' } },
   );
+  if (response.status() === 401) {
+    return;
+  }
+  if (!response.ok()) {
+    throw new Error(
+      `Could not start logout flow (${response.status()}): ${await response.text()}`,
+    );
+  }
   const { logout_url: logoutUrl } = (await response.json()) as {
-    logout_url: string;
+    logout_url?: string;
   };
+  if (!logoutUrl) {
+    throw new Error('Logout flow returned no logout_url');
+  }
   await page.goto(logoutUrl);
 }
 

--- a/apps/console-e2e/src/helpers/kratos.ts
+++ b/apps/console-e2e/src/helpers/kratos.ts
@@ -4,6 +4,7 @@ import type { Page } from '@playwright/test';
 import { CONSOLE_URL, KRATOS_PUBLIC_URL } from './env.js';
 import { waitForVerificationCode } from './mailslurper.js';
 import type { TestUser } from './test-user.js';
+import { generateTotpCode, waitForFreshTotpWindow } from './totp.js';
 
 export async function submitKratosForm(page: Page): Promise<void> {
   await page.locator('form button[type="submit"]').first().click();
@@ -92,6 +93,103 @@ export async function loginViaBrowser(
   const code = await waitForVerificationCode(user.email, { sinceIso });
   await page.locator('input[name="code"]').fill(code);
   await submitKratosForm(page);
+}
+
+interface KratosUiNode {
+  group: string;
+  attributes: {
+    name?: string;
+    value?: unknown;
+    id?: string;
+    text?: { text?: string; context?: { secret?: string } };
+  };
+}
+
+interface KratosFlow {
+  id: string;
+  ui: { nodes: KratosUiNode[]; messages?: { text: string }[] };
+}
+
+function findNodeValue(flow: KratosFlow, name: string): string | undefined {
+  const node = flow.ui.nodes.find((n) => n.attributes.name === name);
+  return typeof node?.attributes.value === 'string'
+    ? node.attributes.value
+    : undefined;
+}
+
+/**
+ * Enrols an authenticator app for the currently signed-in identity.
+ *
+ * Driven through the Kratos JSON API rather than the reference self-service UI:
+ * the secret only exists inside the flow payload, and scraping it out of the
+ * rendered QR code would couple this to that UI's markup.
+ *
+ * `page.request` shares the browser context's cookie jar, so the session and
+ * CSRF cookies established by the login flow apply here.
+ */
+export async function enrollTotp(page: Page): Promise<string> {
+  await page.goto(`${KRATOS_PUBLIC_URL}/self-service/settings/browser`);
+  const flowId = new URL(page.url()).searchParams.get('flow');
+  if (!flowId) {
+    throw new Error(`Settings flow did not start; landed on ${page.url()}`);
+  }
+
+  const flowResponse = await page.request.get(
+    `${KRATOS_PUBLIC_URL}/self-service/settings/flows?id=${flowId}`,
+    { headers: { accept: 'application/json' } },
+  );
+  if (!flowResponse.ok()) {
+    throw new Error(`Could not read settings flow: ${flowResponse.status()}`);
+  }
+  const flow = (await flowResponse.json()) as KratosFlow;
+
+  const secretNode = flow.ui.nodes.find(
+    (node) => node.attributes.id === 'totp_secret_key',
+  );
+  const secret =
+    secretNode?.attributes.text?.context?.secret ??
+    secretNode?.attributes.text?.text;
+  if (!secret) {
+    throw new Error(
+      'Settings flow exposed no TOTP secret — is the totp method enabled in kratos.yaml?',
+    );
+  }
+
+  const csrfToken = findNodeValue(flow, 'csrf_token');
+  await waitForFreshTotpWindow();
+
+  const submission = await page.request.post(
+    `${KRATOS_PUBLIC_URL}/self-service/settings?flow=${flowId}`,
+    {
+      headers: { accept: 'application/json' },
+      data: {
+        csrf_token: csrfToken,
+        method: 'totp',
+        totp_code: generateTotpCode(secret),
+      },
+    },
+  );
+  if (!submission.ok()) {
+    throw new Error(
+      `TOTP enrolment failed (${submission.status()}): ${await submission.text()}`,
+    );
+  }
+
+  // Returned rather than re-read later: Kratos only exposes the secret while
+  // the credential is being set up.
+  return secret;
+}
+
+/** Ends the browser session through the Kratos logout flow. */
+export async function logoutViaBrowser(page: Page): Promise<void> {
+  const response = await page.request.get(
+    `${KRATOS_PUBLIC_URL}/self-service/logout/browser`,
+    { headers: { accept: 'application/json' } },
+  );
+  const { logout_url: logoutUrl } = (await response.json()) as {
+    logout_url: string;
+  };
+  await page.goto(logoutUrl);
 }
 
 export async function getSessionCookie(page: Page): Promise<string> {

--- a/apps/console-e2e/src/helpers/totp.ts
+++ b/apps/console-e2e/src/helpers/totp.ts
@@ -1,0 +1,70 @@
+import { createHmac } from 'node:crypto';
+
+/**
+ * Minimal RFC 6238 TOTP generator.
+ *
+ * Kratos hands out a base32 secret when an identity enrols an authenticator
+ * app; producing valid codes for it is the only way an automated test can move
+ * a session from aal1 to aal2. Hand-rolled rather than pulling a dependency —
+ * the algorithm is thirty lines and this is the only consumer.
+ */
+
+const BASE32_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+const TIME_STEP_SECONDS = 30;
+const DIGITS = 6;
+
+function base32Decode(input: string): Buffer {
+  let bits = 0;
+  let value = 0;
+  const bytes: number[] = [];
+
+  for (const char of input.replace(/=+$/, '').toUpperCase()) {
+    const index = BASE32_ALPHABET.indexOf(char);
+    if (index === -1) continue;
+    value = (value << 5) | index;
+    bits += 5;
+    if (bits >= 8) {
+      bytes.push((value >>> (bits - 8)) & 0xff);
+      bits -= 8;
+    }
+  }
+
+  return Buffer.from(bytes);
+}
+
+/** Generates the TOTP code valid at `atMs` for a base32 secret. */
+export function generateTotpCode(secret: string, atMs = Date.now()): string {
+  const counter = Math.floor(atMs / 1000 / TIME_STEP_SECONDS);
+  const counterBytes = Buffer.alloc(8);
+  counterBytes.writeUInt32BE(Math.floor(counter / 2 ** 32), 0);
+  counterBytes.writeUInt32BE(counter >>> 0, 4);
+
+  const digest = createHmac('sha1', base32Decode(secret))
+    .update(counterBytes)
+    .digest();
+  const offset = digest[digest.length - 1] & 0x0f;
+  const truncated =
+    ((digest[offset] & 0x7f) << 24) |
+    (digest[offset + 1] << 16) |
+    (digest[offset + 2] << 8) |
+    digest[offset + 3];
+
+  return String(truncated % 10 ** DIGITS).padStart(DIGITS, '0');
+}
+
+/**
+ * Waits out the current TOTP window when it is nearly over.
+ *
+ * Kratos rejects a code that expires between generation and validation, which
+ * is a real risk when the code is minted right on a step boundary.
+ */
+export async function waitForFreshTotpWindow(
+  minRemainingSeconds = 3,
+): Promise<void> {
+  const elapsed = (Date.now() / 1000) % TIME_STEP_SECONDS;
+  const remaining = TIME_STEP_SECONDS - elapsed;
+  if (remaining >= minRemainingSeconds) return;
+  await new Promise((resolve) => {
+    setTimeout(resolve, (remaining + 0.25) * 1000);
+  });
+}

--- a/apps/console/__tests__/auth-guard.test.tsx
+++ b/apps/console/__tests__/auth-guard.test.tsx
@@ -1,5 +1,5 @@
 import { ResponseError } from '@ory/client-fetch';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MoltThemeProvider } from '@themoltnet/design-system';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -8,12 +8,13 @@ import { AuthGuard } from '../src/auth/AuthGuard.js';
 import { AuthProvider } from '../src/auth/AuthProvider.js';
 
 const mockToSession = vi.fn();
-const mockAssign = vi.fn();
+const mockReplace = vi.fn();
+const mockCreateBrowserLogoutFlow = vi.fn();
 
 vi.mock('../src/kratos.js', () => ({
   getKratosClient: () => ({
     toSession: mockToSession,
-    createBrowserLogoutFlow: vi.fn(),
+    createBrowserLogoutFlow: mockCreateBrowserLogoutFlow,
   }),
 }));
 
@@ -27,11 +28,28 @@ vi.mock('../src/config.js', () => ({
 }));
 
 /** Builds the error @ory/client-fetch throws for a non-2xx response. */
-function responseError(status: number): ResponseError {
-  return new ResponseError(
-    new Response(null, { status }),
-    'Response returned an error code',
-  );
+function responseError(status: number, body?: unknown): ResponseError {
+  const response =
+    body === undefined
+      ? new Response(null, { status })
+      : new Response(JSON.stringify(body), {
+          status,
+          headers: { 'content-type': 'application/json' },
+        });
+  return new ResponseError(response, 'Response returned an error code');
+}
+
+/**
+ * The 403 Kratos returns from /sessions/whoami when the cookie is valid but the
+ * session sits below the required Authenticator Assurance Level.
+ */
+function aal2RequiredError(
+  redirectBrowserTo = 'https://auth.example.com/self-service/login/browser?aal=aal2',
+): ResponseError {
+  return responseError(403, {
+    error: { id: 'session_aal2_required', code: 403 },
+    redirect_browser_to: redirectBrowserTo,
+  });
 }
 
 /** Points window.location at a console path before rendering. */
@@ -45,27 +63,33 @@ function setLocation({
   hash?: string;
 }) {
   Object.defineProperty(window, 'location', {
-    value: { assign: mockAssign, pathname, search, hash },
+    value: { replace: mockReplace, assign: vi.fn(), pathname, search, hash },
     writable: true,
   });
 }
 
-/** Renders the guard unauthenticated and returns the parsed return_to. */
-async function captureReturnTo(): Promise<string | null> {
-  mockToSession.mockRejectedValue(responseError(401));
-
-  render(
+function renderGuard() {
+  return render(
     <AuthGuard>
       <div data-testid="protected">Protected content</div>
     </AuthGuard>,
     { wrapper: Wrapper },
   );
+}
 
+/** Renders the guard unauthenticated and returns the URL it navigated to. */
+async function captureSignInUrl(): Promise<URL> {
+  renderGuard();
   await waitFor(() => {
-    expect(mockAssign).toHaveBeenCalled();
+    expect(mockReplace).toHaveBeenCalled();
   });
+  return new URL(mockReplace.mock.calls[0][0]);
+}
 
-  return new URL(mockAssign.mock.calls[0][0]).searchParams.get('return_to');
+/** Renders the guard unauthenticated and returns the parsed return_to. */
+async function captureReturnTo(): Promise<string | null> {
+  mockToSession.mockRejectedValue(responseError(401));
+  return (await captureSignInUrl()).searchParams.get('return_to');
 }
 
 function Wrapper({ children }: { children: ReactNode }) {
@@ -79,18 +103,14 @@ function Wrapper({ children }: { children: ReactNode }) {
 describe('AuthGuard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.sessionStorage.clear();
     setLocation({ pathname: '/' });
   });
 
   it('shows loading state while checking session', () => {
     mockToSession.mockReturnValue(new Promise(() => {}));
 
-    render(
-      <AuthGuard>
-        <div data-testid="protected">Protected content</div>
-      </AuthGuard>,
-      { wrapper: Wrapper },
-    );
+    renderGuard();
 
     expect(screen.queryByTestId('protected')).toBeNull();
     expect(screen.getByText('Loading...')).toBeDefined();
@@ -99,34 +119,59 @@ describe('AuthGuard', () => {
   it('does not redirect while the session check is in flight', async () => {
     mockToSession.mockReturnValue(new Promise(() => {}));
 
-    render(
-      <AuthGuard>
-        <div data-testid="protected">Protected content</div>
-      </AuthGuard>,
-      { wrapper: Wrapper },
-    );
+    renderGuard();
 
-    expect(mockAssign).not.toHaveBeenCalled();
+    expect(mockReplace).not.toHaveBeenCalled();
   });
 
   it('redirects to Ory login when not authenticated', async () => {
     mockToSession.mockRejectedValue(responseError(401));
 
-    render(
-      <AuthGuard>
-        <div data-testid="protected">Protected content</div>
-      </AuthGuard>,
-      { wrapper: Wrapper },
-    );
+    renderGuard();
 
     await waitFor(() => {
-      expect(mockAssign).toHaveBeenCalled();
+      expect(mockReplace).toHaveBeenCalled();
     });
 
-    expect(mockAssign.mock.calls[0][0]).toContain(
+    expect(mockReplace.mock.calls[0][0]).toContain(
       'https://auth.example.com/self-service/login/browser',
     );
     expect(screen.queryByTestId('protected')).toBeNull();
+  });
+
+  it('redirects only once per page load', async () => {
+    mockToSession.mockRejectedValue(responseError(401));
+
+    const { rerender } = renderGuard();
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(
+      <Wrapper>
+        <AuthGuard>
+          <div data-testid="protected">Protected content</div>
+        </AuthGuard>
+      </Wrapper>,
+    );
+
+    expect(mockReplace).toHaveBeenCalledTimes(1);
+  });
+
+  // Regression: assign() pushed a history entry for every bounce
+  // through Kratos, so Back walked backwards through the loop rather than out
+  // of it — on mobile, with no way to clear cookies per domain, that left the
+  // user with no escape at all.
+  it('replaces the history entry instead of pushing one', async () => {
+    mockToSession.mockRejectedValue(responseError(401));
+
+    renderGuard();
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalled();
+    });
+    expect(window.location.assign).not.toHaveBeenCalled();
   });
 
   // Regression: issue #1747. return_to was hardcoded to the console root, so
@@ -175,12 +220,7 @@ describe('AuthGuard', () => {
       },
     });
 
-    render(
-      <AuthGuard>
-        <div data-testid="protected">Protected content</div>
-      </AuthGuard>,
-      { wrapper: Wrapper },
-    );
+    renderGuard();
 
     await waitFor(() => {
       expect(screen.getByTestId('protected')).toBeDefined();
@@ -189,5 +229,157 @@ describe('AuthGuard', () => {
     expect(screen.getByTestId('protected').textContent).toBe(
       'Protected content',
     );
+  });
+
+  // Regression: a session parked at aal1 (OIDC login abandoned at
+  // the 2FA step) sent to a plain login flow makes Kratos answer "already
+  // logged in" and 302 back to return_to — console -> Kratos -> console,
+  // forever. The aal2 marker is what makes Kratos render the 2FA form instead.
+  describe('when the session needs a second factor', () => {
+    it('follows the redirect_browser_to Kratos supplies', async () => {
+      mockToSession.mockRejectedValue(aal2RequiredError());
+
+      const url = await captureSignInUrl();
+
+      expect(url.origin + url.pathname).toBe(
+        'https://auth.example.com/self-service/login/browser',
+      );
+      expect(url.searchParams.get('aal')).toBe('aal2');
+      expect(url.searchParams.get('return_to')).toBe(
+        'https://console.example.com/',
+      );
+    });
+
+    it('still requests aal2 when Kratos omits redirect_browser_to', async () => {
+      mockToSession.mockRejectedValue(
+        responseError(403, { error: { id: 'session_aal2_required' } }),
+      );
+
+      expect((await captureSignInUrl()).searchParams.get('aal')).toBe('aal2');
+    });
+
+    it('ignores a redirect_browser_to pointing at another origin', async () => {
+      mockToSession.mockRejectedValue(
+        aal2RequiredError(
+          'https://evil.example.net/self-service/login/browser',
+        ),
+      );
+
+      const url = await captureSignInUrl();
+
+      expect(url.origin).toBe('https://auth.example.com');
+      expect(url.searchParams.get('aal')).toBe('aal2');
+    });
+
+    it('does not add aal2 to a plain unauthenticated redirect', async () => {
+      mockToSession.mockRejectedValue(responseError(401));
+
+      expect((await captureSignInUrl()).searchParams.has('aal')).toBe(false);
+    });
+  });
+
+  // The counter lives in sessionStorage because every bounce is a full page
+  // load; these tests seed it to stand in for the earlier loads.
+  describe('redirect loop breaker', () => {
+    function seedAttempts(count: number, firstAt = Date.now()) {
+      window.sessionStorage.setItem(
+        'moltnet.console.auth-redirects',
+        JSON.stringify({ firstAt, count }),
+      );
+    }
+
+    it('stops redirecting after too many attempts in a short window', async () => {
+      mockToSession.mockRejectedValue(aal2RequiredError());
+      seedAttempts(3);
+
+      renderGuard();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('auth-loop-recovery')).toBeDefined();
+      });
+      expect(mockReplace).not.toHaveBeenCalled();
+    });
+
+    it('keeps redirecting while under the threshold', async () => {
+      mockToSession.mockRejectedValue(aal2RequiredError());
+      seedAttempts(2);
+
+      renderGuard();
+
+      await waitFor(() => {
+        expect(mockReplace).toHaveBeenCalled();
+      });
+      expect(screen.queryByTestId('auth-loop-recovery')).toBeNull();
+    });
+
+    it('ignores attempts older than the detection window', async () => {
+      mockToSession.mockRejectedValue(aal2RequiredError());
+      seedAttempts(9, Date.now() - 60_000);
+
+      renderGuard();
+
+      await waitFor(() => {
+        expect(mockReplace).toHaveBeenCalled();
+      });
+      expect(screen.queryByTestId('auth-loop-recovery')).toBeNull();
+    });
+
+    it('offers a sign-out escape hatch that clears the session server-side', async () => {
+      mockToSession.mockRejectedValue(aal2RequiredError());
+      mockCreateBrowserLogoutFlow.mockResolvedValue({
+        logout_url: 'https://auth.example.com/self-service/logout?token=abc',
+      });
+      seedAttempts(3);
+
+      renderGuard();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('auth-loop-recovery')).toBeDefined();
+      });
+      fireEvent.click(screen.getByText('Sign out and start over'));
+
+      await waitFor(() => {
+        expect(mockCreateBrowserLogoutFlow).toHaveBeenCalled();
+      });
+    });
+
+    it('lets the user retry verification manually', async () => {
+      mockToSession.mockRejectedValue(aal2RequiredError());
+      seedAttempts(3);
+
+      renderGuard();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('auth-loop-recovery')).toBeDefined();
+      });
+      fireEvent.click(screen.getByText('Continue verification'));
+
+      expect(mockReplace).toHaveBeenCalledTimes(1);
+      expect(
+        new URL(mockReplace.mock.calls[0][0]).searchParams.get('aal'),
+      ).toBe('aal2');
+      // The retry resets the counter, otherwise a single mis-typed TOTP code
+      // would drop the user straight back onto the recovery screen.
+      expect(
+        window.sessionStorage.getItem('moltnet.console.auth-redirects'),
+      ).toBeNull();
+    });
+
+    it('clears the counter once the user is authenticated', async () => {
+      seedAttempts(2);
+      mockToSession.mockResolvedValue({
+        active: true,
+        identity: { id: 'identity-123', traits: {} },
+      });
+
+      renderGuard();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('protected')).toBeDefined();
+      });
+      expect(
+        window.sessionStorage.getItem('moltnet.console.auth-redirects'),
+      ).toBeNull();
+    });
   });
 });

--- a/apps/console/__tests__/auth-guard.test.tsx
+++ b/apps/console/__tests__/auth-guard.test.tsx
@@ -52,6 +52,10 @@ function aal2RequiredError(
   });
 }
 
+/** Must match AuthGuard's sentinel parameter and storage key. */
+const HOP_PARAM = '_authhop';
+const HOP_STORAGE_KEY = 'moltnet.console.auth-hop';
+
 /** Points window.location at a console path before rendering. */
 function setLocation({
   pathname = '/',
@@ -86,10 +90,18 @@ async function captureSignInUrl(): Promise<URL> {
   return new URL(mockReplace.mock.calls[0][0]);
 }
 
-/** Renders the guard unauthenticated and returns the parsed return_to. */
+/**
+ * Renders the guard unauthenticated and returns return_to with the loop
+ * sentinel taken back out, so destination assertions stay about the
+ * destination. The sentinel itself is covered by its own describe block.
+ */
 async function captureReturnTo(): Promise<string | null> {
   mockToSession.mockRejectedValue(responseError(401));
-  return (await captureSignInUrl()).searchParams.get('return_to');
+  const raw = (await captureSignInUrl()).searchParams.get('return_to');
+  if (raw === null) return null;
+  const url = new URL(raw);
+  url.searchParams.delete(HOP_PARAM);
+  return url.toString();
 }
 
 function Wrapper({ children }: { children: ReactNode }) {
@@ -245,9 +257,9 @@ describe('AuthGuard', () => {
         'https://auth.example.com/self-service/login/browser',
       );
       expect(url.searchParams.get('aal')).toBe('aal2');
-      expect(url.searchParams.get('return_to')).toBe(
-        'https://console.example.com/',
-      );
+      const returnTo = new URL(url.searchParams.get('return_to') as string);
+      returnTo.searchParams.delete(HOP_PARAM);
+      expect(returnTo.toString()).toBe('https://console.example.com/');
     });
 
     it('still requests aal2 when Kratos omits redirect_browser_to', async () => {
@@ -278,19 +290,52 @@ describe('AuthGuard', () => {
     });
   });
 
-  // The counter lives in sessionStorage because every bounce is a full page
-  // load; these tests seed it to stand in for the earlier loads.
-  describe('redirect loop breaker', () => {
-    function seedAttempts(count: number, firstAt = Date.now()) {
-      window.sessionStorage.setItem(
-        'moltnet.console.auth-redirects',
-        JSON.stringify({ firstAt, count }),
-      );
+  /**
+   * The loop is broken by recognising our own round trip, not by counting.
+   * `return_to` carries a nonce; if Kratos hands the browser back with that
+   * nonce and the session is still unusable, the flow we picked cannot fix it,
+   * so re-entering it is exactly the loop.
+   *
+   * The nonce lives in sessionStorage because the round trip is a full page
+   * load. These tests seed it to stand in for the outbound leg.
+   */
+  describe('sign-in bounce detection', () => {
+    /** Simulates having been redirected out with `hop`, then sent back. */
+    function seedBounce(hop: string, returnedHop: string = hop) {
+      window.sessionStorage.setItem(HOP_STORAGE_KEY, hop);
+      setLocation({
+        pathname: '/tasks',
+        search: `?${HOP_PARAM}=${returnedHop}`,
+      });
     }
 
-    it('stops redirecting after too many attempts in a short window', async () => {
+    it('tags return_to with a sentinel and remembers it', async () => {
+      mockToSession.mockRejectedValue(responseError(401));
+
+      const returnTo = (await captureSignInUrl()).searchParams.get('return_to');
+
+      const hop = new URL(returnTo as string).searchParams.get(HOP_PARAM);
+      expect(hop).toBeTruthy();
+      expect(window.sessionStorage.getItem(HOP_STORAGE_KEY)).toBe(hop);
+    });
+
+    it('keeps the real query string alongside the sentinel', async () => {
+      setLocation({ pathname: '/diaries/abc', search: '?filter=open' });
+      mockToSession.mockRejectedValue(responseError(401));
+
+      const returnTo = new URL(
+        (await captureSignInUrl()).searchParams.get('return_to') as string,
+      );
+
+      expect(returnTo.searchParams.get('filter')).toBe('open');
+      expect(returnTo.searchParams.get(HOP_PARAM)).toBeTruthy();
+    });
+
+    // The bug: Kratos answered "already logged in" and 302'd straight back.
+    // One proven bounce is enough to know the flow cannot clear the challenge.
+    it('stops on the first bounce instead of redirecting again', async () => {
       mockToSession.mockRejectedValue(aal2RequiredError());
-      seedAttempts(3);
+      seedBounce('hop-1');
 
       renderGuard();
 
@@ -300,9 +345,9 @@ describe('AuthGuard', () => {
       expect(mockReplace).not.toHaveBeenCalled();
     });
 
-    it('keeps redirecting while under the threshold', async () => {
+    it('redirects normally when no sentinel comes back', async () => {
       mockToSession.mockRejectedValue(aal2RequiredError());
-      seedAttempts(2);
+      window.sessionStorage.setItem(HOP_STORAGE_KEY, 'hop-1');
 
       renderGuard();
 
@@ -312,9 +357,11 @@ describe('AuthGuard', () => {
       expect(screen.queryByTestId('auth-loop-recovery')).toBeNull();
     });
 
-    it('ignores attempts older than the detection window', async () => {
+    // A sentinel from a bookmarked or shared URL is not evidence that *this*
+    // tab just bounced, so it must not strand the visitor on the recovery page.
+    it('ignores a sentinel that does not match the one we issued', async () => {
       mockToSession.mockRejectedValue(aal2RequiredError());
-      seedAttempts(9, Date.now() - 60_000);
+      seedBounce('hop-1', 'pasted-from-somewhere-else');
 
       renderGuard();
 
@@ -322,6 +369,32 @@ describe('AuthGuard', () => {
         expect(mockReplace).toHaveBeenCalled();
       });
       expect(screen.queryByTestId('auth-loop-recovery')).toBeNull();
+    });
+
+    it('does not carry the sentinel into the next return_to', async () => {
+      mockToSession.mockRejectedValue(aal2RequiredError());
+      seedBounce('hop-1', 'stale');
+
+      const returnTo = new URL(
+        (await captureSignInUrl()).searchParams.get('return_to') as string,
+      );
+
+      expect(returnTo.pathname).toBe('/tasks');
+      expect(returnTo.searchParams.get(HOP_PARAM)).not.toBe('stale');
+    });
+
+    // It is machinery: a user who bookmarks or shares the URL should not
+    // carry it along, and it should not sit in history.
+    it('strips the sentinel from the address bar', async () => {
+      const replaceState = vi.spyOn(window.history, 'replaceState');
+      mockToSession.mockRejectedValue(aal2RequiredError());
+      seedBounce('hop-1');
+
+      renderGuard();
+
+      await waitFor(() => {
+        expect(replaceState).toHaveBeenCalledWith(null, '', '/tasks');
+      });
     });
 
     it('offers a sign-out escape hatch that clears the session server-side', async () => {
@@ -329,7 +402,7 @@ describe('AuthGuard', () => {
       mockCreateBrowserLogoutFlow.mockResolvedValue({
         logout_url: 'https://auth.example.com/self-service/logout?token=abc',
       });
-      seedAttempts(3);
+      seedBounce('hop-1');
 
       renderGuard();
 
@@ -343,9 +416,9 @@ describe('AuthGuard', () => {
       });
     });
 
-    it('lets the user retry verification manually', async () => {
+    it('lets the user retry verification with a fresh sentinel', async () => {
       mockToSession.mockRejectedValue(aal2RequiredError());
-      seedAttempts(3);
+      seedBounce('hop-1');
 
       renderGuard();
 
@@ -355,18 +428,20 @@ describe('AuthGuard', () => {
       fireEvent.click(screen.getByText('Continue verification'));
 
       expect(mockReplace).toHaveBeenCalledTimes(1);
-      expect(
-        new URL(mockReplace.mock.calls[0][0]).searchParams.get('aal'),
-      ).toBe('aal2');
-      // The retry resets the counter, otherwise a single mis-typed TOTP code
-      // would drop the user straight back onto the recovery screen.
-      expect(
-        window.sessionStorage.getItem('moltnet.console.auth-redirects'),
-      ).toBeNull();
+      const signInUrl = new URL(mockReplace.mock.calls[0][0]);
+      expect(signInUrl.searchParams.get('aal')).toBe('aal2');
+      // A new nonce, otherwise the retry would arrive carrying the sentinel
+      // that just tripped the guard and land straight back on this screen.
+      const hop = new URL(
+        signInUrl.searchParams.get('return_to') as string,
+      ).searchParams.get(HOP_PARAM);
+      expect(hop).toBeTruthy();
+      expect(hop).not.toBe('hop-1');
+      expect(window.sessionStorage.getItem(HOP_STORAGE_KEY)).toBe(hop);
     });
 
-    it('clears the counter once the user is authenticated', async () => {
-      seedAttempts(2);
+    it('clears the sentinel once the user is authenticated', async () => {
+      window.sessionStorage.setItem(HOP_STORAGE_KEY, 'hop-1');
       mockToSession.mockResolvedValue({
         active: true,
         identity: { id: 'identity-123', traits: {} },
@@ -377,9 +452,7 @@ describe('AuthGuard', () => {
       await waitFor(() => {
         expect(screen.getByTestId('protected')).toBeDefined();
       });
-      expect(
-        window.sessionStorage.getItem('moltnet.console.auth-redirects'),
-      ).toBeNull();
+      expect(window.sessionStorage.getItem(HOP_STORAGE_KEY)).toBeNull();
     });
   });
 });

--- a/apps/console/__tests__/auth-provider.test.tsx
+++ b/apps/console/__tests__/auth-provider.test.tsx
@@ -1,6 +1,7 @@
 import { FetchError, ResponseError } from '@ory/client-fetch';
 import {
   act,
+  cleanup,
   fireEvent,
   render,
   screen,
@@ -26,11 +27,15 @@ vi.mock('../src/kratos.js', () => ({
 }));
 
 /** Builds the error @ory/client-fetch throws for a non-2xx response. */
-function responseError(status: number): ResponseError {
-  return new ResponseError(
-    new Response(null, { status }),
-    'Response returned an error code',
-  );
+function responseError(status: number, body?: unknown): ResponseError {
+  const response =
+    body === undefined
+      ? new Response(null, { status })
+      : new Response(JSON.stringify(body), {
+          status,
+          headers: { 'content-type': 'application/json' },
+        });
+  return new ResponseError(response, 'Response returned an error code');
 }
 
 const ACTIVE_SESSION = {
@@ -42,7 +47,15 @@ const ACTIVE_SESSION = {
 };
 
 function TestConsumer() {
-  const { isAuthenticated, isLoading, username, email, error } = useAuth();
+  const {
+    isAuthenticated,
+    isLoading,
+    username,
+    email,
+    error,
+    challenge,
+    challengeRedirectTo,
+  } = useAuth();
   return (
     <div>
       <span data-testid="loading">{String(isLoading)}</span>
@@ -50,6 +63,10 @@ function TestConsumer() {
       <span data-testid="username">{username ?? 'null'}</span>
       <span data-testid="email">{email ?? 'null'}</span>
       <span data-testid="error">{error?.message ?? 'null'}</span>
+      <span data-testid="challenge">{challenge}</span>
+      <span data-testid="challenge-redirect">
+        {challengeRedirectTo ?? 'null'}
+      </span>
     </div>
   );
 }
@@ -141,6 +158,43 @@ describe('AuthProvider', () => {
     await waitFor(() => {
       expect(screen.getByTestId('authenticated').textContent).toBe('false');
     });
+  });
+
+  // Regression: 401 and 403 both mean "re-authenticate", but they
+  // need *different* login flows — collapsing them sent an aal1 session to an
+  // aal1 flow, which Kratos answers by redirecting straight back.
+  it('reports 401 and 403 as distinct challenges', async () => {
+    mockToSession.mockRejectedValue(responseError(401));
+    await renderSettled();
+    expect(screen.getByTestId('challenge').textContent).toBe('unauthenticated');
+    expect(screen.getByTestId('challenge-redirect').textContent).toBe('null');
+
+    cleanup();
+    vi.clearAllMocks();
+
+    mockToSession.mockRejectedValue(
+      responseError(403, {
+        error: { id: 'session_aal2_required' },
+        redirect_browser_to: 'https://auth.example.com/login?aal=aal2',
+      }),
+    );
+    await renderSettled();
+    expect(screen.getByTestId('challenge').textContent).toBe(
+      'second_factor_required',
+    );
+    expect(screen.getByTestId('challenge-redirect').textContent).toBe(
+      'https://auth.example.com/login?aal=aal2',
+    );
+  });
+
+  it('reports no challenge while a transient failure is being retried', async () => {
+    mockToSession.mockResolvedValueOnce(ACTIVE_SESSION);
+    await renderSettled();
+
+    mockToSession.mockRejectedValueOnce(responseError(500));
+    await revalidateOnFocus();
+
+    expect(screen.getByTestId('challenge').textContent).toBe('none');
   });
 
   // Regression: issue #1747. A transient failure used to clear the session,

--- a/apps/console/src/auth/AuthGuard.tsx
+++ b/apps/console/src/auth/AuthGuard.tsx
@@ -1,15 +1,93 @@
 /**
  * AuthGuard — Protects routes that require authentication.
  *
- * Shows a loading state while checking session, redirects to login
- * if not authenticated, and renders children if authenticated.
+ * Shows a loading state while checking session, redirects to the login flow
+ * that can actually clear the current challenge, and renders children if
+ * authenticated.
  */
 
-import { Stack, Text } from '@themoltnet/design-system';
-import type { ReactNode } from 'react';
+import { Button, Card, Stack, Text } from '@themoltnet/design-system';
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 
 import { getConfig } from '../config.js';
+import type { AuthChallenge } from './AuthProvider.js';
 import { useAuth } from './useAuth.js';
+
+/**
+ * How many sign-in redirects we allow inside {@link REDIRECT_WINDOW_MS} before
+ * concluding we are ping-ponging with Kratos and stopping to ask the user.
+ *
+ * A healthy flow costs one redirect and then leaves the user on the Kratos
+ * form for seconds-to-minutes, so three inside thirty seconds only happens
+ * when something is bouncing us straight back.
+ */
+const REDIRECT_LOOP_THRESHOLD = 3;
+const REDIRECT_WINDOW_MS = 30_000;
+const REDIRECT_STORAGE_KEY = 'moltnet.console.auth-redirects';
+
+interface RedirectAttempts {
+  firstAt: number;
+  count: number;
+}
+
+/**
+ * sessionStorage, not component or module state: every bounce through Kratos
+ * is a full page load, so anything held in memory resets and the loop stays
+ * invisible. It is also per-tab and dies with the tab, which is exactly the
+ * lifetime "am I currently stuck" wants.
+ *
+ * All access is defensive — storage access throws in some privacy modes, and a
+ * broken counter must never be the reason sign-in stops working.
+ */
+function readAttempts(): RedirectAttempts | null {
+  try {
+    const raw = window.sessionStorage.getItem(REDIRECT_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<RedirectAttempts>;
+    if (
+      typeof parsed.firstAt !== 'number' ||
+      typeof parsed.count !== 'number'
+    ) {
+      return null;
+    }
+    return { firstAt: parsed.firstAt, count: parsed.count };
+  } catch {
+    return null;
+  }
+}
+
+function writeAttempts(attempts: RedirectAttempts | null): void {
+  try {
+    if (attempts === null) {
+      window.sessionStorage.removeItem(REDIRECT_STORAGE_KEY);
+      return;
+    }
+    window.sessionStorage.setItem(
+      REDIRECT_STORAGE_KEY,
+      JSON.stringify(attempts),
+    );
+  } catch {
+    // Storage unavailable — fall back to always redirecting.
+  }
+}
+
+/** Records this page load's redirect and returns the running count. */
+function recordRedirectAttempt(now: number): number {
+  const previous = readAttempts();
+  const withinWindow =
+    previous !== null && now - previous.firstAt <= REDIRECT_WINDOW_MS;
+  const next: RedirectAttempts = withinWindow
+    ? { firstAt: previous.firstAt, count: previous.count + 1 }
+    : { firstAt: now, count: 1 };
+  writeAttempts(next);
+  return next.count;
+}
 
 /**
  * Builds the absolute URL to return to after login, preserving the path, query
@@ -27,8 +105,87 @@ function buildReturnTo(consoleUrl: string): string {
   return new URL(`${pathname}${search}${hash}`, consoleUrl).toString();
 }
 
+/**
+ * Only follow a Kratos-supplied `redirect_browser_to` when it points back at
+ * the Kratos we are configured to talk to. The value is server-controlled
+ * today, but a navigation target read out of a response body is worth pinning.
+ */
+function sameOriginAsKratos(candidate: string, kratosUrl: string): boolean {
+  try {
+    return new URL(candidate).origin === new URL(kratosUrl).origin;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Picks the login flow that can actually clear the current challenge.
+ *
+ * For `second_factor_required` the flow MUST carry `aal=aal2`. Without it
+ * Kratos evaluates the existing aal1 session against a requested aal1,
+ * concludes the user is already logged in, and 302s to `return_to` — putting
+ * the console right back where it started. That is the redirect loop.
+ */
+export function buildSignInUrl({
+  challenge,
+  challengeRedirectTo,
+  kratosUrl,
+  consoleUrl,
+}: {
+  challenge: AuthChallenge;
+  challengeRedirectTo: string | null;
+  kratosUrl: string;
+  consoleUrl: string;
+}): string {
+  const needsSecondFactor = challenge === 'second_factor_required';
+
+  const url =
+    needsSecondFactor &&
+    challengeRedirectTo !== null &&
+    sameOriginAsKratos(challengeRedirectTo, kratosUrl)
+      ? new URL(challengeRedirectTo)
+      : new URL('/self-service/login/browser', kratosUrl);
+
+  if (needsSecondFactor && !url.searchParams.has('aal')) {
+    url.searchParams.set('aal', 'aal2');
+  }
+  url.searchParams.set('return_to', buildReturnTo(consoleUrl));
+  return url.toString();
+}
+
 export function AuthGuard({ children }: { children: ReactNode }) {
-  const { isAuthenticated, isLoading } = useAuth();
+  const { isAuthenticated, isLoading, challenge, challengeRedirectTo, logout } =
+    useAuth();
+  const [loopDetected, setLoopDetected] = useState(false);
+  const hasRedirectedRef = useRef(false);
+
+  const goToSignIn = useCallback(() => {
+    const { kratosUrl, consoleUrl } = getConfig();
+    // replace(), not assign(): each bounce through Kratos would otherwise push
+    // a history entry, so a loop buries the page the user came from under
+    // dozens of entries and Back walks *through* the loop instead of out of it.
+    window.location.replace(
+      buildSignInUrl({ challenge, challengeRedirectTo, kratosUrl, consoleUrl }),
+    );
+  }, [challenge, challengeRedirectTo]);
+
+  useEffect(() => {
+    if (isAuthenticated) writeAttempts(null);
+  }, [isAuthenticated]);
+
+  useEffect(() => {
+    if (isLoading || isAuthenticated || loopDetected) return;
+    // Redirecting is a side effect: done during render it fires once per render
+    // pass, and navigation is async so there is always more than one pass.
+    if (hasRedirectedRef.current) return;
+    hasRedirectedRef.current = true;
+
+    if (recordRedirectAttempt(Date.now()) > REDIRECT_LOOP_THRESHOLD) {
+      setLoopDetected(true);
+      return;
+    }
+    goToSignIn();
+  }, [isLoading, isAuthenticated, loopDetected, goToSignIn]);
 
   if (isLoading) {
     return (
@@ -39,12 +196,74 @@ export function AuthGuard({ children }: { children: ReactNode }) {
   }
 
   if (!isAuthenticated) {
-    const { kratosUrl, consoleUrl } = getConfig();
-    const loginUrl = new URL('/self-service/login/browser', kratosUrl);
-    loginUrl.searchParams.set('return_to', buildReturnTo(consoleUrl));
-    window.location.assign(loginUrl.toString());
+    if (loopDetected) {
+      return (
+        <SignInRecovery
+          challenge={challenge}
+          onRetry={() => {
+            writeAttempts(null);
+            goToSignIn();
+          }}
+          onSignOut={() => {
+            writeAttempts(null);
+            void logout();
+          }}
+        />
+      );
+    }
     return null;
   }
 
   return <>{children}</>;
+}
+
+/**
+ * Shown once the loop is detected, instead of redirecting a fourth time.
+ *
+ * "Sign out" is the control that matters: it ends the half-authenticated
+ * session server-side. Mobile browsers offer no way to clear cookies for a
+ * single domain, so without it a looping user has no way out at all.
+ */
+function SignInRecovery({
+  challenge,
+  onRetry,
+  onSignOut,
+}: {
+  challenge: AuthChallenge;
+  onRetry: () => void;
+  onSignOut: () => void;
+}) {
+  const needsSecondFactor = challenge === 'second_factor_required';
+  return (
+    <Stack
+      align="center"
+      justify="center"
+      style={{ minHeight: '100vh', padding: '1.5rem' }}
+    >
+      <Card style={{ maxWidth: '32rem' }}>
+        <Stack gap={4}>
+          <Text as="h1" variant="h3" data-testid="auth-loop-recovery">
+            Sign-in could not complete
+          </Text>
+          <Text color="muted">
+            {needsSecondFactor
+              ? 'Your session is signed in but still needs two-factor verification. The console stopped retrying so you are not stuck in a redirect loop.'
+              : 'The console was sent back to sign in repeatedly without a session being established, so it stopped retrying.'}
+          </Text>
+          <Stack direction="row" gap={3} wrap>
+            <Button onClick={onRetry}>
+              {needsSecondFactor ? 'Continue verification' : 'Try again'}
+            </Button>
+            <Button variant="secondary" onClick={onSignOut}>
+              Sign out and start over
+            </Button>
+          </Stack>
+          <Text color="muted" variant="caption">
+            Signing out clears the session on the server — you do not need to
+            clear cookies in your browser.
+          </Text>
+        </Stack>
+      </Card>
+    </Stack>
+  );
 }

--- a/apps/console/src/auth/AuthGuard.tsx
+++ b/apps/console/src/auth/AuthGuard.tsx
@@ -20,89 +20,112 @@ import type { AuthChallenge } from './AuthProvider.js';
 import { useAuth } from './useAuth.js';
 
 /**
- * How many sign-in redirects we allow inside {@link REDIRECT_WINDOW_MS} before
- * concluding we are ping-ponging with Kratos and stopping to ask the user.
+ * Query parameter the console asks Kratos to echo back on `return_to`, and the
+ * sessionStorage key holding the value we are currently expecting.
  *
- * A healthy flow costs one redirect and then leaves the user on the Kratos
- * form for seconds-to-minutes, so three inside thirty seconds only happens
- * when something is bouncing us straight back.
+ * Together they answer one question directly: *did the login flow we just sent
+ * the browser into hand it straight back to us?* If it did, and we still have
+ * no usable session, that flow cannot fix the problem and re-entering it would
+ * ping-pong forever.
+ *
+ * This replaces counting redirects. A counter cannot tell a genuine loop from
+ * a user navigating back and forth, needs a threshold and a time window that
+ * are both guesses, and only gives up after several wasted bounces. The
+ * sentinel is causal, fires on the first proven bounce, and has nothing to
+ * tune.
+ *
+ * The token is a nonce rather than a fixed marker so that a `_authhop` pasted
+ * into a shared or bookmarked URL cannot strand an otherwise-fine visitor on
+ * the recovery screen.
  */
-const REDIRECT_LOOP_THRESHOLD = 3;
-const REDIRECT_WINDOW_MS = 30_000;
-const REDIRECT_STORAGE_KEY = 'moltnet.console.auth-redirects';
-
-interface RedirectAttempts {
-  firstAt: number;
-  count: number;
-}
+const HOP_PARAM = '_authhop';
+const HOP_STORAGE_KEY = 'moltnet.console.auth-hop';
 
 /**
- * sessionStorage, not component or module state: every bounce through Kratos
- * is a full page load, so anything held in memory resets and the loop stays
- * invisible. It is also per-tab and dies with the tab, which is exactly the
- * lifetime "am I currently stuck" wants.
+ * sessionStorage, not component or module state: the round trip through Kratos
+ * is a full page load, so anything held in memory is gone by the time the
+ * answer arrives. It is also per-tab and dies with the tab, which is exactly
+ * the lifetime "am I mid-sign-in right now" wants.
  *
- * All access is defensive — storage access throws in some privacy modes, and a
- * broken counter must never be the reason sign-in stops working.
+ * All access is defensive — storage throws in some privacy modes, and a broken
+ * sentinel must never be the reason sign-in stops working. Failing to read it
+ * degrades to "always redirect", i.e. the behaviour without this guard.
  */
-function readAttempts(): RedirectAttempts | null {
+function readHopToken(): string | null {
   try {
-    const raw = window.sessionStorage.getItem(REDIRECT_STORAGE_KEY);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as Partial<RedirectAttempts>;
-    if (
-      typeof parsed.firstAt !== 'number' ||
-      typeof parsed.count !== 'number'
-    ) {
-      return null;
-    }
-    return { firstAt: parsed.firstAt, count: parsed.count };
+    return window.sessionStorage.getItem(HOP_STORAGE_KEY);
   } catch {
     return null;
   }
 }
 
-function writeAttempts(attempts: RedirectAttempts | null): void {
+function writeHopToken(token: string | null): void {
   try {
-    if (attempts === null) {
-      window.sessionStorage.removeItem(REDIRECT_STORAGE_KEY);
+    if (token === null) {
+      window.sessionStorage.removeItem(HOP_STORAGE_KEY);
       return;
     }
-    window.sessionStorage.setItem(
-      REDIRECT_STORAGE_KEY,
-      JSON.stringify(attempts),
-    );
+    window.sessionStorage.setItem(HOP_STORAGE_KEY, token);
   } catch {
     // Storage unavailable — fall back to always redirecting.
   }
 }
 
-/** Records this page load's redirect and returns the running count. */
-function recordRedirectAttempt(now: number): number {
-  const previous = readAttempts();
-  const withinWindow =
-    previous !== null && now - previous.firstAt <= REDIRECT_WINDOW_MS;
-  const next: RedirectAttempts = withinWindow
-    ? { firstAt: previous.firstAt, count: previous.count + 1 }
-    : { firstAt: now, count: 1 };
-  writeAttempts(next);
-  return next.count;
+function newHopToken(): string {
+  return typeof crypto?.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+/** Where the user was trying to go, with the sentinel taken back out. */
+interface Arrival {
+  /** The `_authhop` Kratos echoed back on this load, if any. */
+  returnedHop: string | null;
+  pathname: string;
+  search: string;
+  hash: string;
+}
+
+/**
+ * Reads the current location and separates the sentinel from the destination.
+ *
+ * Pure: stripping the parameter from the address bar is a side effect and
+ * happens in an effect instead, so React may call this more than once (it does
+ * under StrictMode) without the second call losing the sentinel.
+ */
+function parseArrival(): Arrival {
+  const { pathname, search, hash } = window.location;
+  const params = new URLSearchParams(search);
+  const returnedHop = params.get(HOP_PARAM);
+  if (returnedHop === null) {
+    return { returnedHop: null, pathname, search, hash };
+  }
+  params.delete(HOP_PARAM);
+  const rest = params.toString();
+  return { returnedHop, pathname, search: rest ? `?${rest}` : '', hash };
 }
 
 /**
  * Builds the absolute URL to return to after login, preserving the path, query
- * and hash the user was actually trying to reach.
+ * and hash the user was actually trying to reach, and tagging it so we can
+ * recognise our own round trip when Kratos sends the browser back.
  *
  * Kratos matches `allowed_return_urls` by scheme + host + path *prefix* (see
  * ory/kratos x/redir/secure_redirect.go), so the existing console origin entry
- * already covers every subpath — no Ory config change is required.
+ * already covers every subpath and the extra query parameter is not part of
+ * the match — no Ory config change is required.
  *
  * `consoleUrl` carries no trailing slash, so this uses the URL constructor
  * rather than string concatenation to avoid producing "//tasks".
  */
-function buildReturnTo(consoleUrl: string): string {
-  const { pathname, search, hash } = window.location;
-  return new URL(`${pathname}${search}${hash}`, consoleUrl).toString();
+function buildReturnTo(
+  consoleUrl: string,
+  { pathname, search, hash }: Pick<Arrival, 'pathname' | 'search' | 'hash'>,
+  hop: string,
+): string {
+  const url = new URL(`${pathname}${search}${hash}`, consoleUrl);
+  url.searchParams.set(HOP_PARAM, hop);
+  return url.toString();
 }
 
 /**
@@ -131,11 +154,17 @@ export function buildSignInUrl({
   challengeRedirectTo,
   kratosUrl,
   consoleUrl,
+  destination,
+  hop,
 }: {
   challenge: AuthChallenge;
   challengeRedirectTo: string | null;
   kratosUrl: string;
   consoleUrl: string;
+  /** Where to come back to, with any previous sentinel already stripped. */
+  destination: Pick<Arrival, 'pathname' | 'search' | 'hash'>;
+  /** Sentinel Kratos will echo back on `return_to`. */
+  hop: string;
 }): string {
   const needsSecondFactor = challenge === 'second_factor_required';
 
@@ -149,7 +178,10 @@ export function buildSignInUrl({
   if (needsSecondFactor && !url.searchParams.has('aal')) {
     url.searchParams.set('aal', 'aal2');
   }
-  url.searchParams.set('return_to', buildReturnTo(consoleUrl));
+  url.searchParams.set(
+    'return_to',
+    buildReturnTo(consoleUrl, destination, hop),
+  );
   return url.toString();
 }
 
@@ -158,19 +190,54 @@ export function AuthGuard({ children }: { children: ReactNode }) {
     useAuth();
   const [loopDetected, setLoopDetected] = useState(false);
   const hasRedirectedRef = useRef(false);
+  // Both captured once, at mount, before anything can clear or rewrite them.
+  const [arrival] = useState(parseArrival);
+  const [expectedHop] = useState(readHopToken);
+
+  /**
+   * True when Kratos returned the browser to a URL we tagged on the way out
+   * and the session still is not usable. The flow we chose demonstrably cannot
+   * clear this challenge, so going back into it is the loop.
+   */
+  const bouncedBack =
+    arrival.returnedHop !== null && arrival.returnedHop === expectedHop;
 
   const goToSignIn = useCallback(() => {
     const { kratosUrl, consoleUrl } = getConfig();
+    const hop = newHopToken();
+    writeHopToken(hop);
     // replace(), not assign(): each bounce through Kratos would otherwise push
     // a history entry, so a loop buries the page the user came from under
     // dozens of entries and Back walks *through* the loop instead of out of it.
     window.location.replace(
-      buildSignInUrl({ challenge, challengeRedirectTo, kratosUrl, consoleUrl }),
+      buildSignInUrl({
+        challenge,
+        challengeRedirectTo,
+        kratosUrl,
+        consoleUrl,
+        destination: arrival,
+        hop,
+      }),
     );
-  }, [challenge, challengeRedirectTo]);
+  }, [challenge, challengeRedirectTo, arrival]);
+
+  // Keep the sentinel out of the address bar: it is machinery, and a user who
+  // bookmarks or shares the URL should not carry it along.
+  useEffect(() => {
+    if (arrival.returnedHop === null) return;
+    try {
+      window.history.replaceState(
+        null,
+        '',
+        `${arrival.pathname}${arrival.search}${arrival.hash}`,
+      );
+    } catch {
+      // Cosmetic only — the sentinel is already read and never re-read.
+    }
+  }, [arrival]);
 
   useEffect(() => {
-    if (isAuthenticated) writeAttempts(null);
+    if (isAuthenticated) writeHopToken(null);
   }, [isAuthenticated]);
 
   useEffect(() => {
@@ -180,12 +247,13 @@ export function AuthGuard({ children }: { children: ReactNode }) {
     if (hasRedirectedRef.current) return;
     hasRedirectedRef.current = true;
 
-    if (recordRedirectAttempt(Date.now()) > REDIRECT_LOOP_THRESHOLD) {
+    if (bouncedBack) {
+      writeHopToken(null);
       setLoopDetected(true);
       return;
     }
     goToSignIn();
-  }, [isLoading, isAuthenticated, loopDetected, goToSignIn]);
+  }, [isLoading, isAuthenticated, loopDetected, bouncedBack, goToSignIn]);
 
   if (isLoading) {
     return (
@@ -200,12 +268,9 @@ export function AuthGuard({ children }: { children: ReactNode }) {
       return (
         <SignInRecovery
           challenge={challenge}
-          onRetry={() => {
-            writeAttempts(null);
-            goToSignIn();
-          }}
+          onRetry={goToSignIn}
           onSignOut={() => {
-            writeAttempts(null);
+            writeHopToken(null);
             void logout();
           }}
         />
@@ -218,7 +283,8 @@ export function AuthGuard({ children }: { children: ReactNode }) {
 }
 
 /**
- * Shown once the loop is detected, instead of redirecting a fourth time.
+ * Shown as soon as a login flow hands the browser back without fixing the
+ * session, instead of walking back into it.
  *
  * "Sign out" is the control that matters: it ends the half-authenticated
  * session server-side. Mobile browsers offer no way to clear cookies for a
@@ -247,8 +313,8 @@ function SignInRecovery({
           </Text>
           <Text color="muted">
             {needsSecondFactor
-              ? 'Your session is signed in but still needs two-factor verification. The console stopped retrying so you are not stuck in a redirect loop.'
-              : 'The console was sent back to sign in repeatedly without a session being established, so it stopped retrying.'}
+              ? 'Your session is signed in but still needs two-factor verification, and the verification step sent you back here without completing. The console stopped rather than retry it in a loop.'
+              : 'Sign-in sent you back here without establishing a session, so the console stopped rather than retry it in a loop.'}
           </Text>
           <Stack direction="row" gap={3} wrap>
             <Button onClick={onRetry}>

--- a/apps/console/src/auth/AuthProvider.tsx
+++ b/apps/console/src/auth/AuthProvider.tsx
@@ -41,12 +41,35 @@ async function toSessionWithTimeout(): Promise<Session> {
   }
 }
 
+/**
+ * Why the session is unusable, when it is.
+ *
+ * - `none` — either authenticated, or we have not resolved yet.
+ * - `unauthenticated` — Kratos has no session for this browser (401).
+ * - `second_factor_required` — Kratos *has* a session, but it does not meet
+ *   the required Authenticator Assurance Level (403). The distinction matters:
+ *   these two need different login flows. See `challengeRedirectTo`.
+ */
+export type AuthChallenge =
+  | 'none'
+  | 'unauthenticated'
+  | 'second_factor_required';
+
 export interface AuthContextValue {
   session: Session | null;
   identity: Identity | null;
   isAuthenticated: boolean;
   isLoading: boolean;
   error: Error | null;
+  /** Why the session is unusable — drives which login flow AuthGuard opens. */
+  challenge: AuthChallenge;
+  /**
+   * The `redirect_browser_to` Kratos returns alongside a 403. It already points
+   * at the flow that satisfies the missing factor (e.g. `…/self-service/login/
+   * browser?aal=aal2`), so preferring it over a hand-built URL keeps us correct
+   * if Ory ever changes which factor it asks for.
+   */
+  challengeRedirectTo: string | null;
   logout: () => Promise<void>;
   /** Re-check session (e.g. after login completes) */
   refreshSession: () => Promise<void>;
@@ -54,27 +77,70 @@ export interface AuthContextValue {
 
 export const AuthContext = createContext<AuthContextValue | null>(null);
 
+interface OryErrorBody {
+  error?: { id?: string };
+  redirect_browser_to?: string;
+}
+
 /**
- * Distinguishes a genuine "you are logged out" answer from a transient failure
- * (network blip, 5xx, CORS, aborted fetch).
+ * Reads Kratos' JSON error envelope without disturbing the caller's response.
+ *
+ * `.clone()` because @ory/client-fetch hands us an unread body; consuming the
+ * original would break any other reader.
+ */
+async function readOryErrorBody(
+  response: Response,
+): Promise<OryErrorBody | null> {
+  try {
+    return (await response.clone().json()) as OryErrorBody;
+  } catch {
+    return null;
+  }
+}
+
+type SessionFailure =
+  /** Network blip, 5xx, CORS, aborted fetch — keep whatever session we have. */
+  | { kind: 'transient' }
+  | { kind: 'unauthenticated' }
+  | { kind: 'second_factor_required'; redirectTo: string | null };
+
+/**
+ * Classifies a failed `toSession()` call.
  *
  * @ory/client-fetch throws ResponseError (carrying `.response`) for any non-2xx
- * response, and FetchError when fetch() itself rejected. Only 401 (no/invalid
- * session) and 403 (session_aal2_required) mean the user must re-authenticate.
- * Treating anything else as logged-out lets a momentary blip bounce the user to
- * login — see issue #1747.
+ * response, and FetchError when fetch() itself rejected. Only 401 and 403 mean
+ * the user must re-authenticate; treating anything else as logged-out lets a
+ * momentary blip bounce the user to login — see issue #1747.
+ *
+ * 401 and 403 are *not* interchangeable. A 403 from `/sessions/whoami` is
+ * always an AAL error: the cookie is valid, but the session sits at aal1 while
+ * the identity has a second factor enrolled. Sending that user to a plain
+ * (aal1) login flow makes Kratos answer "you are already logged in" and 302
+ * straight back to `return_to` — console redirects to Kratos, Kratos redirects
+ * to console, forever. That is the loop this guard exists to prevent.
  */
-function isAuthenticationFailure(error: unknown): boolean {
-  return (
-    error instanceof ResponseError &&
-    (error.response.status === 401 || error.response.status === 403)
-  );
+async function classifySessionFailure(error: unknown): Promise<SessionFailure> {
+  if (!(error instanceof ResponseError)) return { kind: 'transient' };
+
+  const { status } = error.response;
+  if (status === 401) return { kind: 'unauthenticated' };
+  if (status !== 403) return { kind: 'transient' };
+
+  const body = await readOryErrorBody(error.response);
+  return {
+    kind: 'second_factor_required',
+    redirectTo: body?.redirect_browser_to ?? null,
+  };
 }
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [session, setSession] = useState<Session | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+  const [challenge, setChallenge] = useState<AuthChallenge>('none');
+  const [challengeRedirectTo, setChallengeRedirectTo] = useState<string | null>(
+    null,
+  );
   const inFlightCheckRef = useRef<Promise<void> | null>(null);
   const lastForegroundAttemptAtRef = useRef(Number.NEGATIVE_INFINITY);
 
@@ -100,16 +166,26 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           const sess = await toSessionWithTimeout();
           setSession(sess);
           setError(null);
+          setChallenge('none');
+          setChallengeRedirectTo(null);
         } catch (err) {
-          if (isAuthenticationFailure(err)) {
-            // Genuine sign-out: clear so AuthGuard redirects to login.
-            setSession(null);
-            setError(null);
-          } else {
-            // Transient: keep the session we already have. A background blip
-            // must never unmount the app or bounce the user to login.
+          const failure = await classifySessionFailure(err);
+          if (failure.kind === 'transient') {
+            // Keep the session we already have. A background blip must never
+            // unmount the app or bounce the user to login.
             setError(
               err instanceof Error ? err : new Error('Session check failed'),
+            );
+          } else {
+            // Genuine sign-out, or a session that needs a second factor:
+            // clear so AuthGuard redirects to the right login flow.
+            setSession(null);
+            setError(null);
+            setChallenge(failure.kind);
+            setChallengeRedirectTo(
+              failure.kind === 'second_factor_required'
+                ? failure.redirectTo
+                : null,
             );
           }
         } finally {
@@ -170,6 +246,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     isAuthenticated: !!session?.active,
     isLoading,
     error,
+    challenge,
+    challengeRedirectTo,
     logout,
     refreshSession: checkSession,
   };

--- a/infra/ory/kratos/kratos.yaml
+++ b/infra/ory/kratos/kratos.yaml
@@ -69,6 +69,14 @@ selfservice:
       enabled: true
       config:
         lifespan: 15m
+    # Mirrors Ory Network (infra/ory/project.json). Without it a locally
+    # enrolled identity can never reach aal2, so the second-factor branch of
+    # the console auth guard is untestable here — see the console-e2e
+    # auth-second-factor-loop suite.
+    totp:
+      enabled: true
+      config:
+        issuer: MoltNet
 
   flows:
     registration:
@@ -217,6 +225,12 @@ session:
   lifespan: 720h
   cookie:
     same_site: Lax
+  whoami:
+    # Kratos' default, stated explicitly because the console's redirect logic
+    # depends on it: once an identity enrols a second factor, /sessions/whoami
+    # answers 403 for that identity's aal1 sessions. The console must send
+    # those to an `aal=aal2` login flow, not a plain one.
+    required_aal: highest_available
 
 courier:
   smtp:


### PR DESCRIPTION
## Summary

- Fixes an infinite console ↔ Kratos redirect loop hit when a login is abandoned at the two-factor step: the session cookie exists at `aal1`, `/sessions/whoami` answers **403**, and the console redirected to a login flow whose default `requested_aal` that session already satisfies — so Kratos returned `ErrAlreadyLoggedIn` and 302'd straight back, forever.
- Adds an escape hatch. `AuthGuard` used `window.location.assign`, so every bounce pushed a history entry and Back walked *backwards through* the loop. On mobile there is no per-domain cookie clearing, so the reporter had no way out at all.
- Adds a console-e2e suite that reproduces the state end to end.

## Changes

**`apps/console/src/auth/AuthProvider.tsx`** — 401 and 403 both mean "re-authenticate", but they need *different* login flows, so they can no longer share a branch. `classifySessionFailure` reads Kratos' error envelope and the context now exposes a typed `challenge` (`none` / `unauthenticated` / `second_factor_required`) plus the `redirect_browser_to` Kratos returns alongside `ErrAALNotSatisfied`. Transient failures still keep the existing session (#1747 behaviour is unchanged).

**`apps/console/src/auth/AuthGuard.tsx`**
- `buildSignInUrl` picks the flow from the challenge, forcing `aal=aal2` for the second-factor case. This is the load-bearing fix: `aal=aal2` is the only thing that makes Kratos render the 2FA form instead of bouncing. A Kratos-supplied `redirect_browser_to` is preferred, but only when its origin matches the configured Kratos.
- Redirect moved out of render into an effect (during render it fired once per pass) and switched to `replace()` so bounces stop burying the back button.
- A **`return_to` sentinel** breaks any residual loop and renders a recovery screen. Its **"Sign out and start over"** button ends the session server-side, which is the mobile escape hatch.

**`infra/ory/kratos/kratos.yaml`** — enables `totp` and states `session.whoami.required_aal: highest_available`. Production Ory has had TOTP enabled since `project.json:410`; local did not, so the AAL2 branch was untestable. This follows the *"keep local and production Ory configs aligned"* watch-for from the April CORS incident.

**`apps/console-e2e/`** — new `auth-second-factor-loop.e2e.ts` plus `enrollTotp` / `logoutViaBrowser` helpers and a small RFC 6238 generator (no new dependency). It uses password + TOTP rather than GitHub OIDC: the provider is incidental to the loop, and requiring one would make the suite unrunnable locally. Enrolment goes through the Kratos settings JSON API because the secret only exists in the flow payload — scraping the reference UI's QR markup would be brittle.

## Why a sentinel and not a redirect counter

The `aal=aal2` fix already makes the reported loop terminal — for 403 Kratos now renders the TOTP form, for 401 the login form. So whatever guard remains is insurance against loops we cannot enumerate, and chiefly against the one `aal2` **cannot** touch: `/sessions/whoami` 401ing because a cross-origin XHR does not carry the cookie while a top-level navigation to Kratos does. Console says "logged out", Kratos says "already logged in", ping-pong — and no `aal` parameter helps, because the console genuinely cannot see the session. That is mobile Safari ITP territory, which is the reporter's platform.

For that job a 3-in-30s counter is the wrong instrument: it cannot distinguish a loop from a user navigating back and forth, its threshold and window are both guesses, and it burns three bounces before helping.

Instead `AuthGuard` recognises its own round trip. It mints a nonce, keeps it in `sessionStorage`, tags `return_to` with it as `_authhop`, and on the next load compares what Kratos echoed back against what it issued. A match plus a still-unusable session is *proof* that the flow it chose cannot clear the challenge, so it stops — on the **first** bounce, with nothing to tune. A foreign `_authhop` from a shared or bookmarked URL will not match and is ignored, and `history.replaceState` strips the parameter so it never reaches the address bar. The extra query parameter is harmless to Ory: `allowed_return_urls` matches on scheme + host + path prefix.

## Test plan

The loop assertion counts main-frame navigations back to the console origin over a settle window, so a regression fails with a count rather than an opaque timeout.

- [x] `pnpm exec nx run @moltnet/console:test` — **168 passed**
- [x] `pnpm exec nx run-many -t typecheck --projects=@moltnet/console,@moltnet/console-e2e`
- [x] `pnpm exec nx run-many -t lint --projects=@moltnet/console,@moltnet/console-e2e` — 0 errors
- [x] **`pnpm exec nx run @moltnet/console-e2e:e2e` — run against the local Docker stack.** `auth-second-factor-loop.e2e.ts` 4/4, and the full console-e2e suite **57 passed / 0 failed** (4 conditionally skipped). The Kratos settings-flow payload shape is now observed rather than reasoned from types, and the "lands back on the requested page" assertion — an exact match on `$CONSOLE_URL/tasks` — is what proves the sentinel is stripped before the user sees it.
- [ ] Docs — no user-facing docs touched; the recovery screen is new UI but only reachable from a failure state.

## Note on prior art

Entry `7f9521b5` (#1747) explicitly considered and rejected a sessionStorage redirect-loop breaker, on the reasoning that *"a Kratos bounce-back implies a valid session that then resolves"*. That premise is false for 403 — the session is valid and never resolves. Two distinct root causes have now produced this identical ping-pong (April: duplicated CORS headers; this one: AAL), so the guard is defence against the class rather than against one bug.

Diary: `4749302c` (semantic), `890ac3a1` (episodic), `77d72132` (sentinel decision), `1fed7f73` (Playwright context incident), `64bf608a` + `78541328` + `74e8a766` + `8b5ba125` (commits).

<!-- legreffier-correlation: 5a8808fb-ed04-4ca4-a6bb-7490639fe8e6 -->
