### PR TITLE
fix(n8n): expose parseable credential source

### DIFF
--- a/.agents/skills/n8n-community-nodes/references/verification-checklist.md
+++ b/.agents/skills/n8n-community-nodes/references/verification-checklist.md
@@ -20,6 +20,10 @@ reconciled with both official pages on 2026-09-02.
 - Package name starts with `n8n-nodes-` or `@<scope>/n8n-nodes-`.
 - `package.json` keywords include `n8n-community-node-package`.
 - `package.json#n8n` registers every shipped node and credential entry.
+- Match the starter kit's explicit credential-test shape:
+  `test: ICredentialTestRequest = { request: ... }`. The Portal links directly
+  to that declaration when reporting a missing test, while the beta scanner
+  does not reproduce this pre-check.
 - The interface, help, errors, examples, and README are English-only.
 
 ## Source and documentation
@@ -30,12 +34,11 @@ reconciled with both official pages on 2026-09-02.
   locating credential source files. If the exact-version beta scanner passes
   but the Portal reports `Can't find credential file in repo`, expose the
   credential at the repository-root `credentials/<Name>.credentials.ts` path.
-  Prefer a tracked file-level symlink to the package source so GitHub's Contents
-  API resolves the canonical file without maintaining a duplicate. Do not use a
-  directory symlink: repository tree traversal does not expose nested paths
-  beneath it consistently. If Nx formatting passes changed files to Prettier as
-  explicit paths, add the file symlink to `.nxignore`; `.prettierignore` cannot
-  suppress Prettier's explicit-symlink error.
+  Use a tracked, byte-identical regular-file copy of the package source. Do not
+  use a symlink: GitHub's Contents API dereferences it, but the raw-content URL
+  returns only the link target text, which can let the Portal find the path and
+  then report that the credential test is missing. Enforce copy equality in
+  package validation to prevent drift.
 - `package.json#author` includes an explicit email that matches the verified
   npm owner and Creator Portal account. Do not rely on the registry-generated
   `maintainers` array: Creator Portal resolves `author.email` separately.
@@ -86,8 +89,8 @@ Inspect the tarball produced by pack validation and confirm:
 - every credential path in `package.json#n8n.credentials` is tracked in the
   public repository at that exact path; Creator Portal may resolve the manifest
   path against Git rather than infer it from the source credential;
-- any repository-root Creator Portal compatibility symlink is tracked and
-  resolves to the canonical package credential source;
+- any repository-root Creator Portal compatibility copy is tracked and remains
+  byte-identical to the canonical package credential source;
 - a clean project can install and require both CommonJS entries without the
   bundled SDK or another undeclared runtime package installed separately.
 

--- a/.nxignore
+++ b/.nxignore
@@ -16,10 +16,3 @@ infra/ory
 # symbolic links before applying .prettierignore, so exclude this navigation
 # alias while its AGENTS.md target remains the formatted source of truth.
 .agents/skills/dbos-typescript/CLAUDE.md
-
-# n8n Creator Portal currently resolves credential source from the Git
-# repository root without honoring package.json#repository.directory. Nx
-# format passes changed files to Prettier as explicit paths, and Prettier
-# rejects symlinks before consulting .prettierignore. The package check:pack
-# target verifies this alias is tracked and resolves to the canonical source.
-credentials/MoltNetApi.credentials.ts

