### PR TITLE
fix: use Node SDK entry for OS keyring secret resolution

### DIFF
--- a/apps/issue-lifecycle/package.json
+++ b/apps/issue-lifecycle/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@themoltnet/github-agent": "workspace:*",
+    "@themoltnet/os-keyring": "workspace:*",
     "@themoltnet/sdk": "workspace:*",
     "absurd-sdk": "catalog:",
     "pino": "catalog:",

--- a/apps/issue-lifecycle/src/main.ts
+++ b/apps/issue-lifecycle/src/main.ts
@@ -1,4 +1,4 @@
-import { connect } from '@themoltnet/sdk';
+import { connect } from '@themoltnet/sdk/node';
 import pino from 'pino';
 
 import {

--- a/apps/issue-lifecycle/tsconfig.lib.json
+++ b/apps/issue-lifecycle/tsconfig.lib.json
@@ -13,6 +13,9 @@
       "path": "../../libs/sdk/tsconfig.lib.json"
     },
     {
+      "path": "../../libs/os-keyring/tsconfig.lib.json"
+    },
+    {
       "path": "../../packages/github-agent/tsconfig.lib.json"
     },
     {

--- a/apps/multi-lens-review/package.json
+++ b/apps/multi-lens-review/package.json
@@ -36,6 +36,7 @@
     "smoke:pack": "tsx ../../tools/src/smoke-pack.ts --package . --bin moltnet-multi-lens-review --args --help --expect \"preflight is read-only\""
   },
   "dependencies": {
+    "@themoltnet/os-keyring": "workspace:*",
     "@themoltnet/sdk": "workspace:*",
     "absurd-sdk": "catalog:",
     "pino": "catalog:"

--- a/apps/multi-lens-review/src/main.ts
+++ b/apps/multi-lens-review/src/main.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 
-import { connect } from '@themoltnet/sdk';
+import { connect } from '@themoltnet/sdk/node';
 import { createSdkTaskClient } from '@themoltnet/tasks-orchestrator';
 import pino from 'pino';
 

--- a/apps/multi-lens-review/tsconfig.lib.json
+++ b/apps/multi-lens-review/tsconfig.lib.json
@@ -14,6 +14,9 @@
     },
     {
       "path": "../../libs/sdk/tsconfig.lib.json"
+    },
+    {
+      "path": "../../libs/os-keyring/tsconfig.lib.json"
     }
   ]
 }

