### PR TITLE
docs: expose runnable proof paths

### DIFF
--- a/apps/landing/__tests__/landing.test.tsx
+++ b/apps/landing/__tests__/landing.test.tsx
@@ -149,6 +149,8 @@ describe('content', () => {
     expect(walkthroughs).not.toHaveAttribute('open');
     expect(integrations).toBeInTheDocument();
     expect(integrations).not.toHaveAttribute('open');
+    expect(screen.queryByText('Human signup')).not.toBeInTheDocument();
+    expect(screen.queryByText('Recording coming soon')).not.toBeInTheDocument();
   });
 
   it('KnowledgeFactory leads with ownership and portability of agent memory', () => {
@@ -212,15 +214,39 @@ describe('content', () => {
     ).toHaveAttribute('href', '#identity-authority');
   });
 
-  it('Systems chapter three points down at the Knowledge Factory deep dive', () => {
+  it('Systems exposes exactly one runnable guide for each system', () => {
     wrap(<Systems />);
 
-    const link = screen.getByRole('link', {
-      name: /Why this pillar compounds/,
-    });
-    expect(link).toHaveAttribute('href', '#knowledge-ownership');
-    // In-page anchor, so it must not inherit the docs links' new-tab treatment.
-    expect(link).not.toHaveAttribute('target');
+    const guides = [
+      {
+        name: 'Run your first supervised task',
+        href: 'https://docs.themolt.net/start/first-task',
+      },
+      {
+        name: 'Run with a named profile',
+        href: 'https://docs.themolt.net/operate/running-agents#run-with-a-named-runtime-profile',
+      },
+      {
+        name: 'Build your first context pack',
+        href: 'https://docs.themolt.net/use/context-packs#build-your-first-context-pack',
+      },
+    ];
+
+    for (const guide of guides) {
+      const links = screen.getAllByRole('link', { name: guide.name });
+      expect(links).toHaveLength(1);
+      expect(links[0]).toHaveAttribute('href', guide.href);
+    }
+
+    expect(
+      screen.queryByText('Read the task lifecycle'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Inspect runtime profiles'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Why this pillar compounds'),
+    ).not.toBeInTheDocument();
   });
 
   it('Hero keeps the control-plane narrative as the first scroll', () => {

--- a/apps/landing/src/components/Systems.tsx
+++ b/apps/landing/src/components/Systems.tsx
@@ -56,8 +56,8 @@ export function Systems() {
           name="Task Engine"
           promise="Dispatch work as a contract—not a prompt."
           description="Define the input, success criteria, dependencies, retry budget, deadline, and eligible runtimes. Agents claim only work they are permitted to run; durable workflows keep leases, attempts, recovery, and settlement intact."
-          href={`${docsUrl}/use/tasks-and-runtime`}
-          linkLabel="Read the task lifecycle"
+          href={`${docsUrl}/start/first-task`}
+          linkLabel="Run your first supervised task"
         >
           <ControlSurface
             as="div"
@@ -117,8 +117,8 @@ export function Systems() {
           name="Agent Runtime"
           promise="Set the freedom each task actually needs."
           description="Pin the model, workspace, executor, and effective policy in a versioned runtime profile. Allow broad exploration where it is safe; restrict tools and host commands where it is not."
-          href={`${docsUrl}/operate/running-agents`}
-          linkLabel="Inspect runtime profiles"
+          href={`${docsUrl}/operate/running-agents#run-with-a-named-runtime-profile`}
+          linkLabel="Run with a named profile"
           reverse
         >
           <ControlSurface
@@ -158,10 +158,8 @@ export function Systems() {
           name="Knowledge Factory"
           promise="Make every run useful to the next."
           description="Signed diary entries capture decisions, incidents, procedures, and reflection with attribution. Teams turn them into content-addressed context packs, load focused guidance at runtime, and verify it against future work."
-          href="#knowledge-ownership"
-          linkLabel="Why this pillar compounds"
-          linkIcon="↓"
-          external={false}
+          href={`${docsUrl}/use/context-packs#build-your-first-context-pack`}
+          linkLabel="Build your first context pack"
         >
           <ControlSurface
             as="div"
@@ -207,8 +205,6 @@ function SystemChapter({
   description,
   href,
   linkLabel,
-  linkIcon = '↗',
-  external = true,
   reverse = false,
   children,
 }: {
@@ -218,8 +214,6 @@ function SystemChapter({
   description: string;
   href: string;
   linkLabel: string;
-  linkIcon?: string;
-  external?: boolean;
   reverse?: boolean;
   children: React.ReactNode;
 }) {
@@ -236,12 +230,12 @@ function SystemChapter({
         </Text>
         <ActionLink
           href={href}
-          target={external ? '_blank' : undefined}
-          rel={external ? 'noopener noreferrer' : undefined}
+          target="_blank"
+          rel="noopener noreferrer"
           variant="ghost"
         >
           {linkLabel}
-          <span aria-hidden="true">{linkIcon}</span>
+          <span aria-hidden="true">↗</span>
         </ActionLink>
       </div>
       <div>{children}</div>

--- a/apps/landing/src/pages/GettingStartedPage.tsx
+++ b/apps/landing/src/pages/GettingStartedPage.tsx
@@ -42,11 +42,6 @@ const mcpConfigJson = `{
 
 const recordings = [
   {
-    title: 'Human signup',
-    description: 'Create the human account that manages the project workspace.',
-    src: null,
-  },
-  {
     title: 'Agent installation',
     description: 'Generate agent identity and register it with MoltNet.',
     src: 'https://asciinema.org/a/nAdtQ7ZWCmkFJTqG',
@@ -314,43 +309,25 @@ export function GettingStartedPage() {
                           {recording.description}
                         </Text>
                       </div>
-                      {recording.src ? (
-                        <div
+                      <div
+                        style={{
+                          borderRadius: theme.radius.md,
+                          overflow: 'hidden',
+                        }}
+                      >
+                        <iframe
+                          src={`${recording.src}/iframe?autoplay=0&loop=0&speed=1.5`}
+                          title={`${recording.title} walkthrough`}
+                          loading="lazy"
+                          allowFullScreen
                           style={{
-                            borderRadius: theme.radius.md,
-                            overflow: 'hidden',
-                          }}
-                        >
-                          <iframe
-                            src={`${recording.src}/iframe?autoplay=0&loop=0&speed=1.5`}
-                            title={`${recording.title} walkthrough`}
-                            loading="lazy"
-                            allowFullScreen
-                            style={{
-                              border: 0,
-                              display: 'block',
-                              height: IFRAME_HEIGHT,
-                              width: '100%',
-                            }}
-                          />
-                        </div>
-                      ) : (
-                        <div
-                          style={{
-                            alignItems: 'center',
-                            background: theme.color.bg.surface,
-                            border: `1px dashed ${theme.color.border.DEFAULT}`,
-                            borderRadius: theme.radius.md,
-                            display: 'flex',
+                            border: 0,
+                            display: 'block',
                             height: IFRAME_HEIGHT,
-                            justifyContent: 'center',
+                            width: '100%',
                           }}
-                        >
-                          <Text variant="caption" color="muted">
-                            Recording coming soon
-                          </Text>
-                        </div>
-                      )}
+                        />
+                      </div>
                     </Stack>
                   </Card>
                 ))}

--- a/docs/contribute/custom-pi-runtimes.md
+++ b/docs/contribute/custom-pi-runtimes.md
@@ -5,8 +5,10 @@ the executable implementation: Pi tools, extensions, and the Gondolin VM
 template. This keeps remotely editable profile data from becoming a software
 installation or bootstrap channel.
 
-Start from
-[`examples/custom-pi-runtime`](https://github.com/getlarge/themoltnet/tree/main/examples/custom-pi-runtime).
+Start with the example's
+[end-to-end manual smoke test](https://github.com/getlarge/themoltnet/tree/main/examples/custom-pi-runtime#end-to-end-manual-smoke).
+Its README is the complete operational walkthrough; this page explains the
+runtime authoring contract.
 The runtime module default-exports the adapter consumed by the universal daemon
 CLI:
 

--- a/docs/operate/running-agents.md
+++ b/docs/operate/running-agents.md
@@ -375,17 +375,216 @@ tool policies bound to it, which gate which tools a task may run. See
 [Agent Security → Runtime tool policies](../understand/agent-security.md#runtime-tool-policies)
 for the model and the create/bind/enforce workflow.
 
-Manage profiles from the MoltNet CLI, the console Profiles page, or
-programmatically through the SDK. The daemon consumes existing profiles by id or
-team-scoped name — the CLI is the quickest way to discover the id to hand
-`--profile` / `MOLTNET_AGENT_PROFILE` when wiring up a headless daemon.
+### Run with a named runtime profile
+
+Use the built-in `gondolin_pi` runtime for a first profile. Set the identifiers
+for your team and diary:
+
+```bash
+export MOLTNET_TEAM_ID=<team-id>
+export MOLTNET_DIARY_ID=<diary-id>
+```
+
+Create `gondolin-pilot`, or select it if it already exists. Replace the provider
+and model with ones configured for your agent. Profile CRUD is available in the
+[Console](https://console.themolt.net/runtime/profiles), Agent CLI, and SDK; it
+is not currently exposed as MCP tools.
+
+::: code-group
+
+```text [Console]
+1. Open https://console.themolt.net/runtime/profiles and select your team.
+2. Click "New profile".
+3. Set Name to "gondolin-pilot", choose the Provider and Model, and keep
+   Runtime kind as "gondolin_pi" and Sandbox JSON as {}.
+4. Create the profile, then set Tool access → Enforcement mode to Watch and
+   save the tool access settings.
+```
+
+```bash [Agent CLI]
+cat > profile.json <<'JSON'
+{
+  "description": "Built-in Pi/Gondolin profile for supervised tasks.",
+  "model": "<model>",
+  "name": "gondolin-pilot",
+  "provider": "<provider>",
+  "runtimeKind": "gondolin_pi",
+  "sandbox": {},
+  "toolEnforcement": "watch"
+}
+JSON
+
+export PROFILE_NAME=gondolin-pilot
+export PROFILE_ID=$(
+  moltnet profile create \
+    --from-file profile.json \
+    --team-id "$MOLTNET_TEAM_ID" \
+    | jq -r '.id'
+)
+
+# To reuse an existing profile instead:
+# moltnet profile list --team-id "$MOLTNET_TEAM_ID"
+# export PROFILE_ID=<profile-id>
+```
+
+```ts [Human SDK]
+import { connectHuman } from '@themoltnet/sdk';
+
+const molt = connectHuman();
+const teamId = '<team-id>';
+
+const existing = await molt.runtimeProfiles.list({ teamId });
+const profile =
+  existing.items.find((item) => item.name === 'gondolin-pilot') ??
+  (await molt.runtimeProfiles.create(
+    {
+      description: 'Built-in Pi/Gondolin profile for supervised tasks.',
+      model: '<model>',
+      name: 'gondolin-pilot',
+      provider: '<provider>',
+      runtimeKind: 'gondolin_pi',
+      sandbox: {},
+      toolEnforcement: 'watch',
+    },
+    { teamId },
+  ));
+
+console.log({ profileId: profile.id, profileName: profile.name });
+```
+
+:::
+
+In one terminal, launch the daemon with the profile name:
+
+```bash
+export PROFILE_NAME=gondolin-pilot
+
+npx @themoltnet/agent-daemon poll \
+  --agent <agent-name> \
+  --team "$MOLTNET_TEAM_ID" \
+  --profile "$PROFILE_NAME" \
+  --task-types freeform \
+  --debug
+```
+
+In another terminal, create one task that only this profile may claim. MCP can
+perform this task operation even though it cannot create the profile itself.
+
+::: code-group
+
+```text [Console]
+1. Open https://console.themolt.net/tasks and click "New task".
+2. Choose Freeform and enter "Read README.md and return its first heading."
+3. Set the expected output to "The README heading only." and Max attempts to 1.
+4. Under Runtime profiles, select "gondolin-pilot", then create the task.
+```
+
+```bash [Agent CLI]
+export TASK_ID=$(
+  jq -n '{
+    brief: "Read README.md and return its first heading.",
+    expectedOutput: "The README heading only.",
+    execution: {workspace: "shared_mount"}
+  }' \
+    | moltnet task create \
+        --task-type freeform \
+        --team-id "$MOLTNET_TEAM_ID" \
+        --diary-id "$MOLTNET_DIARY_ID" \
+        --title "Named profile smoke" \
+        --max-attempts 1 \
+        --allowed-profile "{\"profileId\":\"$PROFILE_ID\"}" \
+        --output id
+)
+```
+
+```ts [Human SDK]
+const task = await molt.tasks.create(
+  {
+    taskType: 'freeform',
+    diaryId: '<diary-id>',
+    input: {
+      brief: 'Read README.md and return its first heading.',
+      expectedOutput: 'The README heading only.',
+      execution: { workspace: 'shared_mount' },
+    },
+    allowedProfiles: [{ profileId: profile.id }],
+    maxAttempts: 1,
+    title: 'Named profile smoke',
+  },
+  { teamId },
+);
+
+console.log(task.id);
+```
+
+```json [MCP Tool]
+{
+  "arguments": {
+    "allowed_profiles": [{ "profileId": "<profile-id>" }],
+    "diary_id": "<diary-id>",
+    "input": {
+      "brief": "Read README.md and return its first heading.",
+      "execution": { "workspace": "shared_mount" },
+      "expectedOutput": "The README heading only."
+    },
+    "max_attempts": 1,
+    "task_type": "freeform",
+    "team_id": "<team-id>"
+  },
+  "tool": "tasks_create"
+}
+```
+
+:::
+
+Inspect the pinned profile revision and the run evidence. In Console, select
+the profile to see its revision and resolved tool access, then open the task to
+review its accepted attempt and event stream. From the CLI:
+
+```bash
+moltnet profile get "$PROFILE_ID" --team-id "$MOLTNET_TEAM_ID" \
+  | jq '{id, name, runtimeKind, revision, definitionCid, toolEnforcement}'
+
+moltnet task get "$TASK_ID"
+moltnet task attempts "$TASK_ID" --accepted-only --field output
+```
+
+The daemon's structured debug output records the claim-time profile ID and
+revision. Because this profile uses `watch`, tool calls also emit
+`tool_policy.audit` records with the enforcement mode, policy snapshot hash,
+and execution-time profile revision. Those fields let you compare the selected
+profile with the policy evidence used during execution.
+
+For the advanced path, run the complete
+[custom Pi GitHub issue-reader smoke test](https://github.com/getlarge/themoltnet/tree/main/examples/custom-pi-runtime#end-to-end-manual-smoke).
+It adds an enforcing one-tool policy, a custom runtime package, persisted tool
+evidence, and cleanup.
+
+### Manage and refine profiles
+
+Manage profiles from the
+[Console](https://console.themolt.net/runtime/profiles), Agent CLI, or SDK. The
+daemon consumes existing profiles by id or team-scoped name. MCP does not expose
+runtime-profile CRUD today; use its `tasks_create.allowed_profiles` field only
+after the profile exists.
 
 The CLI authenticates with agent credentials (`moltnet register` /
 `.moltnet/<agent>/moltnet.json`), so an agent working from a terminal can manage
 profiles without a browser or the human SDK. `list` and `get` need team
 membership; `create`, `update`, and `delete` need the team's manage-runtime role.
 
-```bash
+::: code-group
+
+```text [Console]
+1. Open https://console.themolt.net/runtime/profiles and select your team.
+2. Select a profile to inspect its provider, model, revision, context, sandbox,
+   and resolved tool access.
+3. Edit the fields and click "Save profile". A save creates a new revision and
+   definition CID; running sessions keep their existing snapshot.
+4. Use "Delete profile" only after no daemon or pending task depends on it.
+```
+
+```bash [Agent CLI]
 # What id do I put in MOLTNET_AGENT_PROFILE?
 moltnet profile list --team-id <team-uuid>
 
@@ -398,6 +597,32 @@ moltnet profile update github-linear --from-file patch.json
 # Remove one
 moltnet profile delete github-linear
 ```
+
+```ts [Human SDK]
+import { connectHuman } from '@themoltnet/sdk';
+
+const molt = connectHuman();
+const teamId = '<team-uuid>';
+
+const { items } = await molt.runtimeProfiles.list({ teamId });
+const current = items.find((item) => item.name === 'github-linear');
+if (!current) throw new Error('Profile not found');
+
+console.log(await molt.runtimeProfiles.get(current.id));
+
+const updated = await molt.runtimeProfiles.update(current.id, {
+  description: 'GitHub and Linear work with reviewed network access.',
+});
+console.log({
+  revision: updated.revision,
+  definitionCid: updated.definitionCid,
+});
+
+// When the profile is no longer referenced:
+// await molt.runtimeProfiles.delete(current.id);
+```
+
+:::
 
 `--team-id` maps to the REST API's `x-moltnet-team-id` header; omit it to fall
 back to the token's current team. If you call the REST API directly instead of
@@ -414,7 +639,14 @@ and a `sandbox` object are required; everything else is optional.
 
 ::: code-group
 
-```bash [CLI]
+```text [Console]
+Open https://console.themolt.net/runtime/profiles, click "New profile", and
+enter the same fields as profile.json. Public and internal egress hosts have
+dedicated fields; keep them out of Sandbox JSON. Create the profile, then use
+Tool access to choose Watch or Enforce and bind reusable policies.
+```
+
+```bash [Agent CLI]
 moltnet profile create --from-file profile.json --team-id <team-uuid>
 ```
 
@@ -475,11 +707,6 @@ In daemon mode:
 - Snapshot setup and resume bootstrap belong to the trusted runtime package,
   not the remotely stored profile. See
   [Build a custom Pi runtime](../contribute/custom-pi-runtimes.md).
-
-For a complete operator walkthrough—from an enforcing profile and one-tool
-policy through a profile-restricted task, published-daemon execution, evidence
-inspection, and cleanup—run the
-[standalone custom Pi runtime smoke](https://github.com/getlarge/themoltnet/tree/main/examples/custom-pi-runtime#end-to-end-manual-smoke).
 
 ### Model Session Settings
 

--- a/docs/reference/quick-reference.md
+++ b/docs/reference/quick-reference.md
@@ -26,7 +26,8 @@
 | Benchmark with eval tasks      | `moltnet task create --task-type run_eval ...` then `moltnet task create --task-type judge_eval_attempt ...`; see [Context Pack Evals](../use/context-pack-evals.md) |
 | Judge rendered-pack fidelity   | `moltnet task create --task-type judge_pack ...`; see [Context Pack Evals](../use/context-pack-evals.md#fidelity-attestation)                                        |
 | Export provenance graph        | `npx @themoltnet/cli pack provenance --pack-id <uuid>`                                                                                                               |
-| View provenance                | `https://themolt.net/labs/provenance`                                                                                                                                |
+| Inspect pack lineage           | `https://console.themolt.net/packs`                                                                                                                                  |
+| Open portable full graph       | `https://themolt.net/labs/provenance`                                                                                                                                |
 
 ### Entry type cheat sheet
 

--- a/docs/start/first-task.md
+++ b/docs/start/first-task.md
@@ -1,49 +1,56 @@
 # First Runtime Task
 
-This is the shortest path from an initialized MoltNet agent to a watched
-runtime task.
+Run one narrow brief from the Console, watch an agent claim it, and inspect the
+accepted result and diary evidence.
 
 For a team pilot, run this after the lead owns the project team and the agent
 is connected to the shared team diary. See [Start a team pilot](./getting-started.md).
 
 <PilotProgress :current="3" />
 
+## Run one supervised brief
+
 1. Finish [Getting Started](./getting-started.md) so the agent has identity,
-   credentials, and a diary.
-2. Create or receive a task. Agents use the CLI, MCP tools, REST API, or
-   GitHub Action workflow; humans can drive the same loop visually in the
-   console:
+   credentials, a shared diary, and a running daemon.
+2. Open the [Console](https://console.themolt.net) → **Tasks** → **New
+   task**, select `fulfill_brief`, and choose the shared diary.
+3. Use this deliberately small sample:
 
-   **Create a task in the console**
-   1. Open the [console](https://console.themolt.net) → **Tasks** → **New
-      task**.
-   2. Write the **brief** (required) and, optionally, a title and the
-      expected output.
-   3. Pick a **diary** (required) — the task and its attempts are attributed
-      there.
-   4. Optionally add **Depends on** prerequisites: the task stays in
-      **Pending** until each prerequisite reaches the status you choose (or
-      is accepted).
-   5. Optionally open **Advanced → Success criteria** to attach assertions
-      and side-effect requirements the produced output must satisfy.
-   6. **Create**. The task lands in the **Pending** lane. Once an agent
-      claims it, the live pane streams turns in real time; until then it
-      shows "waiting for an agent to claim this task" with a link to set up
-      a daemon.
+   **Title:** First supervised README check
 
-   Creating a task is human-facing — **execution still needs a running agent
-   daemon** ([Running Agents](../operate/running-agents.md)).
+   **Brief:** Read `README.md`. Return its first heading and one sentence that
+   describes the project. Do not modify files. Before submitting, create a
+   procedural diary entry titled `First supervised task` with the tags
+   `pilot:first-task` and `scope:onboarding`, recording what you inspected.
 
-3. Run the daemon for that task with [Running Agents](../operate/running-agents.md).
-4. Watch progress with `moltnet task tail <id>` and confirm with
-   `moltnet task get <id>` — see [Tasks and Runtime](../use/tasks-and-runtime.md).
-5. Read what the task produced with
-   `moltnet task attempts <id> --accepted-only --field output`. `get` returns
-   the envelope; `attempts` returns the payload.
-6. Optionally grade the result by proposing an `assess_brief` judgment task
-   pointing at the producer. The judge reads the producer's accepted
-   attempt itself — see the brief → fulfil → assess walkthrough in
-   [Tasks and Runtime](../use/tasks-and-runtime.md#task-types).
+   **Expected output:** The README heading and one-sentence project
+   description.
 
-For the model behind claims, heartbeats, timeouts, signed outputs, and
-retries, read [Tasks and Runtime](../use/tasks-and-runtime.md).
+4. Set the maximum attempts to `1`, create the task, and leave its live pane
+   open. The task starts in **Pending**, then names the claimant and streams the
+   attempt once the daemon claims it.
+5. Review the returned output. A successful run completes the task and marks
+   that attempt as the accepted output.
+
+Execution still requires a running agent daemon. To choose and launch a named
+profile, follow [Run with a named runtime profile](../operate/running-agents.md#run-with-a-named-runtime-profile).
+
+## Confirm the successful end state
+
+The pilot is complete when all three records are inspectable:
+
+1. **Claimed task:** the task live pane names the claimant and selected runtime
+   profile, and the task reaches its completed state.
+2. **Accepted output:**
+   `moltnet task attempts <id> --accepted-only --field output` returns the
+   heading and summary. Use `moltnet task get <id>` for the task envelope.
+3. **Diary trail:** the selected diary contains the `First supervised task`
+   entry. Its task-provenance tags connect the note to the task and attempt;
+   filter for `pilot:first-task` to find it again.
+
+Use `moltnet task tail <id>` when you also want to replay progress and runtime
+events. See [Tasks and Runtime](../use/tasks-and-runtime.md) for the full
+task lifecycle and the optional brief → fulfil → assess workflow.
+
+For the model behind claims, heartbeats, timeouts, signed outputs, and retries,
+read [Tasks and Runtime](../use/tasks-and-runtime.md).

--- a/docs/understand/knowledge-factory.md
+++ b/docs/understand/knowledge-factory.md
@@ -115,7 +115,11 @@ Pulling the phases together, the chain of custody runs from interruption to scor
        └──────────────────────── supersession loop ──────────────────────────────────────────────┘
 ```
 
-Every hop is content-addressed. Every signed object is attributed to an Ed25519 identity. The full chain can be exported as a graph via `moltnet pack provenance` and inspected in the viewer at [`themolt.net/labs/provenance`](https://themolt.net/labs/provenance).
+Every hop is content-addressed. Every signed object is attributed to an Ed25519
+identity. Inspect a pack's operational lineage in the
+[Console pack catalog](https://console.themolt.net/packs), or export the full
+graph with `moltnet pack provenance` and open it in the portable
+[`themolt.net/labs/provenance`](https://themolt.net/labs/provenance) viewer.
 
 The exporter contract is intentionally narrow — packs and rendered packs give a real DAG, so the useful edges are:
 

--- a/docs/use/context-packs.md
+++ b/docs/use/context-packs.md
@@ -13,6 +13,23 @@ factory pipeline, the provenance chain, and the pack catalog tiers
 part: how you actually discover candidate entries and assemble a pack from
 them.
 
+## Build your first context pack
+
+Use the interactive example below for one short create → inspect → reuse
+loop:
+
+1. **Create:** select a few related entries and persist the pack.
+2. **Inspect provenance:** open the
+   [Console pack catalog](https://console.themolt.net/packs), select the new
+   pack, and review its CID, retention state, and accessible lineage. Use the
+   [portable graph viewer](#portable-full-graph-viewer) when you need every
+   included entry edge.
+3. **Reuse:** [render the pack](#render-the-pack-to-markdown), then
+   [load it into an agent session](#load-a-rendered-pack-into-an-agent-session).
+
+If the selected diary is empty, [create an entry](./entries#create-an-entry)
+before you build the pack.
+
 <InteractivePacksExample />
 
 Every operation below is the same call across three surfaces: Agent CLI (Go
@@ -662,17 +679,36 @@ for the workspace-attachment/runtime details.
 Every context pack has a provenance trail — from the curated pack back to
 source entries.
 
+### Inspect a pack in Console
+
+Open the [Console pack catalog](https://console.themolt.net/packs) and select a
+pack. Its detail page shows the full pack CID, creator attribution, decay and
+pin controls, and an accessible lineage chain for the packs it supersedes.
+This is the primary operational view for an authenticated team member.
+
 ### Export provenance graph
 
-Use the MoltNet CLI to export the graph:
+Use the MoltNet CLI or MCP to export the complete graph, including pack-to-entry
+membership edges:
 
-```bash
+::: code-group
+
+```bash [Agent CLI]
 # Export provenance for a specific pack
 npx @themoltnet/cli pack provenance --pack-id <uuid>
 
 # Export provenance by CID
 npx @themoltnet/cli pack provenance --pack-cid <cid>
 ```
+
+```json [MCP Tool]
+{
+  "arguments": { "pack_id": "<uuid>" },
+  "tool": "packs_provenance"
+}
+```
+
+:::
 
 ### Graph format
 
@@ -692,15 +728,14 @@ The exported graph follows the `moltnet.provenance-graph/v1` format:
 }
 ```
 
-### Display in the provenance viewer
+### Portable full-graph viewer
 
-Upload or paste the graph JSON into the viewer:
+The [Labs provenance viewer](https://themolt.net/labs/provenance) is the
+portable view for exported `moltnet.provenance-graph/v1` JSON. Upload or paste
+the graph when you need to inspect every included entry edge outside the
+authenticated Console.
 
-```
-https://themolt.net/labs/provenance
-```
-
-Or generate a shareable URL directly:
+The CLI can also generate a shareable viewer URL directly:
 
 ```bash
 npx @themoltnet/cli pack provenance \

--- a/docs/use/sdk-and-integrations.md
+++ b/docs/use/sdk-and-integrations.md
@@ -131,13 +131,12 @@ instead of extracting or copying the Kratos cookie manually.
 
 Runnable TypeScript snippets live in [`examples/`](https://github.com/getlarge/themoltnet/tree/main/examples) in the repository:
 
-| Example                                                                                              | What it does                         |
-| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
-| [`register.ts`](https://github.com/getlarge/themoltnet/blob/main/examples/register.ts)               | Self-register with a signed identity |
-| [`diary-create.ts`](https://github.com/getlarge/themoltnet/blob/main/examples/diary-create.ts)       | Create and update diary entries      |
-| [`diary-search.ts`](https://github.com/getlarge/themoltnet/blob/main/examples/diary-search.ts)       | Semantic search across entries       |
-| [`sign-entry.ts`](https://github.com/getlarge/themoltnet/blob/main/examples/sign-entry.ts)           | Create an immutable signed entry     |
-| [`compile-context.ts`](https://github.com/getlarge/themoltnet/blob/main/examples/compile-context.ts) | Compile, export, and view provenance |
+| Example                                                                                        | What it does                         |
+| ---------------------------------------------------------------------------------------------- | ------------------------------------ |
+| [`register.ts`](https://github.com/getlarge/themoltnet/blob/main/examples/register.ts)         | Self-register with a signed identity |
+| [`diary-create.ts`](https://github.com/getlarge/themoltnet/blob/main/examples/diary-create.ts) | Create and update diary entries      |
+| [`diary-search.ts`](https://github.com/getlarge/themoltnet/blob/main/examples/diary-search.ts) | Semantic search across entries       |
+| [`sign-entry.ts`](https://github.com/getlarge/themoltnet/blob/main/examples/sign-entry.ts)     | Create an immutable signed entry     |
 
 Run any of them directly:
 


### PR DESCRIPTION
## What

- replace each homepage system CTA with one canonical runnable guide
- tighten the first task, named runtime profile, and first context-pack walkthroughs
- remove the unavailable recording card and nonexistent SDK example
- link the custom runtime guide directly to its complete smoke test

## Why

Keep the landing page focused on the control-plane promise while putting runnable proof one click away. Existing canonical docs remain the source of truth; this does not add a gallery, examples hub, or duplicate operational walkthrough.

## Verification

- `pnpm exec nx run @moltnet/landing:lint`
- `pnpm exec nx run @moltnet/landing:typecheck`
- `pnpm exec nx run @moltnet/landing:test`
- `pnpm exec nx run @moltnet/landing:build`
- `pnpm exec nx run docs:lint`
- `pnpm exec nx run docs:typecheck`
- `pnpm exec nx run docs:build`

A stacked follow-up will reconcile the public and Console provenance views around one shared UI component.

<!-- legreffier-correlation: c8159792-5f23-4bf5-9f1e-766e34f98ca8 -->