--- a/credentials/MoltNetApi.credentials.ts
+++ b/credentials/MoltNetApi.credentials.ts
@@ -1,1 +1,170 @@
-../libs/n8n-nodes-moltnet/credentials/MoltNetApi.credentials.ts
+import type {
+  IAuthenticateGeneric,
+  ICredentialDataDecryptedObject,
+  ICredentialTestRequest,
+  ICredentialType,
+  IDataObject,
+  IHttpRequestHelper,
+  INodeProperties,
+} from 'n8n-workflow';
+
+export class MoltNetApi implements ICredentialType {
+  name = 'moltNetApi';
+
+  displayName = 'MoltNet API';
+
+  icon = {
+    light: 'file:../nodes/MoltNet/moltnet-mark.svg',
+    dark: 'file:../nodes/MoltNet/moltnet-mark.dark.svg',
+  } as const;
+
+  // n8n's closest supported palette color to MoltNet identity amber.
+  iconColor = 'orange' as const;
+
+  documentationUrl =
+    'https://github.com/getlarge/themoltnet/tree/main/libs/n8n-nodes-moltnet#credentials';
+
+  authenticate: IAuthenticateGeneric = {
+    type: 'generic',
+    properties: {
+      headers: {
+        Authorization: '=Bearer {{$credentials.accessToken}}',
+      },
+    },
+  };
+
+  async preAuthentication(
+    this: IHttpRequestHelper,
+    credentials: ICredentialDataDecryptedObject,
+  ): Promise<IDataObject> {
+    const clientId = optionalString(credentials.clientId);
+    const authentication =
+      credentials.authentication ?? (clientId ? 'oauth2' : 'agentKey');
+
+    if (authentication === 'agentKey') {
+      const agentKey = optionalString(credentials.agentApiKey);
+      if (!agentKey) throw new Error('MoltNet agent key is required');
+      return { accessToken: agentKey };
+    }
+
+    const clientSecret = optionalString(credentials.clientSecret);
+    if (!clientId || !clientSecret) {
+      throw new Error(
+        'MoltNet OAuth2 client ID and client secret are required',
+      );
+    }
+    const apiUrl = String(credentials.apiUrl).trim().replace(/\/$/u, '');
+    const response = (await this.helpers.httpRequest({
+      method: 'POST',
+      url: `${apiUrl}/oauth2/token`,
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: [
+        'grant_type=client_credentials',
+        `client_id=${encodeURIComponent(clientId)}`,
+        `client_secret=${encodeURIComponent(clientSecret)}`,
+      ].join('&'),
+      json: true,
+    })) as IDataObject;
+    const accessToken = optionalString(response.access_token);
+    if (!accessToken) {
+      throw new Error(
+        'MoltNet OAuth2 response did not contain an access token',
+      );
+    }
+    return { accessToken };
+  }
+
+  // Keep the explicit type to match n8n's documented starter-kit shape.
+  test: ICredentialTestRequest = {
+    request: {
+      baseURL: '={{$credentials.apiUrl}}',
+      url: '/agents/whoami',
+      method: 'GET',
+    },
+  };
+
+  properties: INodeProperties[] = [
+    {
+      displayName: 'Access Token',
+      name: 'accessToken',
+      type: 'hidden',
+      typeOptions: { expirable: true, password: true },
+      default: '',
+    },
+    {
+      displayName: 'API URL',
+      name: 'apiUrl',
+      type: 'string',
+      default: 'https://api.themolt.net',
+      required: true,
+    },
+    {
+      displayName: 'Authentication',
+      name: 'authentication',
+      type: 'options',
+      default: 'agentKey',
+      options: [
+        {
+          name: 'Agent Key (Recommended)',
+          value: 'agentKey',
+          description: 'Use a scoped, rotatable MoltNet agent key',
+        },
+        {
+          name: 'OAuth2 Client Credentials',
+          value: 'oauth2',
+          description:
+            'Exchange an agent client ID and secret for access tokens',
+        },
+      ],
+    },
+    {
+      displayName: 'Agent Key',
+      name: 'agentApiKey',
+      type: 'string',
+      typeOptions: { password: true },
+      default: '',
+      required: true,
+      displayOptions: { show: { authentication: ['agentKey'] } },
+      description:
+        'Scoped agent key. For this node, grant agent:profile, task:manage, and task:read.',
+    },
+    {
+      displayName: 'Client ID',
+      name: 'clientId',
+      type: 'string',
+      default: '',
+      required: true,
+      displayOptions: { show: { authentication: ['oauth2'] } },
+      placeholder: 'e.g. a854b555-aeef-4f13-ab22-8d0b819d478e',
+    },
+    {
+      displayName: 'Client Secret',
+      name: 'clientSecret',
+      type: 'string',
+      typeOptions: { password: true },
+      default: '',
+      required: true,
+      displayOptions: { show: { authentication: ['oauth2'] } },
+    },
+    {
+      displayName: 'Default Team ID',
+      name: 'teamId',
+      type: 'string',
+      default: '',
+      placeholder: 'e.g. 11111111-1111-4111-8111-111111111111',
+      description: 'Default team context used when a node does not override it',
+    },
+    {
+      displayName: 'Default Diary ID',
+      name: 'diaryId',
+      type: 'string',
+      default: '',
+      placeholder: 'e.g. 22222222-2222-4222-8222-222222222222',
+      description: 'Default diary used when a node does not override it',
+    },
+  ];
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}