--- a/libs/pi-extension/eslint.config.mjs
+++ b/libs/pi-extension/eslint.config.mjs
@@ -5,7 +5,13 @@ import baseConfig, {
 export default [
   ...baseConfig,
   createNxDependencyChecksConfig({
-    ignoredDependencies: ['@earendil-works/pi-ai', '@moltnet/crypto-service'],
+    ignoredDependencies: [
+      '@earendil-works/pi-ai',
+      '@moltnet/crypto-service',
+      // Dynamically imported by @themoltnet/sdk/node for OS keyring
+      // secret resolution; not directly imported by this package.
+      '@themoltnet/os-keyring',
+    ],
   }),
   {
     files: ['src/**/*.ts'],

--- a/libs/pi-extension/package.json
+++ b/libs/pi-extension/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "@earendil-works/gondolin": "catalog:",
+    "@themoltnet/os-keyring": "workspace:*",
     "@themoltnet/pi-runtime": "workspace:*",
     "@themoltnet/sdk": "workspace:*"
   },

--- a/libs/pi-extension/scripts/check-loader-bundle.mjs
+++ b/libs/pi-extension/scripts/check-loader-bundle.mjs
@@ -6,7 +6,13 @@ const distPath = join(import.meta.dirname, '..', 'dist', 'index.js');
 const dist = readFileSync(distPath, 'utf8');
 
 for (const dependency of ['@themoltnet/pi-runtime', '@themoltnet/sdk']) {
-  if (!dist.includes(`from "${dependency}"`)) {
+  // Accept both the isomorphic entry ("@themoltnet/sdk") and the Node
+  // entry ("@themoltnet/sdk/node") — the Node entry is required for OS
+  // keyring secret resolution.
+  const importMatched =
+    dist.includes(`from "${dependency}"`) ||
+    dist.includes(`from "${dependency}/node"`);
+  if (!importMatched) {
     process.stderr.write(
       `FAIL: pi-extension must import the published ${dependency} package\n`,
     );

--- a/libs/pi-extension/scripts/smoke-pi-loader.mjs
+++ b/libs/pi-extension/scripts/smoke-pi-loader.mjs
@@ -107,15 +107,11 @@ const tarballs = [
   pack('libs/pi-runtime'),
   pack('libs/pi-extension'),
 ];
-const install = spawnSync(
-  'npm',
-  ['install', ...tarballs, '--no-audit', '--no-fund', '--loglevel=error'],
-  {
-    cwd: installDir,
-    encoding: 'utf8',
-    env: { ...process.env, npm_config_cache: npmCache },
-  },
-);
+const install = spawnSync('pnpm', ['add', ...tarballs, '--ignore-scripts'], {
+  cwd: installDir,
+  encoding: 'utf8',
+  env: { ...process.env, npm_config_cache: npmCache },
+});
 if (install.status !== 0) {
   fail(
     'npm install of the packed pi-extension dependency set failed',

--- a/libs/pi-extension/src/index.ts
+++ b/libs/pi-extension/src/index.ts
@@ -43,7 +43,7 @@ import {
   resumeVm,
   type SandboxConfig,
 } from '@themoltnet/pi-runtime';
-import { connect } from '@themoltnet/sdk';
+import { connect } from '@themoltnet/sdk/node';
 
 import type { ExtensionState, TrackedError } from './commands/index.js';
 import {

--- a/libs/pi-extension/tsconfig.lib.json
+++ b/libs/pi-extension/tsconfig.lib.json
@@ -27,6 +27,9 @@
     },
     {
       "path": "../sdk/tsconfig.lib.json"
+    },
+    {
+      "path": "../os-keyring/tsconfig.lib.json"
     }
   ]
 }

--- a/libs/pi-runtime/eslint.config.mjs
+++ b/libs/pi-runtime/eslint.config.mjs
@@ -16,6 +16,9 @@ export default [
       '@noble/ed25519',
       '@noble/hashes',
       'multiformats',
+      // Dynamically imported by @themoltnet/sdk/node for OS keyring
+      // secret resolution; not directly imported by this package.
+      '@themoltnet/os-keyring',
     ],
   }),
   {

--- a/libs/pi-runtime/package.json
+++ b/libs/pi-runtime/package.json
@@ -42,6 +42,7 @@
     "@noble/hashes": "catalog:",
     "@opentelemetry/api": "catalog:",
     "@themoltnet/agent-runtime": "workspace:*",
+    "@themoltnet/os-keyring": "workspace:*",
     "@themoltnet/sdk": "workspace:*",
     "@themoltnet/shell-command-analyzer": "workspace:*",
     "multiformats": "catalog:",

--- a/libs/pi-runtime/scripts/smoke-packed-analyzer.mjs
+++ b/libs/pi-runtime/scripts/smoke-packed-analyzer.mjs
@@ -96,15 +96,11 @@ try {
     pack('libs/pi-runtime'),
   ];
 
-  const install = spawnSync(
-    'npm',
-    ['install', ...tarballs, '--no-audit', '--no-fund', '--loglevel=error'],
-    {
-      cwd: installDir,
-      encoding: 'utf8',
-      env: { ...process.env, npm_config_cache: npmCache },
-    },
-  );
+  const install = spawnSync('pnpm', ['add', ...tarballs, '--ignore-scripts'], {
+    cwd: installDir,
+    encoding: 'utf8',
+    env: { ...process.env, npm_config_cache: npmCache },
+  });
   if (install.status !== 0) {
     cleanup();
     fail(

--- a/libs/pi-runtime/scripts/smoke-packed-analyzer.mjs
+++ b/libs/pi-runtime/scripts/smoke-packed-analyzer.mjs
@@ -31,7 +31,13 @@ const publishedRuntimeDependencies = [
   '@themoltnet/shell-command-analyzer',
 ];
 for (const dependency of publishedRuntimeDependencies) {
-  if (!bundle.includes(`from "${dependency}"`)) {
+  // Accept both the isomorphic entry ("@themoltnet/sdk") and the Node
+  // entry ("@themoltnet/sdk/node") — the Node entry is required for OS
+  // keyring secret resolution.
+  const importMatched =
+    bundle.includes(`from "${dependency}"`) ||
+    bundle.includes(`from "${dependency}/node"`);
+  if (!importMatched) {
     fail(`pi-runtime must import the published ${dependency} package`);
   }
 }

--- a/libs/pi-runtime/src/runtime/execute-pi-task.ts
+++ b/libs/pi-runtime/src/runtime/execute-pi-task.ts
@@ -51,7 +51,7 @@ import {
   traceRuntimePhase,
   validateTaskOutput,
 } from '@themoltnet/agent-runtime';
-import { connect } from '@themoltnet/sdk';
+import { connect } from '@themoltnet/sdk/node';
 import { ShellCommandAnalyzer } from '@themoltnet/shell-command-analyzer';
 
 import { resolvePiCodingAgentDir } from '../config.js';

--- a/libs/pi-runtime/tsconfig.lib.json
+++ b/libs/pi-runtime/tsconfig.lib.json
@@ -28,6 +28,9 @@
       "path": "../sdk/tsconfig.lib.json"
     },
     {
+      "path": "../os-keyring/tsconfig.lib.json"
+    },
+    {
       "path": "../agent-runtime/tsconfig.lib.json"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -820,6 +820,9 @@ importers:
       '@themoltnet/github-agent':
         specifier: workspace:*
         version: link:../../packages/github-agent
+      '@themoltnet/os-keyring':
+        specifier: workspace:*
+        version: link:../../libs/os-keyring
       '@themoltnet/sdk':
         specifier: workspace:*
         version: link:../../libs/sdk
@@ -1150,6 +1153,9 @@ importers:
 
   apps/multi-lens-review:
     dependencies:
+      '@themoltnet/os-keyring':
+        specifier: workspace:*
+        version: link:../../libs/os-keyring
       '@themoltnet/sdk':
         specifier: workspace:*
         version: link:../../libs/sdk
@@ -2280,6 +2286,9 @@ importers:
       '@earendil-works/gondolin':
         specifier: 'catalog:'
         version: 0.9.1
+      '@themoltnet/os-keyring':
+        specifier: workspace:*
+        version: link:../os-keyring
       '@themoltnet/pi-runtime':
         specifier: workspace:*
         version: link:../pi-runtime
@@ -2332,6 +2341,9 @@ importers:
       '@themoltnet/agent-runtime':
         specifier: workspace:*
         version: link:../agent-runtime
+      '@themoltnet/os-keyring':
+        specifier: workspace:*
+        version: link:../os-keyring
       '@themoltnet/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -15606,7 +15618,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@25.1.0)(@vitest/ui@3.2.4)(jiti@2.7.0)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.19)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
 
   '@vitest/utils@3.2.4':
     dependencies:

--- a/tools/src/check-pack.ts
+++ b/tools/src/check-pack.ts
@@ -45,8 +45,12 @@ export function getTarballEntries(pkgDir: string): string[] {
     cwd: pkgDir,
     encoding: 'utf-8',
   });
-  const parsed = JSON.parse(output) as { files: PackEntry[] }[];
-  return (parsed[0]?.files ?? []).map((e) => e.path);
+  const parsed = JSON.parse(output) as
+    | { files: PackEntry[] }[]
+    | Record<string, { files: PackEntry[] }>;
+  // npm <12 returns an array; npm 12+ returns a dict keyed by package name.
+  const entry = Array.isArray(parsed) ? parsed[0] : Object.values(parsed)[0];
+  return (entry?.files ?? []).map((e) => e.path);
 }
 
 /**


### PR DESCRIPTION
## Problem

After migrating OAuth2 client secrets to the OS keyring, agent configs use `client_secret_ref` with `provider: "os-keyring"`:

```json
"client_secret_ref": {
  "provider": "os-keyring",
  "key": "oauth2/<identity_id>/<client_id>"
}
```

Several packages imported `connect` from `@themoltnet/sdk` — the **isomorphic** entry point — which only registers `EnvironmentSecretProvider`. When `resolveConnection()` tried to resolve the `os-keyring` secret reference, the provider wasn't registered, causing:

```
Extension error: Unable to resolve OAuth2 client secret.
  at resolveConnection (…/sdk/dist/assets/connect-…js:721:11)
```

Additionally, `@themoltnet/os-keyring` is only an **optional peer dependency** of the SDK, so it wasn't installed in the runtime `node_modules` of these packages.

## Fix

Switch runtime `connect()` imports to `@themoltnet/sdk/node` (which auto-registers `OSKeyringSecretProvider` via `createNodeSecretProviderRegistry()`) and add `@themoltnet/os-keyring` as an explicit dependency in:

- `libs/pi-extension` — `src/index.ts`
- `libs/pi-runtime` — `src/runtime/execute-pi-task.ts`
- `apps/multi-lens-review` — `src/main.ts`
- `apps/issue-lifecycle` — `src/main.ts`

Also relax the smoke-script import assertions to accept either the isomorphic or Node SDK entry.

## Already correct (no changes needed)

- **agent-daemon** — already imports `createNodeSecretProviderRegistry` from `@themoltnet/sdk/node` and passes it explicitly to `connect()`. Already declares `@themoltnet/os-keyring`.
- **console-e2e** / **node-red-contrib-core** — pass explicit `clientId`/`clientSecret`, never hit the secret provider path.

## Depends on

- **#1874** (npm 12 compatibility for check-pack and smoke scripts) — must be merged first to keep CI green.

<!-- legreffier-correlation: 4420f967-f6e5-4f5a-afce-de915fcfb2dd -->
