### PR TITLE
fix(release): validate complete Apple signing chain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,7 +311,7 @@ jobs:
             echo "native-keyring=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if ! git diff --quiet "$NX_BASE" "$NX_HEAD" -- tools/release/agent-bundle tools/package.json apps/agent-daemon/package.json .tool-versions .github/workflows/ci.yml; then
+          if ! git diff --quiet "$NX_BASE" "$NX_HEAD" -- tools/release/agent-bundle tools/release/cli tools/package.json apps/agent-daemon/package.json apps/moltnet-cli/.goreleaser.yml .tool-versions .github/workflows/ci.yml .github/workflows/release.yml; then
             echo "agent-bundle=true" >> "$GITHUB_OUTPUT"
           else
             echo "agent-bundle=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1217,6 +1217,10 @@ jobs:
               exit 1
             fi
           done
+          cert="$RUNNER_TEMP/apple-developer-id.p12"
+          printf '%s' "$APPLE_CERT_P12" | base64 --decode > "$cert"
+          chmod 600 "$cert"
+          sh tools/release/cli/verify-apple-p12.sh --p12 "$cert"
           notary_key="$RUNNER_TEMP/AuthKey.p8"
           printf '%s\n' "$NOTARY_KEY" > "$notary_key"
           chmod 600 "$notary_key"
@@ -1244,7 +1248,7 @@ jobs:
 
       - name: Remove signing material
         if: ${{ always() }}
-        run: rm -f "$RUNNER_TEMP/release-signing-key" "$RUNNER_TEMP/AuthKey.p8"
+        run: rm -f "$RUNNER_TEMP/release-signing-key" "$RUNNER_TEMP/AuthKey.p8" "$RUNNER_TEMP/apple-developer-id.p12"
 
       - name: Upload binaries to GitHub Release
         run: |

--- a/apps/moltnet-cli/.goreleaser.yml
+++ b/apps/moltnet-cli/.goreleaser.yml
@@ -75,6 +75,8 @@ scoops:
 # downloads, so without this Gatekeeper blocks `brew install` on macOS 15+.
 # Cross-platform (quill, built into GoReleaser): runs on the Linux release
 # runner with the same Apple secrets as the agent-daemon bundle (#2063).
+# Quill requires APPLE_CERT_P12 to contain the leaf, Developer ID G2
+# intermediate, and Apple root; the release workflow validates that chain.
 # Go binaries need no entitlements (no JIT, CGO_ENABLED=0). A bare binary
 # cannot be stapled; Gatekeeper verifies the ticket online on first run.
 notarize:

--- a/apps/moltnet-cli/README.md
+++ b/apps/moltnet-cli/README.md
@@ -14,8 +14,8 @@ npm install -g @themoltnet/cli
 
 Or download a binary from [GitHub Releases](https://github.com/getlarge/themoltnet/releases).
 
-> **macOS Gatekeeper:** The binary is not Apple-notarized. If macOS blocks it, run:
-> `xattr -d com.apple.quarantine $(which moltnet)`
+> **macOS Gatekeeper:** Release binaries are Developer ID signed and notarized
+> before they are archived for Homebrew, npm, and GitHub Releases.
 
 ## Quick Start
 

--- a/docs/understand/infrastructure.md
+++ b/docs/understand/infrastructure.md
@@ -493,7 +493,21 @@ The workflow uses `permissions: id-token: write` so GitHub Actions can mint OIDC
 
 The CLI is distributed via `brew install --cask getlarge/moltnet/moltnet`. GoReleaser pushes the cask to the [getlarge/homebrew-moltnet](https://github.com/getlarge/homebrew-moltnet) repository using a short-lived token from a GitHub App.
 
-Homebrew quarantines cask downloads, and macOS 15+ blocks a quarantined executable that is not notarized. The `notarize.macos` block in `apps/moltnet-cli/.goreleaser.yml` therefore signs each darwin binary with the Developer ID Application certificate and submits it to Apple's notary service **before** archiving, so the tarballs, the `@themoltnet/cli-darwin-*` npm packages and the cask all carry the same notarized Mach-O. It reuses the agent-daemon bundle's Apple secrets (#2063). A missing `APPLE_CERT_P12` fails the release unless the repo variable `ALLOW_UNSIGNED_DARWIN=true` is set. The `signs` block writes `checksums.txt.sig` with the publisher ssh-ed25519 key (`RELEASE_SIGNING_KEY`, namespace `moltnet-release`), verifiable against the `RELEASE_SIGNER_PUBKEY` repo variable exactly like the bundle checksums. Windows binaries are not Authenticode-signed.
+Homebrew quarantines cask downloads, and macOS 15+ blocks a quarantined executable that is not notarized. The `notarize.macos` block in `apps/moltnet-cli/.goreleaser.yml` therefore signs each darwin binary with the Developer ID Application certificate and submits it to Apple's notary service **before** archiving, so the tarballs, the `@themoltnet/cli-darwin-*` npm packages and the cask all carry the same notarized Mach-O. It reuses the agent-daemon bundle's Apple secrets (#2063). Quill requires `APPLE_CERT_P12` to contain the complete chain: the Developer ID Application leaf, the Developer ID G2 intermediate, and the self-signed Apple Root CA. A leaf-plus-intermediate P12 can be accepted by Quill's chain preflight while producing an invalid designated requirement, so the release workflow validates the three-certificate chain before GoReleaser runs. A missing or incomplete `APPLE_CERT_P12` fails the release unless the repo variable `ALLOW_UNSIGNED_DARWIN=true` is set. The `signs` block writes `checksums.txt.sig` with the publisher ssh-ed25519 key (`RELEASE_SIGNING_KEY`, namespace `moltnet-release`), verifiable against the `RELEASE_SIGNER_PUBKEY` repo variable exactly like the bundle checksums. Windows binaries are not Authenticode-signed.
+
+Build the P12 with both CA certificates in `-certfile` (the root certificate is public and comes from Apple's Certificate Authority page):
+
+```bash
+cat DeveloperIDG2CA.pem AppleIncRootCertificate.pem > DeveloperID-full-chain.pem
+openssl pkcs12 -export -legacy \
+  -inkey devid-application.key \
+  -in devid.crt \
+  -certfile DeveloperID-full-chain.pem \
+  -name "Developer ID Application" \
+  -out devid-application.p12
+```
+
+Base64-encode that P12 into `APPLE_CERT_P12`. Keep `-legacy`: macOS `security import` must also be able to consume the same secret for the native agent-daemon signing job.
 
 The Windows counterpart is the Scoop bucket [getlarge/scoop-moltnet](https://github.com/getlarge/scoop-moltnet) (`scoop bucket add moltnet https://github.com/getlarge/scoop-moltnet && scoop install moltnet`): the `scoops` block in the same GoReleaser config writes `bucket/moltnet.json` with the zip URLs and SHA256 hashes on every CLI release, pushed with the same GitHub App token (`SCOOP_TAP_TOKEN`). The App must be installed on **both** `homebrew-moltnet` and `scoop-moltnet`; a `404` on `/repos/getlarge/scoop-moltnet/installation` means the bucket repo is missing from the App's repository selection. Scoop downloads without the mark-of-the-web and verifies the manifest hash, so the unsigned exe installs without a SmartScreen prompt.
 
@@ -518,7 +532,7 @@ The workflow uses `actions/create-github-app-token@v3` to mint a scoped installa
 | --------------------------------------------------- | ----------------------------------------- | -------------------------------------------------------------------------------------------------------- |
 | `MOLTNET_RELEASE_APP_ID`                            | `release-cli` job                         | GitHub App ID for Homebrew tap push                                                                      |
 | `MOLTNET_RELEASE_APP_KEY`                           | `release-cli` job                         | GitHub App private key (PEM)                                                                             |
-| `APPLE_CERT_P12` / `APPLE_CERT_PASSWORD`            | `release-cli`, `sign-agent-bundle-darwin` | Developer ID Application certificate (base64 `.p12`)                                                     |
+| `APPLE_CERT_P12` / `APPLE_CERT_PASSWORD`            | `release-cli`, `sign-agent-bundle-darwin` | Developer ID Application certificate plus G2 intermediate and Apple root (base64 `.p12`)                 |
 | `NOTARY_KEY_ID` / `NOTARY_ISSUER_ID` / `NOTARY_KEY` | `release-cli`, `sign-agent-bundle-darwin` | App Store Connect API key for notarization                                                               |
 | `RELEASE_SIGNING_KEY`                               | `release-cli`, `sign-agent-bundle-*`      | Publisher ssh-ed25519 key signing release checksums (public half: repo variable `RELEASE_SIGNER_PUBKEY`) |
 | `CLAWHUB_TOKEN`                                     | `publish-skill-clawhub`                   | ClawHub CLI auth for skill publish                                                                       |

--- a/tools/package.json
+++ b/tools/package.json
@@ -18,7 +18,7 @@
     "bench:embedding": "tsx src/bench-embedding-warmup.ts",
     "bench:task-readiness": "tsx src/bench-task-readiness.ts",
     "smtp:test": "tsx src/test-smtp.ts",
-    "test:agent-bundle": "node --test release/agent-bundle/agent-bundle.test.mjs",
+    "test:agent-bundle": "node --test release/agent-bundle/agent-bundle.test.mjs release/cli/p12-chain.test.mjs",
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
@@ -77,8 +77,11 @@
         "cache": true,
         "inputs": [
           "{workspaceRoot}/tools/release/agent-bundle/**",
+          "{workspaceRoot}/tools/release/cli/**",
           "{projectRoot}/package.json",
           "{workspaceRoot}/apps/agent-daemon/package.json",
+          "{workspaceRoot}/apps/moltnet-cli/.goreleaser.yml",
+          "{workspaceRoot}/.github/workflows/release.yml",
           "{workspaceRoot}/.tool-versions"
         ]
       },

--- a/tools/release/cli/p12-chain.test.mjs
+++ b/tools/release/cli/p12-chain.test.mjs
@@ -1,0 +1,175 @@
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { after, before, describe, it } from 'node:test';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const verifier = join(here, 'verify-apple-p12.sh');
+const fixture = mkdtempSync(join(tmpdir(), 'moltnet-p12-chain-test-'));
+const password = 'test-password';
+
+function openssl(args) {
+  execFileSync('openssl', args, { cwd: fixture, stdio: 'ignore' });
+}
+
+function verify(p12, suppliedPassword = password) {
+  return spawnSync('sh', [verifier, '--p12', join(fixture, p12)], {
+    cwd: fixture,
+    encoding: 'utf8',
+    env: { ...process.env, APPLE_CERT_PASSWORD: suppliedPassword },
+  });
+}
+
+before(() => {
+  writeFileSync(
+    join(fixture, 'intermediate.ext'),
+    'basicConstraints=critical,CA:TRUE\nkeyUsage=critical,keyCertSign,cRLSign\n',
+  );
+  writeFileSync(
+    join(fixture, 'leaf.ext'),
+    'basicConstraints=critical,CA:FALSE\nkeyUsage=critical,digitalSignature\nextendedKeyUsage=codeSigning\n',
+  );
+
+  openssl([
+    'req',
+    '-x509',
+    '-newkey',
+    'rsa:2048',
+    '-nodes',
+    '-days',
+    '2',
+    '-subj',
+    '/CN=Apple Root CA/O=Apple Inc./C=US',
+    '-addext',
+    'basicConstraints=critical,CA:TRUE',
+    '-keyout',
+    'root.key',
+    '-out',
+    'root.pem',
+  ]);
+  openssl([
+    'req',
+    '-newkey',
+    'rsa:2048',
+    '-nodes',
+    '-subj',
+    '/CN=Developer ID Certification Authority/OU=G2/O=Apple Inc./C=US',
+    '-keyout',
+    'intermediate.key',
+    '-out',
+    'intermediate.csr',
+  ]);
+  openssl([
+    'x509',
+    '-req',
+    '-days',
+    '2',
+    '-in',
+    'intermediate.csr',
+    '-CA',
+    'root.pem',
+    '-CAkey',
+    'root.key',
+    '-CAcreateserial',
+    '-extfile',
+    'intermediate.ext',
+    '-out',
+    'intermediate.pem',
+  ]);
+  openssl([
+    'req',
+    '-newkey',
+    'rsa:2048',
+    '-nodes',
+    '-subj',
+    '/CN=Developer ID Application: Test/OU=TESTTEAM/O=Test/C=US',
+    '-keyout',
+    'leaf.key',
+    '-out',
+    'leaf.csr',
+  ]);
+  openssl([
+    'x509',
+    '-req',
+    '-days',
+    '2',
+    '-in',
+    'leaf.csr',
+    '-CA',
+    'intermediate.pem',
+    '-CAkey',
+    'intermediate.key',
+    '-CAcreateserial',
+    '-extfile',
+    'leaf.ext',
+    '-out',
+    'leaf.pem',
+  ]);
+
+  writeFileSync(
+    join(fixture, 'full-chain.pem'),
+    readFileSync(join(fixture, 'intermediate.pem'), 'utf8') +
+      readFileSync(join(fixture, 'root.pem'), 'utf8'),
+  );
+  openssl([
+    'pkcs12',
+    '-export',
+    '-legacy',
+    '-inkey',
+    'leaf.key',
+    '-in',
+    'leaf.pem',
+    '-certfile',
+    'full-chain.pem',
+    '-passout',
+    `pass:${password}`,
+    '-out',
+    'full-chain.p12',
+  ]);
+  openssl([
+    'pkcs12',
+    '-export',
+    '-legacy',
+    '-inkey',
+    'leaf.key',
+    '-in',
+    'leaf.pem',
+    '-certfile',
+    'intermediate.pem',
+    '-passout',
+    `pass:${password}`,
+    '-out',
+    'missing-root.p12',
+  ]);
+});
+
+after(() => {
+  rmSync(fixture, { recursive: true, force: true });
+});
+
+describe('Apple signing P12 validation', () => {
+  it('accepts a leaf, intermediate, and self-signed root chain', () => {
+    const result = verify('full-chain.p12');
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /valid 3-certificate Developer ID chain/);
+  });
+
+  it('rejects the leaf and intermediate bundle that Quill misclassifies', () => {
+    const result = verify('missing-root.p12');
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /exactly 3 certificates.*found 2/);
+  });
+
+  it('does not disclose the password when decoding fails', () => {
+    const result = verify('full-chain.p12', 'wrong-password');
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /could not be decoded/);
+    assert.doesNotMatch(result.stderr, /wrong-password/);
+  });
+});

--- a/tools/release/cli/p12-chain.test.mjs
+++ b/tools/release/cli/p12-chain.test.mjs
@@ -3,6 +3,7 @@ import { execFileSync, spawnSync } from 'node:child_process';
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 import { after, before, describe, it } from 'node:test';
 

--- a/tools/release/cli/verify-apple-p12.sh
+++ b/tools/release/cli/verify-apple-p12.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+# Verify that APPLE_CERT_P12 contains the complete Developer ID chain Quill
+# needs to produce a valid macOS designated requirement.
+
+set -eu
+
+usage() {
+  echo "usage: verify-apple-p12.sh --p12 FILE" >&2
+  exit 2
+}
+
+p12=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --p12)
+      [ "$#" -ge 2 ] || usage
+      p12=$2
+      shift 2
+      ;;
+    *) usage ;;
+  esac
+done
+
+[ -n "$p12" ] || usage
+[ -f "$p12" ] || { echo "P12 file not found: $p12" >&2; exit 1; }
+[ -n "${APPLE_CERT_PASSWORD:-}" ] || {
+  echo "APPLE_CERT_PASSWORD is required to verify the P12" >&2
+  exit 1
+}
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/moltnet-p12-check.XXXXXX")
+cleanup() {
+  rm -f "$work/bundle.pem" "$work/cert-1.pem" "$work/cert-2.pem" "$work/cert-3.pem"
+  rmdir "$work"
+}
+trap cleanup EXIT HUP INT TERM
+
+if ! openssl pkcs12 -legacy -in "$p12" -passin env:APPLE_CERT_PASSWORD \
+  -nokeys -out "$work/bundle.pem" 2>/dev/null; then
+  echo "APPLE_CERT_P12 could not be decoded; check the P12 and password" >&2
+  exit 1
+fi
+
+cert_count=$(awk '/^-----BEGIN CERTIFICATE-----$/ { count++ } END { print count + 0 }' "$work/bundle.pem")
+if [ "$cert_count" -ne 3 ]; then
+  echo "APPLE_CERT_P12 must contain exactly 3 certificates (Developer ID leaf + G2 intermediate + Apple root); found $cert_count" >&2
+  exit 1
+fi
+
+awk -v dir="$work" '
+  /^-----BEGIN CERTIFICATE-----$/ { count++; file = dir "/cert-" count ".pem" }
+  file != "" { print > file }
+  /^-----END CERTIFICATE-----$/ { close(file); file = "" }
+' "$work/bundle.pem"
+
+leaf=
+intermediate=
+root=
+for cert in "$work"/cert-*.pem; do
+  subject=$(openssl x509 -in "$cert" -noout -subject -nameopt RFC2253)
+  case "$subject" in
+    *"CN=Developer ID Application:"*) leaf=$cert ;;
+    *"CN=Developer ID Certification Authority"*) intermediate=$cert ;;
+    *"CN=Apple Root CA"*) root=$cert ;;
+  esac
+done
+
+[ -n "$leaf" ] || { echo "APPLE_CERT_P12 has no Developer ID Application leaf certificate" >&2; exit 1; }
+[ -n "$intermediate" ] || { echo "APPLE_CERT_P12 has no Developer ID Certification Authority intermediate" >&2; exit 1; }
+[ -n "$root" ] || { echo "APPLE_CERT_P12 has no Apple Root CA certificate" >&2; exit 1; }
+
+root_subject=$(openssl x509 -in "$root" -noout -subject -nameopt RFC2253 | sed 's/^subject=//')
+root_issuer=$(openssl x509 -in "$root" -noout -issuer -nameopt RFC2253 | sed 's/^issuer=//')
+if [ "$root_subject" != "$root_issuer" ]; then
+  echo "APPLE_CERT_P12 Apple root certificate is not self-signed" >&2
+  exit 1
+fi
+
+# Developer ID certificates contain Apple-specific critical extensions that
+# generic OpenSSL does not interpret. Quill ignores those known extensions;
+# -ignore_critical lets OpenSSL validate the cryptographic chain itself.
+if ! openssl verify -ignore_critical -purpose any -CAfile "$root" -untrusted "$intermediate" "$leaf" >/dev/null 2>&1; then
+  echo "APPLE_CERT_P12 does not contain a valid Developer ID leaf-to-root chain" >&2
+  exit 1
+fi
+
+echo "APPLE_CERT_P12 contains a valid 3-certificate Developer ID chain"