--- a/libs/n8n-nodes-moltnet/__tests__/credentials.spec.ts
+++ b/libs/n8n-nodes-moltnet/__tests__/credentials.spec.ts
@@ -58,6 +58,7 @@ describe('MoltNet API credentials', () => {
       request: {
         baseURL: '={{$credentials.apiUrl}}',
         url: '/agents/whoami',
+        method: 'GET',
       },
     });
   });

--- a/libs/n8n-nodes-moltnet/credentials/MoltNetApi.credentials.ts
+++ b/libs/n8n-nodes-moltnet/credentials/MoltNetApi.credentials.ts
@@ -1,6 +1,7 @@
 import type {
   IAuthenticateGeneric,
   ICredentialDataDecryptedObject,
+  ICredentialTestRequest,
   ICredentialType,
   IDataObject,
   IHttpRequestHelper,
@@ -73,10 +74,12 @@ export class MoltNetApi implements ICredentialType {
     return { accessToken };
   }
 
-  test = {
+  // Keep the explicit type to match n8n's documented starter-kit shape.
+  test: ICredentialTestRequest = {
     request: {
       baseURL: '={{$credentials.apiUrl}}',
       url: '/agents/whoami',
+      method: 'GET',
     },
   };
 

--- a/libs/n8n-nodes-moltnet/dist/credentials/MoltNetApi.credentials.js
+++ b/libs/n8n-nodes-moltnet/dist/credentials/MoltNetApi.credentials.js
@@ -39,7 +39,8 @@ var MoltNetApi = class {
 	}
 	test = { request: {
 		baseURL: "={{$credentials.apiUrl}}",
-		url: "/agents/whoami"
+		url: "/agents/whoami",
+		method: "GET"
 	} };
 	properties = [
 		{

--- a/libs/n8n-nodes-moltnet/scripts/check-pack.mjs
+++ b/libs/n8n-nodes-moltnet/scripts/check-pack.mjs
@@ -2,12 +2,10 @@ import { execFileSync } from 'node:child_process';
 import console from 'node:console';
 import {
   existsSync,
-  lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
-  realpathSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -74,13 +72,10 @@ try {
   }
 
   const portalCredentialPath = resolve(repositoryRoot, portalCredential);
+  const credentialSource = readFileSync(sourceCredential, 'utf8');
   assert(
-    lstatSync(portalCredentialPath).isSymbolicLink(),
-    `${portalCredential} must remain a symlink to avoid duplicating credential source`,
-  );
-  assert(
-    realpathSync(portalCredentialPath) === realpathSync(sourceCredential),
-    `${portalCredential} must resolve to the package credential source`,
+    readFileSync(portalCredentialPath, 'utf8') === credentialSource,
+    `${portalCredential} must be a byte-identical checked-in copy of the package credential source`,
   );
 
   try {


### PR DESCRIPTION
## Summary

- replace the repository-root MoltNet credential symlink with a real, byte-identical source file
- match n8n's starter-kit `ICredentialTestRequest` declaration and make the GET test method explicit
- make `check:pack` reject drift between the root compatibility copy and canonical package source
- update the n8n verification skill with the observed raw-content limitation

## Why

Creator Portal accepted the repository-root credential path in 0.3.3, then reported “Missing credential test,” even though the canonical credential already had a functional test and the exact-version beta scanner passed.

The Portal implementation is private, so its precise detector logic is not proven. The concrete transport evidence is that GitHub's raw URL for the root symlink returns only the link target text, not the TypeScript source. This patch covers both plausible detector behaviors by exposing a real root source file containing the test in the starter-kit shape.

## Verification

- `pnpm exec nx run @themoltnet/n8n-nodes-moltnet:lint`
- `pnpm exec nx run @themoltnet/n8n-nodes-moltnet:typecheck`
- `pnpm exec nx run @themoltnet/n8n-nodes-moltnet:test` — 41 tests
- `pnpm exec nx run @themoltnet/n8n-nodes-moltnet:check:pack`
- `pnpm exec nx format:check --base=origin/main --head=HEAD`
- root and canonical credential sources verified byte-identical

MoltNet diary: `5ec24f4e-079e-408a-80e7-e6c357bff25e`

<!-- legreffier-correlation: 752e8320-57e6-4e65-aeb4-b7d57773234f -->
