### PR TITLE
feat(landing): give the Knowledge Factory pillar its own section

### DIFF
--- a/apps/landing/__tests__/landing.test.tsx
+++ b/apps/landing/__tests__/landing.test.tsx
@@ -191,12 +191,12 @@ describe('content', () => {
     ).toBeInTheDocument();
   });
 
-  it('KnowledgeFactory frames policy and typed work as a byproduct', () => {
+  it('KnowledgeFactory credits the other two pillars rather than demoting them', () => {
     wrap(<KnowledgeFactory />);
 
     expect(
       screen.getByRole('heading', {
-        name: 'The governance layer is a byproduct, not a second purchase.',
+        name: 'This pillar is only worth anything because the other two hold it up.',
       }),
     ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Task Engine/ })).toHaveAttribute(
@@ -208,18 +208,29 @@ describe('content', () => {
       '#agent-runtime',
     );
     expect(
-      screen.getByRole('link', { name: /How the factory runs/ }),
-    ).toHaveAttribute('href', '#knowledge-factory-system');
+      screen.getByRole('link', { name: /Identity & Authority/ }),
+    ).toHaveAttribute('href', '#identity-authority');
   });
 
-  it('Hero routes the first scroll into the Knowledge Factory section', () => {
+  it('Systems chapter three points down at the Knowledge Factory deep dive', () => {
+    wrap(<Systems />);
+
+    const link = screen.getByRole('link', {
+      name: /Why this pillar compounds/,
+    });
+    expect(link).toHaveAttribute('href', '#knowledge-ownership');
+    // In-page anchor, so it must not inherit the docs links' new-tab treatment.
+    expect(link).not.toHaveAttribute('target');
+  });
+
+  it('Hero keeps the control-plane narrative as the first scroll', () => {
     wrap(<Hero />);
 
     expect(
       screen.getByRole('link', {
-        name: /start with the memory you should already own/i,
+        name: /follow one task through the system/i,
       }),
-    ).toHaveAttribute('href', '#knowledge-factory');
+    ).toHaveAttribute('href', '#execution-trace');
   });
 
   it('ExecutionTrace preserves the causal task trail', () => {

--- a/apps/landing/__tests__/landing.test.tsx
+++ b/apps/landing/__tests__/landing.test.tsx
@@ -18,6 +18,7 @@ import { TagChip } from '../src/components/feed/TagChip';
 import { Footer } from '../src/components/Footer';
 import { GetStarted } from '../src/components/GetStarted';
 import { Hero } from '../src/components/Hero';
+import { KnowledgeFactory } from '../src/components/KnowledgeFactory';
 import { Nav } from '../src/components/Nav';
 import { OpenSource } from '../src/components/OpenSource';
 import { Systems } from '../src/components/Systems';
@@ -53,6 +54,10 @@ describe('smoke render', () => {
 
   it('renders Hero', () => {
     wrap(<Hero />);
+  });
+
+  it('renders KnowledgeFactory', () => {
+    wrap(<KnowledgeFactory />);
   });
 
   it('renders ExecutionTrace', () => {
@@ -144,6 +149,77 @@ describe('content', () => {
     expect(walkthroughs).not.toHaveAttribute('open');
     expect(integrations).toBeInTheDocument();
     expect(integrations).not.toHaveAttribute('open');
+  });
+
+  it('KnowledgeFactory leads with ownership and portability of agent memory', () => {
+    wrap(<KnowledgeFactory />);
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'Your agents learn on your work. That memory should be yours.',
+      }),
+    ).toBeInTheDocument();
+
+    const ledger = screen.getByRole('list', {
+      name: 'Knowledge portability ledger',
+    });
+    expect(ledger.querySelectorAll(':scope > li')).toHaveLength(4);
+    // Direction is announced, not just struck through, so the ledger still
+    // reads as before/after without the visual column captions.
+    expect(screen.getByText('Assistant memory')).toHaveTextContent(
+      'Today: Assistant memory',
+    );
+    expect(screen.getByText('Context pack')).toHaveTextContent(
+      'In MoltNet: Context pack',
+    );
+  });
+
+  it('KnowledgeFactory addresses both the individual and the organisation', () => {
+    wrap(<KnowledgeFactory />);
+
+    expect(screen.getByText('For one person')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', {
+        name: 'Own the conversations you already had.',
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('For an organisation')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', {
+        name: 'One memory instead of twelve silos.',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('KnowledgeFactory frames policy and typed work as a byproduct', () => {
+    wrap(<KnowledgeFactory />);
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'The governance layer is a byproduct, not a second purchase.',
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Task Engine/ })).toHaveAttribute(
+      'href',
+      '#task-engine',
+    );
+    expect(screen.getByRole('link', { name: /Agent Runtime/ })).toHaveAttribute(
+      'href',
+      '#agent-runtime',
+    );
+    expect(
+      screen.getByRole('link', { name: /How the factory runs/ }),
+    ).toHaveAttribute('href', '#knowledge-factory-system');
+  });
+
+  it('Hero routes the first scroll into the Knowledge Factory section', () => {
+    wrap(<Hero />);
+
+    expect(
+      screen.getByRole('link', {
+        name: /start with the memory you should already own/i,
+      }),
+    ).toHaveAttribute('href', '#knowledge-factory');
   });
 
   it('ExecutionTrace preserves the causal task trail', () => {

--- a/apps/landing/src/components/Hero.tsx
+++ b/apps/landing/src/components/Hero.tsx
@@ -28,7 +28,11 @@ const systems = [
     name: 'Knowledge Factory',
     href: '#knowledge-factory',
     state: 'pack_b31e',
-    details: ['entries attributed', 'provenance linked', 'context reusable'],
+    details: [
+      'entries attributed',
+      'provenance linked',
+      'portable to any runtime',
+    ],
   },
 ] as const;
 
@@ -67,8 +71,9 @@ export function Hero() {
               color="secondary"
               style={{ maxWidth: '58ch' }}
             >
-              MoltNet dispatches typed work, enforces runtime policy, and turns
-              attributed outcomes into reusable knowledge—under one identity and
+              MoltNet turns what your agents learn into signed knowledge you own
+              and can carry between runtimes—then dispatches typed work and
+              enforces runtime policy against it, under one identity and
               authorization model.
             </Text>
 
@@ -184,8 +189,8 @@ export function Hero() {
           </div>
         </div>
 
-        <a className="ops-scroll-cue" href="#execution-trace">
-          Follow one task through the system
+        <a className="ops-scroll-cue" href="#knowledge-factory">
+          Start with the memory you should already own
           <span aria-hidden="true">↓</span>
         </a>
       </Container>

--- a/apps/landing/src/components/Hero.tsx
+++ b/apps/landing/src/components/Hero.tsx
@@ -71,10 +71,9 @@ export function Hero() {
               color="secondary"
               style={{ maxWidth: '58ch' }}
             >
-              MoltNet turns what your agents learn into signed knowledge you own
-              and can carry between runtimes—then dispatches typed work and
-              enforces runtime policy against it, under one identity and
-              authorization model.
+              MoltNet dispatches typed work, enforces runtime policy, and turns
+              attributed outcomes into knowledge you own and can carry between
+              runtimes—under one identity and authorization model.
             </Text>
 
             <Stack direction="row" gap={3} wrap>
@@ -189,8 +188,8 @@ export function Hero() {
           </div>
         </div>
 
-        <a className="ops-scroll-cue" href="#knowledge-factory">
-          Start with the memory you should already own
+        <a className="ops-scroll-cue" href="#execution-trace">
+          Follow one task through the system
           <span aria-hidden="true">↓</span>
         </a>
       </Container>

--- a/apps/landing/src/components/KnowledgeFactory.tsx
+++ b/apps/landing/src/components/KnowledgeFactory.tsx
@@ -1,0 +1,217 @@
+import {
+  ActionLink,
+  Badge,
+  Container,
+  ControlSurface,
+  Text,
+} from '@themoltnet/design-system';
+
+import { getConfig } from '../config';
+
+/**
+ * Entry-point framing for the Knowledge Factory.
+ *
+ * Most visitors do not arrive looking for an agent control plane. They arrive
+ * because the context their agents build keeps dying inside one vendor's
+ * account. This section leads with that loss, states the two ownership stakes
+ * (individual portability, organisational de-siloing), and treats policy and
+ * typed dispatch as what you inherit on the way rather than the opening pitch.
+ */
+
+const ledger = [
+  {
+    today: 'Chat history',
+    todayDetail: 'scroll back and hope you find it',
+    moltnet: 'Signed entry',
+    moltnetDetail: 'attributed to the agent that wrote it',
+  },
+  {
+    today: 'Assistant memory',
+    todayDetail: 'one vendor, opaque, not exportable',
+    moltnet: 'Context pack',
+    moltnetDetail: 'content-addressed selection you can diff',
+  },
+  {
+    today: 'Rules files per repo',
+    todayDetail: 'undated, unattributed, copied by hand',
+    moltnet: 'Rendered skill',
+    moltnetDetail: 'plain Markdown any runtime can load',
+  },
+  {
+    today: 'The wiki page',
+    todayDetail: 'written once, never checked again',
+    moltnet: 'Verified pack',
+    moltnetDetail: 'scored against real task outcomes',
+  },
+] as const;
+
+const audiences = [
+  {
+    id: 'individual',
+    scope: 'For one person',
+    promise: 'Own the conversations you already had.',
+    points: [
+      'Corrections, dead ends, and decisions become entries you keep—signed with your own agent key, stored in your own diary.',
+      'Packs render to Markdown skills, so the assistant you switch to next reads the same context the last one learned.',
+      'Nothing is locked to a model or an editor. The format is entries, packs, and text.',
+    ],
+  },
+  {
+    id: 'organisation',
+    scope: 'For an organisation',
+    promise: 'One memory instead of twelve silos.',
+    points: [
+      'Team-scoped diaries replace per-seat, per-product memory that no one can audit or hand over.',
+      'Content-addressed packs let two agents prove they loaded the same bytes—across teams, vendors, and time.',
+      'Grants scope who reads what; attribution survives revocation, so provenance holds after people and tools rotate.',
+    ],
+  },
+] as const;
+
+export function KnowledgeFactory() {
+  const { docsUrl } = getConfig();
+
+  return (
+    <section
+      id="knowledge-factory"
+      className="ops-section ops-factory-section"
+      aria-labelledby="factory-title"
+    >
+      <Container maxWidth="xl">
+        <div className="ops-section-heading ops-section-heading-wide">
+          <span className="ops-kicker">Start here · Knowledge Factory</span>
+          <Text id="factory-title" variant="h2">
+            Your agents learn on your work. That memory should be yours.
+          </Text>
+          <Text variant="bodyLarge" color="secondary">
+            Every assistant your team uses is accumulating context—the
+            conventions, the corrections, the reason you rejected the obvious
+            approach. It lives inside one vendor&apos;s account, in a shape you
+            cannot export, verify, or hand to the next tool. Change the model,
+            the editor, or the team, and it starts over.
+          </Text>
+          <Text variant="bodyLarge" color="secondary">
+            The Knowledge Factory is the part of MoltNet you can adopt on its
+            own. Capture what agents learn as signed entries you own, condense
+            them into content-addressed packs, and load them into whatever
+            runtime you use next.
+          </Text>
+        </div>
+
+        <ControlSurface
+          tone="identity"
+          active
+          padding="none"
+          className="ops-factory-ledger"
+        >
+          <div className="ops-factory-ledger-head">
+            <span>Where knowledge lives now</span>
+            <Badge variant="accent">portability</Badge>
+            <span>What MoltNet stores instead</span>
+          </div>
+          <ul aria-label="Knowledge portability ledger">
+            {ledger.map((row) => (
+              <li key={row.today}>
+                {/* The strike-through and the arrow carry direction visually;
+                    these labels carry it for screen readers, where the column
+                    captions above are too far away to associate. */}
+                <div className="ops-factory-from">
+                  <strong>
+                    <span className="ops-visually-hidden">Today: </span>
+                    {row.today}
+                  </strong>
+                  <small>{row.todayDetail}</small>
+                </div>
+                <span className="ops-factory-arrow" aria-hidden="true">
+                  →
+                </span>
+                <div className="ops-factory-to">
+                  <strong>
+                    <span className="ops-visually-hidden">In MoltNet: </span>
+                    {row.moltnet}
+                  </strong>
+                  <small>{row.moltnetDetail}</small>
+                </div>
+              </li>
+            ))}
+          </ul>
+          <div className="ops-factory-chain">
+            <span>capture</span>
+            <span aria-hidden="true">·</span>
+            <span>attribute</span>
+            <span aria-hidden="true">·</span>
+            <span>condense</span>
+            <span aria-hidden="true">·</span>
+            <span>surface</span>
+            <span aria-hidden="true">·</span>
+            <span>test</span>
+            <span aria-hidden="true">·</span>
+            <span>decay</span>
+          </div>
+        </ControlSurface>
+
+        <div className="ops-factory-audiences">
+          {audiences.map((audience) => (
+            <ControlSurface
+              as="article"
+              key={audience.id}
+              padding="lg"
+              className="ops-factory-audience"
+            >
+              <span className="ops-kicker">{audience.scope}</span>
+              <Text variant="h3">{audience.promise}</Text>
+              <ul>
+                {audience.points.map((point) => (
+                  <li key={point}>
+                    <span aria-hidden="true">✓</span>
+                    <span>{point}</span>
+                  </li>
+                ))}
+              </ul>
+            </ControlSurface>
+          ))}
+        </div>
+
+        <div className="ops-factory-byproduct">
+          <div>
+            <span className="ops-record-label">And on the way</span>
+            <Text variant="h3">
+              The governance layer is a byproduct, not a second purchase.
+            </Text>
+            <Text variant="bodyLarge" color="secondary">
+              Knowledge only counts if you can say where it came from and
+              whether it held up. So the work that produces an entry runs as a
+              typed contract, the runtime that loads a pack is already
+              policy-bound, and every hop is attributed to a key. Teams adopt
+              the Knowledge Factory to stop losing context—and find the audit
+              trail their security review was going to ask for anyway.
+            </Text>
+          </div>
+          <div className="ops-factory-links">
+            <a href="#task-engine">
+              <strong>Task Engine</strong>
+              <span>typed work, retry budgets, signed outcomes</span>
+            </a>
+            <a href="#agent-runtime">
+              <strong>Agent Runtime</strong>
+              <span>pinned profiles, tool and command policy</span>
+            </a>
+            <a href="#knowledge-factory-system">
+              <strong>How the factory runs</strong>
+              <span>entry → pack → skill → verified task</span>
+            </a>
+          </div>
+          <ActionLink
+            href={`${docsUrl}/understand/knowledge-factory`}
+            target="_blank"
+            rel="noopener noreferrer"
+            variant="secondary"
+          >
+            Read the Knowledge Factory
+            <span aria-hidden="true">↗</span>
+          </ActionLink>
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/apps/landing/src/components/KnowledgeFactory.tsx
+++ b/apps/landing/src/components/KnowledgeFactory.tsx
@@ -9,13 +9,16 @@ import {
 import { getConfig } from '../config';
 
 /**
- * Entry-point framing for the Knowledge Factory.
+ * Deep dive on the third pillar, sitting immediately after the three-system
+ * chapters so the control-plane frame is already established.
  *
- * Most visitors do not arrive looking for an agent control plane. They arrive
- * because the context their agents build keeps dying inside one vendor's
- * account. This section leads with that loss, states the two ownership stakes
- * (individual portability, organisational de-siloing), and treats policy and
- * typed dispatch as what you inherit on the way rather than the opening pitch.
+ * MoltNet is one control plane; the Knowledge Factory is the pillar whose value
+ * compounds, and the one most visitors already feel the absence of. This
+ * section gives it the weight the other two get from the trace and the
+ * authority plane: the portability stake stated plainly, both audiences named
+ * (individual ownership, organisational de-siloing), and a closing band that
+ * points back at the Task Engine and Agent Runtime as what makes a pack's
+ * provenance real rather than as separate products.
  */
 
 const ledger = [
@@ -73,13 +76,15 @@ export function KnowledgeFactory() {
 
   return (
     <section
-      id="knowledge-factory"
+      id="knowledge-ownership"
       className="ops-section ops-factory-section"
       aria-labelledby="factory-title"
     >
       <Container maxWidth="xl">
         <div className="ops-section-heading ops-section-heading-wide">
-          <span className="ops-kicker">Start here · Knowledge Factory</span>
+          <span className="ops-kicker">
+            Pillar 03 · Knowledge Factory, up close
+          </span>
           <Text id="factory-title" variant="h2">
             Your agents learn on your work. That memory should be yours.
           </Text>
@@ -91,10 +96,9 @@ export function KnowledgeFactory() {
             the editor, or the team, and it starts over.
           </Text>
           <Text variant="bodyLarge" color="secondary">
-            The Knowledge Factory is the part of MoltNet you can adopt on its
-            own. Capture what agents learn as signed entries you own, condense
-            them into content-addressed packs, and load them into whatever
-            runtime you use next.
+            All three pillars run on one control plane, but this is the one that
+            compounds. Entries signed today are the context an agent loads next
+            quarter, on a runtime that may not exist yet.
           </Text>
         </div>
 
@@ -174,16 +178,21 @@ export function KnowledgeFactory() {
 
         <div className="ops-factory-byproduct">
           <div>
-            <span className="ops-record-label">And on the way</span>
+            <span className="ops-record-label">
+              Why it takes a control plane
+            </span>
             <Text variant="h3">
-              The governance layer is a byproduct, not a second purchase.
+              This pillar is only worth anything because the other two hold it
+              up.
             </Text>
             <Text variant="bodyLarge" color="secondary">
-              Knowledge only counts if you can say where it came from and
-              whether it held up. So the work that produces an entry runs as a
-              typed contract, the runtime that loads a pack is already
-              policy-bound, and every hop is attributed to a key. Teams adopt
-              the Knowledge Factory to stop losing context—and find the audit
+              A pack that claims to be verified means a real task ran against
+              it, under a policy you can name, by an agent you can identify.
+              That is the Task Engine and the Agent Runtime doing their job.
+              Knowledge you cannot trace is a knowledge base with better
+              formatting—so the rest of the control plane is not a second
+              purchase you make later, it is what makes an entry worth loading.
+              Teams who adopt MoltNet to stop losing context inherit the audit
               trail their security review was going to ask for anyway.
             </Text>
           </div>
@@ -196,9 +205,9 @@ export function KnowledgeFactory() {
               <strong>Agent Runtime</strong>
               <span>pinned profiles, tool and command policy</span>
             </a>
-            <a href="#knowledge-factory-system">
-              <strong>How the factory runs</strong>
-              <span>entry → pack → skill → verified task</span>
+            <a href="#identity-authority">
+              <strong>Identity &amp; Authority</strong>
+              <span>the keys every hop is attributed to</span>
             </a>
           </div>
           <ActionLink

--- a/apps/landing/src/components/Systems.tsx
+++ b/apps/landing/src/components/Systems.tsx
@@ -154,12 +154,14 @@ export function Systems() {
         </SystemChapter>
 
         <SystemChapter
-          id="knowledge-factory-system"
+          id="knowledge-factory"
           name="Knowledge Factory"
           promise="Make every run useful to the next."
           description="Signed diary entries capture decisions, incidents, procedures, and reflection with attribution. Teams turn them into content-addressed context packs, load focused guidance at runtime, and verify it against future work."
-          href={`${docsUrl}/understand/knowledge-factory`}
-          linkLabel="Explore the Knowledge Factory"
+          href="#knowledge-ownership"
+          linkLabel="Why this pillar compounds"
+          linkIcon="↓"
+          external={false}
         >
           <ControlSurface
             as="div"
@@ -205,6 +207,8 @@ function SystemChapter({
   description,
   href,
   linkLabel,
+  linkIcon = '↗',
+  external = true,
   reverse = false,
   children,
 }: {
@@ -214,6 +218,8 @@ function SystemChapter({
   description: string;
   href: string;
   linkLabel: string;
+  linkIcon?: string;
+  external?: boolean;
   reverse?: boolean;
   children: React.ReactNode;
 }) {
@@ -230,12 +236,12 @@ function SystemChapter({
         </Text>
         <ActionLink
           href={href}
-          target="_blank"
-          rel="noopener noreferrer"
+          target={external ? '_blank' : undefined}
+          rel={external ? 'noopener noreferrer' : undefined}
           variant="ghost"
         >
           {linkLabel}
-          <span aria-hidden="true">↗</span>
+          <span aria-hidden="true">{linkIcon}</span>
         </ActionLink>
       </div>
       <div>{children}</div>

--- a/apps/landing/src/components/Systems.tsx
+++ b/apps/landing/src/components/Systems.tsx
@@ -154,7 +154,7 @@ export function Systems() {
         </SystemChapter>
 
         <SystemChapter
-          id="knowledge-factory"
+          id="knowledge-factory-system"
           name="Knowledge Factory"
           promise="Make every run useful to the next."
           description="Signed diary entries capture decisions, incidents, procedures, and reflection with attribution. Teams turn them into content-addressed context packs, load focused guidance at runtime, and verify it against future work."

--- a/apps/landing/src/index.css
+++ b/apps/landing/src/index.css
@@ -395,6 +395,203 @@ button {
   text-transform: uppercase;
 }
 
+/* Knowledge factory entry point */
+
+.ops-visually-hidden {
+  position: absolute;
+  overflow: hidden;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  border: 0;
+  margin: -1px;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.ops-factory-section .ops-kicker {
+  color: var(--ops-identity);
+}
+
+.ops-factory-ledger {
+  overflow: hidden;
+  margin-top: 3.5rem;
+}
+
+.ops-factory-ledger-head {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  min-height: 3.25rem;
+  padding: 0 1.5rem;
+  border-bottom: 1px solid var(--ops-border);
+  background: var(--ops-identity-muted);
+  color: var(--ops-text-secondary);
+  font-family: var(--ops-font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
+  gap: 1rem;
+  text-transform: uppercase;
+}
+
+.ops-factory-ledger-head > span:last-child {
+  color: var(--ops-identity);
+  text-align: right;
+}
+
+.ops-factory-ledger ul {
+  list-style: none;
+}
+
+.ops-factory-ledger li {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  min-height: 5rem;
+  padding: 1.1rem 1.5rem;
+  border-bottom: 1px solid var(--ops-border);
+  gap: 1.5rem;
+}
+
+.ops-factory-from,
+.ops-factory-to {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.ops-factory-from {
+  justify-items: end;
+  text-align: right;
+}
+
+.ops-factory-from strong {
+  color: var(--ops-text-secondary);
+  font-weight: 500;
+  text-decoration: line-through;
+  text-decoration-color: var(--ops-border-hover);
+}
+
+.ops-factory-to strong {
+  color: var(--ops-text);
+  font-weight: 600;
+}
+
+.ops-factory-from small,
+.ops-factory-to small {
+  color: var(--ops-text-muted);
+  font-family: var(--ops-font-mono);
+  font-size: 0.66rem;
+  line-height: 1.5;
+}
+
+.ops-factory-arrow {
+  color: var(--ops-identity);
+  font-size: 0.9rem;
+}
+
+.ops-factory-chain {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: center;
+  padding: 1rem 1.5rem;
+  color: var(--ops-text-muted);
+  font-family: var(--ops-font-mono);
+  font-size: 0.64rem;
+  letter-spacing: 0.08em;
+  gap: 0.75rem;
+  text-transform: uppercase;
+}
+
+.ops-factory-audiences {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  margin-top: 2rem;
+  gap: 1.5rem;
+}
+
+.ops-factory-audience {
+  display: grid;
+  align-content: start;
+  gap: 1rem;
+}
+
+.ops-factory-audience ul {
+  display: grid;
+  gap: 0.9rem;
+  list-style: none;
+}
+
+.ops-factory-audience li {
+  display: grid;
+  grid-template-columns: 1.25rem 1fr;
+  color: var(--ops-text-secondary);
+  font-size: 0.92rem;
+  line-height: 1.6;
+  gap: 0.5rem;
+}
+
+.ops-factory-audience li > span:first-child {
+  color: var(--ops-identity);
+  font-size: 0.8rem;
+  line-height: 1.85;
+}
+
+.ops-factory-byproduct {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr);
+  align-items: start;
+  margin-top: 3.5rem;
+  padding-top: 3rem;
+  border-top: 1px solid var(--ops-border);
+  gap: 2.5rem 3rem;
+}
+
+.ops-factory-byproduct > div:first-child {
+  display: grid;
+  gap: 1.1rem;
+}
+
+.ops-factory-links {
+  display: grid;
+  border: 1px solid var(--ops-border);
+  border-radius: 0.75rem;
+}
+
+.ops-factory-links a {
+  display: grid;
+  min-height: 4.5rem;
+  align-content: center;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--ops-border);
+  gap: 0.25rem;
+}
+
+.ops-factory-links a:last-child {
+  border-bottom: 0;
+}
+
+.ops-factory-links a:hover {
+  background: var(--ops-elevated);
+}
+
+.ops-factory-links strong {
+  color: var(--ops-text);
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.ops-factory-links span {
+  color: var(--ops-text-muted);
+  font-family: var(--ops-font-mono);
+  font-size: 0.66rem;
+}
+
+.ops-factory-byproduct > a {
+  grid-column: 1 / -1;
+  justify-self: start;
+}
+
 /* Execution trace */
 
 .ops-trace-section {
@@ -1256,6 +1453,10 @@ button {
     min-height: 17rem;
     border-bottom: 1px solid var(--ops-border);
   }
+
+  .ops-factory-byproduct {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 820px) {
@@ -1328,6 +1529,38 @@ button {
 
   .ops-system-chapter.is-reverse > :first-child {
     order: initial;
+  }
+
+  .ops-factory-audiences {
+    grid-template-columns: 1fr;
+  }
+
+  .ops-factory-ledger-head {
+    grid-template-columns: 1fr auto;
+    min-height: auto;
+    padding: 1rem 1.25rem;
+  }
+
+  /* The two column captions stop meaning anything once rows stack; the
+     struck-through "before" line and the ↓ carry the direction instead. */
+  .ops-factory-ledger-head > span:last-child {
+    display: none;
+  }
+
+  .ops-factory-ledger li {
+    grid-template-columns: 1fr;
+    padding: 1.25rem;
+    justify-items: start;
+    gap: 0.6rem;
+  }
+
+  .ops-factory-from {
+    justify-items: start;
+    text-align: left;
+  }
+
+  .ops-factory-arrow {
+    transform: rotate(90deg);
   }
 
   .ops-ory-foundation {

--- a/apps/landing/src/pages/HomePage.tsx
+++ b/apps/landing/src/pages/HomePage.tsx
@@ -16,10 +16,10 @@ import { Systems } from '../components/Systems';
  * OWN-WORLD: Matte graphite control surfaces, exact rule lines, network teal
  * for work in motion, and identity amber for authority and signatures.
  *
- * STORY: Start where the loss is felt—knowledge trapped in one vendor's
- * memory—then see the three systems that keep it honest, follow one task
- * through them, inspect the authority boundary and real Console, and start a
- * supervised team pilot.
+ * STORY: See the three systems, follow one task through them, then go deeper on
+ * the pillar whose value compounds—knowledge you own rather than knowledge
+ * stranded in a vendor's memory—before inspecting the authority boundary and
+ * real Console, and starting a supervised team pilot.
  *
  * FIRST VIEWPORT: A concise claim and two actions sit beside a large three-part
  * system map seated on an Identity & Authority foundation.
@@ -51,9 +51,9 @@ export function HomePage() {
   return (
     <div className="ops-home" style={cssVariables}>
       <Hero />
-      <KnowledgeFactory />
       <ExecutionTrace />
       <Systems />
+      <KnowledgeFactory />
       <AuthorityPlane />
       <Collaboration />
       <OpenSource />

--- a/apps/landing/src/pages/HomePage.tsx
+++ b/apps/landing/src/pages/HomePage.tsx
@@ -5,6 +5,7 @@ import { Collaboration } from '../components/Collaboration';
 import { ExecutionTrace } from '../components/ExecutionTrace';
 import { GetStarted } from '../components/GetStarted';
 import { Hero } from '../components/Hero';
+import { KnowledgeFactory } from '../components/KnowledgeFactory';
 import { OpenSource } from '../components/OpenSource';
 import { Systems } from '../components/Systems';
 
@@ -15,8 +16,10 @@ import { Systems } from '../components/Systems';
  * OWN-WORLD: Matte graphite control surfaces, exact rule lines, network teal
  * for work in motion, and identity amber for authority and signatures.
  *
- * STORY: See the three systems, follow one task through them, inspect the
- * authority boundary and real Console, then start a supervised team pilot.
+ * STORY: Start where the loss is felt—knowledge trapped in one vendor's
+ * memory—then see the three systems that keep it honest, follow one task
+ * through them, inspect the authority boundary and real Console, and start a
+ * supervised team pilot.
  *
  * FIRST VIEWPORT: A concise claim and two actions sit beside a large three-part
  * system map seated on an Identity & Authority foundation.
@@ -48,6 +51,7 @@ export function HomePage() {
   return (
     <div className="ops-home" style={cssVariables}>
       <Hero />
+      <KnowledgeFactory />
       <ExecutionTrace />
       <Systems />
       <AuthorityPlane />


### PR DESCRIPTION
## Summary

- Adds a Knowledge Factory deep-dive section to the home page, placed after the three Systems chapters, so the pillar gets weight the other two already get from the execution trace and the authority plane.
- Leads with the portability stake — the context your agents build lives inside one vendor's account, in a shape you cannot export, verify, or hand to the next tool — and names both audiences it lands with: an individual owning their own conversations, and an organisation replacing per-seat, per-product memory silos.
- Frames typed dispatch and runtime policy as what makes a pack's provenance real, not as separate products. The observation that teams arrive for portable memory and inherit an audit trail survives as a consequence, not as a demotion of the other two pillars.

MoltNet is still one control plane with three pillars; this is emphasis on one of them, not a repositioning. The hero's control-plane claim, the "follow one task through the system" scroll cue, and the canonical `#knowledge-factory` anchor (nav, footer, hero system map) are all unchanged in intent — see the second commit, which walks back a first pass that pushed the emphasis too far.

## Changes

**`apps/landing/src/components/KnowledgeFactory.tsx`** (new) — the section itself:

- A **portability ledger** contrasting how knowledge is stored today (chat history, assistant memory, per-repo rules files, the wiki page) with what MoltNet stores instead (signed entry, context pack, rendered skill, verified pack). Deliberately generic — no competitor is named. Rows carry visually-hidden `Today:` / `In MoltNet:` labels so the before/after direction survives the mobile stack, where the column captions collapse and only the strike-through and arrow remain.
- **Two audience surfaces** — "Own the conversations you already had" and "One memory instead of twelve silos".
- **A closing band**, "This pillar is only worth anything because the other two hold it up", linking across to `#task-engine`, `#agent-runtime`, and `#identity-authority`.

**`apps/landing/src/components/Systems.tsx`** — chapter three now links down to the deep dive ("Why this pillar compounds ↓") instead of straight out to docs; the deep dive carries the docs link. `SystemChapter` takes optional `linkIcon` / `external` props so an in-page anchor does not inherit the docs links' `target="_blank"` treatment.

**`apps/landing/src/components/Hero.tsx`** — subhead keeps its dispatch → policy → knowledge order, with the knowledge clause sharpened from "reusable knowledge" to "knowledge you own and can carry between runtimes". The Knowledge Factory system-map card reads "portable to any runtime" instead of "context reusable".

**`apps/landing/src/pages/HomePage.tsx`** — section order and the STORY note in the page's design comment.

**`apps/landing/src/index.css`** — styles for the ledger, audience cards, and closing band, plus responsive rules at the existing 1180px and 820px breakpoints and an `.ops-visually-hidden` utility (the landing had none).

**`apps/landing/__tests__/landing.test.tsx`** — smoke render plus four content assertions: the ownership heading and ledger shape, both audience surfaces, the closing band crediting the other two pillars, and the chapter-to-deep-dive anchor being a same-tab in-page link.

## Test plan

Section order verified in a real browser (`hero → execution-trace → systems → knowledge-ownership → identity-authority → console → open-source → get-started`), with all six cross-section anchors resolving. Rendered and inspected at 1440 / 768 / 390px. The landing pins `mode="dark"` at the theme provider, so there is no light-mode variant to check.

- [x] Relevant Nx tests pass (`pnpm exec nx run @moltnet/landing:test` — 59 passed)
- [x] Relevant typecheck passes (`pnpm exec nx run @moltnet/landing:typecheck`)
- [x] Relevant lint passes (`pnpm exec nx run @moltnet/landing:lint`)
- [x] Docs and examples are updated when the user-facing behavior changes — no doc changes needed; the section links out to the existing `understand/knowledge-factory` page rather than restating it

https://claude.ai/code/session_01HkgsiMCPYqt7gAcv8J4veA

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkgsiMCPYqt7gAcv8J4veA)_