### PR DESCRIPTION
## Summary

- keep the existing cross-platform GoReleaser/Quill signing path
- fail the CLI release before GoReleaser when APPLE_CERT_P12 is missing the Apple root or has an invalid chain
- cover full-chain, missing-root, and wrong-password cases with generated PKCS12 fixtures
- document the required leaf + Developer ID G2 + Apple Root CA bundle and remove obsolete quarantine-bypass guidance

## Root cause

The shared P12 contained the Developer ID Application leaf and Developer ID G2 intermediate, but not Apple Root CA. Quill incorrectly treated that two-certificate bundle as complete and emitted a designated requirement that looked for the Apple intermediate extension on certificate root. The final archived Mach-O therefore failed strict native codesign verification even though Apple notarization had been reported as successful.

## Verification

- 25 release-tool tests passed
- the new preflight rejects the real two-certificate vault P12 and accepts the corrected three-certificate P12
- GoReleaser v2.18.0 configuration check passed
- the exact pinned Quill code path produced certificate 1 for the Apple intermediate extension
- codesign --verify --strict passed on the disposable CLI binary
- Apple Notary Service accepted submission e728fdd4-2e3a-4356-8778-43b01409f871
- codesign -R=notarized --check-notarization passed
- the released agent-daemon v0.47 bundle was independently verified: all 15 Mach-O files passed strict verification and the runtime satisfied the notarized requirement

## Deployment prerequisite

Rotate the APPLE_CERT_P12 repository secret to the tested full-chain P12 before the next CLI release. This PR deliberately does not mutate repository or vault secrets.

## MoltNet diary

- root cause: 9accc7d5-b38f-42bb-8dc7-44d698112ad6
- decision: 4ba4ac5f-6901-4d65-998b-c60628a37b0a
- accountable commit: 91fbac9d-0824-4f34-9005-44146cfb43d4

<!-- legreffier-correlation: 6204ed20-c1ee-4e57-9c46-adee1c4acf2c -->
