### PR TITLE
fix: npm 12 compatibility for check-pack and smoke scripts

### DIFF
--- a/libs/pi-extension/scripts/smoke-pi-loader.mjs
+++ b/libs/pi-extension/scripts/smoke-pi-loader.mjs
@@ -107,15 +107,11 @@ const tarballs = [
   pack('libs/pi-runtime'),
   pack('libs/pi-extension'),
 ];
-const install = spawnSync(
-  'npm',
-  ['install', ...tarballs, '--no-audit', '--no-fund', '--loglevel=error'],
-  {
-    cwd: installDir,
-    encoding: 'utf8',
-    env: { ...process.env, npm_config_cache: npmCache },
-  },
-);
+const install = spawnSync('pnpm', ['add', ...tarballs, '--ignore-scripts'], {
+  cwd: installDir,
+  encoding: 'utf8',
+  env: { ...process.env, npm_config_cache: npmCache },
+});
 if (install.status !== 0) {
   fail(
     'npm install of the packed pi-extension dependency set failed',

--- a/libs/pi-runtime/scripts/smoke-packed-analyzer.mjs
+++ b/libs/pi-runtime/scripts/smoke-packed-analyzer.mjs
@@ -96,15 +96,11 @@ try {
     pack('libs/pi-runtime'),
   ];
 
-  const install = spawnSync(
-    'npm',
-    ['install', ...tarballs, '--no-audit', '--no-fund', '--loglevel=error'],
-    {
-      cwd: installDir,
-      encoding: 'utf8',
-      env: { ...process.env, npm_config_cache: npmCache },
-    },
-  );
+  const install = spawnSync('pnpm', ['add', ...tarballs, '--ignore-scripts'], {
+    cwd: installDir,
+    encoding: 'utf8',
+    env: { ...process.env, npm_config_cache: npmCache },
+  });
   if (install.status !== 0) {
     cleanup();
     fail(

--- a/tools/src/check-pack.ts
+++ b/tools/src/check-pack.ts
@@ -45,8 +45,12 @@ export function getTarballEntries(pkgDir: string): string[] {
     cwd: pkgDir,
     encoding: 'utf-8',
   });
-  const parsed = JSON.parse(output) as { files: PackEntry[] }[];
-  return (parsed[0]?.files ?? []).map((e) => e.path);
+  const parsed = JSON.parse(output) as
+    | { files: PackEntry[] }[]
+    | Record<string, { files: PackEntry[] }>;
+  // npm <12 returns an array; npm 12+ returns a dict keyed by package name.
+  const entry = Array.isArray(parsed) ? parsed[0] : Object.values(parsed)[0];
+  return (entry?.files ?? []).map((e) => e.path);
 }
 
 /**


### PR DESCRIPTION
## Problem

npm 12 (shipped with Node 24) changed two behaviours that break CI `check:pack` tasks when they are not cached:

1. **`npm pack --dry-run --json`** now returns a dict keyed by package name instead of an array. The `check-pack.ts` tool expected an array, so it returned an empty file list → "dist/index.js missing from tarball".

2. **`npm install` in project-scoped installs** rejects packages with postinstall scripts (`EALLOWSCRIPTS`). The pi-extension and pi-runtime smoke scripts use `npm install` to set up a temporary consumer project, so they fail on npm 12.

## Fix

1. Update `getTarballEntries()` in `tools/src/check-pack.ts` to handle both array (npm <12) and dict (npm 12+) output formats.

2. Switch the smoke scripts from `npm install` to `pnpm add --ignore-scripts` — the smoke tests only need the packages extracted into `node_modules`, not their postinstall hooks.

## Scope

This is a pre-existing tooling issue, not related to any feature change. It was exposed when a cache miss forced `check:pack` to run fresh.